### PR TITLE
ctx/fix(dataplane): fix labels and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Initializing app config from file dataplane-operator.yaml
 * Install the dataplane.
 
 ```shell
-helm dep update unionai/dataplane
 helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds
 helm upgrade --install unionai-dataplane unionai/dataplane \
     --create-namespace \
@@ -74,7 +73,7 @@ helm upgrade --install unionai-dataplane unionai/dataplane \
     --set secrets.admin.create=true \
     --set secrets.admin.clientId="<client.id>" \
     --set secrets.admin.clientSecret="<client.secret>" \
-    --values="<values.yaml>"
+    --values "<values.yaml>"
 ```
 
 Once deployed you can check to see if the cluster has been successfully registered to the control plane by running the `get cluster` command in `uctl`

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -3,6 +3,6 @@ name: dataplane-crds
 description: Deploys the Union dataplane CRDs.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.1.0
-appVersion: 2025.1.0
+version: 2025.1.1
+appVersion: 2025.1.1
 kubeVersion: ">= 1.28.0"

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,8 +4,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.1.0
-appVersion: 2025.1.0
+version: 2025.1.1
+appVersion: 2025.1.1
 kubeVersion: ">= 1.28.0"
 dependencies:
   - name: kube-prometheus-stack

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -243,7 +243,7 @@ access the storage is injected.
 Health check URL helpers
 */}}
 {{- define "prometheus.health.url" -}}
-http://{{ template "kube-prometheus-stack.fullname" . }}-prometheus.{{ .Release.Namespace }}.svc.cluster.local:9090/-/healthy
+http://union-prometheus.{{ .Release.Namespace }}.svc.cluster.local:9090/-/healthy
 {{- end -}}
 
 {{- define "propeller.health.url" -}}
@@ -251,7 +251,7 @@ http://flytepropeller.{{ .Release.Namespace }}.svc.cluster.local:10254
 {{- end -}}
 
 {{- define "proxy.health.url" -}}
-http://union-operator-proxy.{{ .Release.Namespace }}.svc.cluster.local:10254
+http://operator-proxy.{{ .Release.Namespace }}.svc.cluster.local:10254
 {{- end -}}
 
 {{/*
@@ -297,6 +297,13 @@ Global pod environment variables
   valueFrom:
     resourceFieldRef:
       resource: limits.cpu
+- name: CLUSTER_NAME
+  valueFrom:
+    secretKeyRef:
+      name: operator-cluster-name
+      key: cluster_name
+- name: DEPLOYMENT_NAME
+  value: operator
 {{- with .Values.additionalPodEnvVars }}
 {{- toYaml .}}
 {{- end }}

--- a/charts/dataplane/templates/common/cluster-secret.yaml
+++ b/charts/dataplane/templates/common/cluster-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "union-operator.fullname" . }}-cluster-name
+  name: operator-cluster-name
 type: Opaque
 data:
   cluster_name: {{ .Values.clusterName | b64enc }}

--- a/charts/dataplane/templates/operator/deployment-proxy.yaml
+++ b/charts/dataplane/templates/operator/deployment-proxy.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "union-operator.fullname" . }}-proxy
+  name: operator-proxy
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
@@ -21,7 +21,7 @@ spec:
         {{- end }}
         {{- include "global.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "proxy.selectorLabels" . | nindent 8 }}
+        {{- include "proxy.podLabels" . | nindent 8 }}
     spec:
       volumes:
         - name: config-volume

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "union-operator.fullname" . }}
+  name: operator
   labels:
     {{- include "operator.labels" . | nindent 4 }}
 spec:
@@ -20,7 +20,7 @@ spec:
         {{- end }}
         {{- include "global.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "operator.selectorLabels" . | nindent 6 }}
+        {{ include "operator.podLabels" . | nindent 8 }}
     spec:
       priorityClassName: {{ .Values.operator.priorityClassName }}
       {{- with .Values.operator.imagePullSecrets }}

--- a/charts/dataplane/templates/operator/service-proxy.yaml
+++ b/charts/dataplane/templates/operator/service-proxy.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "union-operator.fullname" . }}-proxy
+  name: operator-proxy
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
 spec:

--- a/charts/dataplane/templates/operator/service.yaml
+++ b/charts/dataplane/templates/operator/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "union-operator.fullname" . }}
+  name: operator
   labels:
     {{- include "operator.labels" . | nindent 4 }}
 spec:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -624,13 +624,12 @@ prometheus:
     enabled: true
     prometheusSpec:
       resources:
-        resources:
-          limits:
-            cpu: "1"
-            memory: "2Gi"
-          requests:
-            cpu: "1"
-            memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+        requests:
+          cpu: "1"
+          memory: "2Gi"
 
   alertmanager:
     enabled: false


### PR DESCRIPTION
* [x] The renaming of the chart introduced a couple of naming errors for the deployment, services, and checks.  Fixed those errors.
* [x] Fixed error with prometheus resource values.
* [x] Fixed labels for operator and proxy deployments.