### PR TITLE
ctx/add union monitoring

### DIFF
--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -3,6 +3,6 @@ name: dataplane-crds
 description: Deploys the Union dataplane CRDs.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.1.1
-appVersion: 2025.1.1
+version: 2025.1.2
+appVersion: 2025.1.2
 kubeVersion: ">= 1.28.0"

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,8 +4,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.1.1
-appVersion: 2025.1.1
+version: 2025.1.2
+appVersion: 2025.1.2
 kubeVersion: ">= 1.28.0"
 dependencies:
   - name: kube-prometheus-stack

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -13,3 +13,11 @@ dependencies:
     version: 68.2.2
     condition: monitoring.prometheus.enabled
     alias: prometheus
+  - name: loki
+    version: "6.25.*"
+    repository: https://grafana.github.io/helm-charts
+    condition: loki.enabled
+  - name: fluent-bit
+    version: "0.48.*"
+    repository: https://fluent.github.io/helm-charts
+    condition: fluent-bit.enabled

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           secret:
             secretName: {{ .Values.operator.secretName }}
       containers:
-        - name: oeprator
+        - name: operator
           securityContext:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}
           image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"

--- a/charts/dataplane/templates/operator/monitoring.yaml
+++ b/charts/dataplane/templates/operator/monitoring.yaml
@@ -1,0 +1,490 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: union-default-rules
+  namespace: union
+spec:
+  groups:
+    - name: rollup
+      rules:
+        - record: instance_type:kube_node_labels:sum
+          expr: sum by (label_cloud_google_com_gke_accelerator, label_cloud_google_com_gke_preemptible, label_eks_amazonaws_com_capacity_type, label_flyte_org_node_role, label_node_group_name, label_node_kubernetes_io_instance_type, label_node_pool_name, label_topology_kubernetes_io_region) (kube_node_labels{job="kube-state-metrics"})
+        - record: deployment:kube_deployment_status_replicas_unavailable:sum
+          expr: sum by (deployment,namespace) (kube_deployment_status_replicas_unavailable{})
+        - record: daemonset:kube_daemonset_status_number_unavailable:sum
+          expr: sum by(daemonset,namespace)(kube_daemonset_status_number_unavailable{})
+        - record: phase:kube_pod_status_phase:sum
+          expr: sum by (label_union_ai_namespace_type, phase) (kube_pod_status_phase{job="kube-state-metrics"} * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels)
+        - record: namespace_phase:kube_pod_status_phase:sum
+          expr: sum by (namespace, label_union_ai_namespace_type, phase) (kube_pod_status_phase{job="kube-state-metrics"} * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels)
+        - record: union:kube_pod_container_status_restarts_total
+          expr: kube_pod_container_status_restarts_total * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"}
+        - record: union:kube_pod_container_status_last_terminated_reason
+          expr: kube_pod_container_status_last_terminated_reason{reason!="Completed"} * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"}
+        - record: namespace_type:pod:container_cpu_usage_seconds_total:count
+          expr: count by (label_union_ai_namespace_type) (count  by (namespace, label_union_ai_namespace_type, pod) (container_cpu_usage_seconds_total{pod!="", job=~"kubernetes-cadvisor.*", name!=""} * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels))
+        - record: namespace:pod:container_cpu_usage_seconds_total:count
+          expr: count by (namespace, label_union_ai_namespace_type) (count  by (namespace, label_union_ai_namespace_type, pod) (container_cpu_usage_seconds_total{pod!="", job=~"kubernetes-cadvisor.*", name!=""} * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels))
+        - record: container:container_cpu_usage_seconds_total:rate_sum
+          expr: sum(rate(container_cpu_usage_seconds_total{container!="", job=~"kubernetes-cadvisor.*"}[5m])) by (namespace, pod, container) * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"}
+        - record: container:container_memory_working_set_bytes:sum
+          expr: sum by (namespace, pod, container) (container_memory_working_set_bytes{image!="", job=~"kubernetes-cadvisor.*", name!=""}) * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"}
+        - record: container:container_spec_memory_limit_bytes:sum
+          expr: sum by (namespace, pod, container) (container_spec_memory_limit_bytes{image!="", job=~"kubernetes-cadvisor.*", name!=""}) * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"}
+        - record: container:cpu_utilization
+          expr: (sum(rate(container_cpu_usage_seconds_total{container!="", job=~"kubernetes-cadvisor.*"}[5m])) by (namespace, pod, container) * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"} / sum(container_spec_cpu_quota{container!=""}/container_spec_cpu_period{container!=""}) by (namespace, pod, container))
+        - record: container:memory_utilization
+          expr: (sum(container_memory_working_set_bytes{name!="", job=~"kubernetes-cadvisor.*"}) BY (namespace, pod, container) * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"} / sum(container_spec_memory_limit_bytes{name!=""} > 0) BY (namespace, pod, container))
+        - record: container:throttle_rate
+          expr: sum by (container, pod, namespace) (increase(container_cpu_cfs_throttled_periods_total{container!="", job=~"kubernetes-cadvisor.*"}[5m])) * on (namespace) group_left(label_union_ai_namespace_type) kube_namespace_labels{label_union_ai_namespace_type!="flyte"} / sum by (container, pod, namespace)(increase(container_cpu_cfs_periods_total[5m]))
+        - record: job:up:sum
+          expr: sum by (job) (up)
+        - record: job:up:count
+          expr: count by (job) (up)
+        - record: flyte_agent_request_latency_seconds:mean1m
+          expr: sum(rate(flyte_agent_request_latency_seconds_sum[1m])) / sum(rate(flyte_agent_request_latency_seconds_count[1m]))
+        - record: name:time_series_cardinality:count
+          expr: sum by (name)(label_replace(count by(__name__) ({__name__=~".+"}), "name", "$1", "__name__", "(.+)"))
+        - record: fluentbit_input_bytes_total:sum
+          expr: sum(fluentbit_input_bytes_total)
+        - record: fluentbit_output_dropped_records_total:sum
+          expr: sum(fluentbit_output_dropped_records_total)
+        - record: fluentbit_output_proc_bytes_total:sum
+          expr: sum(fluentbit_output_proc_bytes_total)
+        - record: instance:fluentbit_output_proc_records_total:rate_sum
+          expr: sum by(instance)(rate(fluentbit_output_proc_records_total[2m]))
+        - record: instance:node_vmstat_pgmajfault:rate5m
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
+        - record: k8s_client_request_total_unlabeled
+          expr: sum(k8s_client_request_total) without (code, method)
+        - record: k8s_client_request_latency_unlabeled_bucket
+          expr: sum(k8s_client_request_latency_bucket) without (verb)
+        - record: k8s_client_request_latency_unlabeled_count
+          expr: sum(k8s_client_request_latency_count) without (verb)
+        - record: k8s_client_request_latency_unlabeled_sum
+          expr: sum(k8s_client_request_latency_sum) without (verb)
+        - record: k8s_client_rate_limiter_latency_unlabeled_bucket
+          expr: sum(k8s_client_rate_limiter_latency_bucket) without (verb)
+        - record: k8s_client_rate_limiter_latency_unlabeled_count
+          expr: sum(k8s_client_rate_limiter_latency_count) without (verb)
+        - record: k8s_client_rate_limiter_latency_unlabeled_sum
+          expr: sum(k8s_client_rate_limiter_latency_sum) without (verb)
+        - record: node:common_labels
+          expr: node_uname_info{nodename=~".+"} * on(nodename) group_left(label_node_pool_name, label_node_kubernetes_io_instance_type, label_flyte_org_node_role, label_union_ai_node_role) count by (nodename, label_node_pool_name, label_node_kubernetes_io_instance_type, label_flyte_org_node_role, label_union_ai_node_role)(kube_node_labels{label_node_pool_name!~".*-secondary", job="kube-state-metrics"})
+        - record: node_nf_conntrack_entry_utilization
+          expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit
+        - record: instance:node_network_receive_bytes_total:sum
+          expr: sum by (instance) (node_network_receive_bytes_total)
+        - record: instance:node_network_transmit_bytes_total:sum
+          expr: sum by (instance) (node_network_transmit_bytes_total)
+        - record: instance:node_network_receive_errs_total:sum
+          expr: sum by (instance) (node_network_receive_errs_total)
+        - record: instance:node_network_transmit_errs_total:sum
+          expr: sum by (instance) (node_network_transmit_errs_total)
+        - record: instance:node_network_receive_packets_total:sum
+          expr: sum by (instance) (node_network_receive_packets_total)
+        - record: instance:node_network_transmit_packets_total:sum
+          expr: sum by (instance) (node_network_transmit_packets_total)
+        # Count active Flyte namespaces, useful for approximating active users in serverless environments
+        - record: namespace:flyte:total
+          expr: count(kube_namespace_labels{label_union_ai_namespace_type="flyte"})
+        # Count the number of reasons why Pods are terminating or waiting.
+        - record: node:namespace:kube_pod_container_status_last_terminated_reason:sum
+          expr: sum by (node, namespace, reason)(kube_pod_container_status_last_terminated_reason * on(pod) group_left(node) (sum by (node, namespace, pod)(kube_pod_info{nodename!=""})))
+        - record: node:namespace:kube_pod_container_status_terminated_reason:sum
+          expr: sum by (node, namespace, reason)(kube_pod_container_status_terminated_reason * on(pod) group_left(node) (sum by (node, namespace, pod)(kube_pod_info{nodename!=""})))
+        - record: node:namespace:kube_pod_container_status_waiting_reason:sum
+          expr: sum by (node, namespace, reason)(kube_pod_container_status_waiting_reason * on(pod) group_left(node) (sum by (node, namespace, pod)(kube_pod_info{nodename!=""})))
+        - record: node:kubelet_version:count
+          expr: count by (kubelet_version)(label_replace(kube_node_info, "kubelet_version", "$1", "kubelet_version", "v([0-9]+\\.[0-9]+).*"))
+        - record: node:kube_node_status_utilization
+          expr: 1 - (kube_node_status_allocatable{resource=~"cpu|memory|ephemeral_storage|nvidia_com_gpu"} / kube_node_status_capacity)
+---
+{{- if .Values.integration.opencost -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: union-opencost-rules
+  namespace: union
+spec:
+  groups:
+    # Granular aggregations of cost
+    - name: resources_rollup_15s
+      interval: 15s
+      rules:
+        - record: execution_id:mem_usage_bytes_total:sum
+          expr: sum by (label_project, label_domain, label_workflow_name, label_execution_id, node) (max by (namespace, pod) ((sum by (namespace, pod) (container_memory_working_set_bytes{namespace!="",pod!="",image!=""}) > sum by (namespace, pod) (kube_pod_container_resource_requests{namespace!="",pod!="",resource="memory"})) or sum by (namespace, pod) (kube_pod_container_resource_requests{namespace!="",pod!="",resource="memory"})) * on (namespace, pod) group_left(label_domain, label_project, label_execution_id, label_workflow_name) (kube_pod_labels{label_domain!="", label_project!="", label_execution_id!="", label_workflow_name!=""}) * on (namespace, pod) group_left() (max by (namespace, pod) (kube_pod_status_phase{phase="Running"} == 1)) * on (namespace, pod) group_left(node) (kube_pod_info))
+        - record: execution_id:cpu_usage:sum
+          expr: sum by (label_project, label_domain, label_workflow_name, label_execution_id, node) (max by (namespace, pod) ((sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace!="",pod!="",image!=""}[5m])) > sum by (namespace, pod) (kube_pod_container_resource_requests{namespace!="",pod!="",resource="cpu"})) or sum by (namespace, pod) (kube_pod_container_resource_requests{namespace!="",pod!="",resource="cpu"})) * on (namespace, pod) group_left(label_domain, label_project, label_execution_id, label_workflow_name) (kube_pod_labels{label_domain!="",label_project!="",label_execution_id!="",label_workflow_name!=""}) * on (namespace, pod) group_left() (max by (namespace, pod) (kube_pod_status_phase{phase="Running"} == 1)) * on (namespace, pod) group_left(node) (kube_pod_info))
+        - record: execution_id:gpu_usage:sum
+          expr: sum by (label_project, label_domain, label_workflow_name, label_execution_id, node) (container_gpu_allocation * on (namespace, pod) group_left(label_domain, label_project, label_execution_id, label_workflow_name) (kube_pod_labels{label_domain!="", label_project!="", label_execution_id!="", label_workflow_name!=""}) * on (namespace, pod) group_left() (max by (namespace, pod) (kube_pod_status_phase{phase="Running"} == 1)) * on (namespace, pod) group_left(node) (kube_pod_info))
+    - name: cost_calculations_15s
+      interval: 15s
+      rules:
+        - record: execution_info # A join metric to look up execution-level info. Used below to disambiguate workflow/task execution costs from app costs.
+          expr: |
+            max by (label_domain, label_project, label_entity_name, label_execution_id, label_entity_id)(
+              label_replace(
+                label_replace(
+                  kube_pod_labels{label_domain!="", label_project!="", label_workflow_name!="", label_task_name!="", label_execution_id!=""}, # filter for workflow/task executions
+                  "label_entity_id", "$1", "label_execution_id", "(.*)" # join key
+                ), "label_entity_name", "$1", "label_workflow_name", "(.*)" # set label_entity_name to the workflow/task name from the kube_pod_labels
+              )
+            )
+        - record: app_info # A join metric to look up app-level info. Used below to disambiguate workflow/task execution costs from app costs.
+          expr: |
+            max by (label_domain, label_project, label_app_name, label_app_version, label_entity_id)(
+              label_replace(
+                label_replace(
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        kube_pod_labels{
+                          label_serving_unionai_dev_domain!="",
+                          label_serving_unionai_dev_project!="",
+                          label_serving_unionai_dev_app_name!="",
+                          label_serving_knative_dev_revision!=""
+                        }, # this filters for apps
+                        "label_domain", "$1", "label_serving_unionai_dev_domain", "(.*)" # rename the app domain label to label_domain for consistency
+                      ),
+                      "label_project", "$1", "label_serving_unionai_dev_project", "(.*)" # rename the app project label to label_project for consistency
+                    ),
+                    "label_app_name", "$1", "label_serving_unionai_dev_app_name", "(.*)" # rename to cleanup
+                  ),
+                  "label_app_version", "$1", "label_serving_knative_dev_revision", "(.*)" # the app_version is equivalent to an execution_id for workflows (lowest level of granularity)
+                ),
+                "label_entity_id", "$1", "label_app_version", "(.*)" # join key
+              )
+            )
+        - record: entity_id:mem_usage_bytes_total_per_node:sum # Allocated memory (max(requested, consumed)) aggregated per node and entity, where entity is either a task/workflow execution or an app.
+          expr: |
+            sum by (label_entity_type, label_domain, label_project, label_entity_id, node) ( # aggregate up to entity
+              # First, calculate the allocated memory for each pod
+              max by (namespace, pod) ( # this is the case where consumed (the memory working set) exceeds requested memory
+                (
+                  sum by (namespace, pod) (
+                    container_memory_working_set_bytes{namespace!="",pod!="",image!=""}
+                  )
+                  > sum by (namespace, pod) (
+                    kube_pod_container_resource_requests{namespace!="", pod!="", node!="", resource="memory"}
+                  )
+                )
+                or sum by (namespace, pod) ( # this is the case where memory requests are <= consumed memory
+                  kube_pod_container_resource_requests{namespace!="", pod!="", node!="", resource="memory"} # needed to add node!="" to dedupe
+                )
+              )
+              # Next, add labels to each pod that contain the relevant entity information (i.e. workflow/task or app). Note that this is repetitive but we do not want to double the number of pod-level metrics we save
+              * on (namespace, pod) group_left(label_entity_type, label_domain, label_project, label_entity_id) (
+                max by (label_entity_type, label_domain, label_project, label_entity_id, namespace, pod)( # adds workflow/task labels
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          kube_pod_labels{label_domain!="", label_project!="", label_workflow_name!="", label_execution_id!=""}, # this filters for workflow and task executions only (no apps)
+                          "label_entity_type", "workflow", "", "" # set label_entity_type to "workflow" (note that both workflow and single task executions will say "workflow")
+                        ),
+                        "label_entity_id", "$1", "label_execution_id", "(.*)" # set label_entity_id to the execution id (join key)
+                      ),
+                      "label_domain", "$1", "label_domain", "(.*)"
+                    ),
+                    "label_project", "$1", "label_project", "(.*)"
+                  )
+                )
+                or
+                max by (label_entity_type, label_domain, label_project, label_entity_id, namespace, pod)( # adds app labels
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          kube_pod_labels{
+                            label_serving_unionai_dev_domain!="",
+                            label_serving_unionai_dev_project!="",
+                            label_serving_unionai_dev_app_name!="",
+                            label_serving_knative_dev_revision!=""
+                          },
+                          "label_entity_type", "app", "", ""
+                        ),
+                        "label_entity_id", "$1", "label_serving_knative_dev_revision", "(.*)" # join key (so we have label_entity_id with both execution ids and app versions)
+                      ),
+                      "label_domain", "$1", "label_serving_unionai_dev_domain", "(.*)" # cast to joinable name
+                    ),
+                    "label_project", "$1", "label_serving_unionai_dev_project", "(.*)" # cast to joinable name
+                  )
+                )
+              )
+              # Then filter for pods only in the "Running" or "Pending" phase
+              * on (namespace, pod) group_left() (
+                max by (namespace, pod) (
+                  kube_pod_status_phase{phase=~"Running|Pending"} == 1
+                )
+              )
+              # Now join in node identifiers which are used for subsequent overhead calculations
+              * on (namespace, pod) group_left(node) (
+                max by (namespace, pod, node) (kube_pod_info{node!=""}) # needed to add node!="" to dedupe
+              )
+            )
+        - record: entity_id:cpu_usage_per_node:sum # Allocated cpu (max(requested, consumed)) aggregated per node and entity, where entity is either a task/workflow execution or an app.
+          expr: |
+            sum by (label_entity_type, label_domain, label_project, label_entity_id, node) (
+              # First, calculate the allocated cpu for each pod
+              max by (namespace, pod) ( # this is the case where consumed (the cpu usage seconds total) exceeds requested cpu
+                (
+                  sum by (namespace, pod) (
+                    irate(container_cpu_usage_seconds_total{namespace!="",pod!="",image!=""}[5m])
+                  )
+                  > sum by (namespace, pod) (
+                    kube_pod_container_resource_requests{namespace!="", pod!="", node!="", resource="cpu"}
+                  )
+                )
+                or sum by (namespace, pod) ( # this is the case where cpu requests are <= consumed cpu
+                    kube_pod_container_resource_requests{namespace!="", pod!="", node!="", resource="cpu"}
+                )
+              )
+              # Next, add labels to each pod that contain the relevant entity information (i.e. workflow/task or app). Note that this is repetitive but I didn't want to double the number of pod-level metrics we save
+              * on (namespace, pod) group_left(label_entity_type, label_domain, label_project, label_entity_id) (
+                max by (label_entity_type, label_domain, label_project, label_entity_id, namespace, pod)( # adds workflow/task labels
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          kube_pod_labels{label_domain!="", label_project!="", label_workflow_name!="", label_execution_id!=""}, # this filters for workflow and task executions only (no apps)
+                          "label_entity_type", "workflow", "", ""  # set label_entity_type to "workflow" (note that both workflow and single task executions will say "workflow")
+                        ),
+                        "label_entity_id", "$1", "label_execution_id", "(.*)" # set label_entity_id to the execution id (join key)
+                      ),
+                      "label_domain", "$1", "label_domain", "(.*)"
+                    ),
+                    "label_project", "$1", "label_project", "(.*)"
+                  )
+                )
+                or
+                max by (label_entity_type, label_domain, label_project, label_entity_id, namespace, pod)( # adds app labels
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          kube_pod_labels{
+                            label_serving_unionai_dev_domain!="",
+                            label_serving_unionai_dev_project!="",
+                            label_serving_unionai_dev_app_name!="",
+                            label_serving_knative_dev_revision!=""
+                            }, # this filters for apps only
+                          "label_entity_type", "app", "", "" # set label_entity_type to "app"
+                        ),
+                        "label_entity_id", "$1", "label_serving_knative_dev_revision", "(.*)" # set label_entity_id to the app name (so we have label_entity_id with both execution ids and app versions)
+                      ),
+                      "label_domain", "$1", "label_serving_unionai_dev_domain", "(.*)" # cast to joinable name
+                    ),
+                    "label_project", "$1", "label_serving_unionai_dev_project", "(.*)" # cast to joinable name
+                  )
+                )
+              )
+              # Then filter for pods only in the "Running" or "Pending" phase
+              * on (namespace, pod) group_left() (
+                max by (namespace, pod) (
+                  kube_pod_status_phase{phase=~"Running|Pending"} == 1
+                )
+              )
+              # Now join in node identifiers which are used for subsequent overhead calculations
+              * on (namespace, pod) group_left(node) (
+                max by (namespace, pod, node) (kube_pod_info{node!=""}) # needed to add node!="" to dedupe
+              )
+            )
+        - record: entity_id:gpu_usage_per_node:sum # Allocated gpu aggregated per node and entity, where entity is either a task/workflow execution or an app.
+          expr: |
+            sum by (label_entity_type, label_domain, label_project, label_entity_id, node) (
+              # First, grab the allocated gpu for each pod (which is always either 1 or zero, since k8s can't split gpus the way it can with cpu/memory)
+              container_gpu_allocation # we are using the opencost metric for gpu allocation. may want to look into using native k8s/dcgm exporter data in the future
+              # Next, add labels to each pod that contain the relevant entity information (i.e. workflow/task or app). Note that this is repetitive but I didn't want to double the number of pod-level metrics we save
+              * on (namespace, pod) group_left(label_entity_type, label_domain, label_project, label_entity_id) (
+                max by (label_entity_type, label_domain, label_project, label_entity_id, namespace, pod)( # adds workflow/task labels
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          kube_pod_labels{label_domain!="", label_project!="", label_workflow_name!="", label_execution_id!=""}, # this filters for workflow and task executions only (no apps)
+                          "label_entity_type", "workflow", "", ""
+                        ),
+                        "label_entity_id", "$1", "label_execution_id", "(.*)" # set label_entity_id to the execution id (join key)
+                      ),
+                      "label_domain", "$1", "label_domain", "(.*)"
+                    ),
+                    "label_project", "$1", "label_project", "(.*)"
+                  )
+                )
+                or
+                max by (label_entity_type, label_domain, label_project, label_entity_id, namespace, pod)( # adds app labels
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          kube_pod_labels{
+                            label_serving_unionai_dev_domain!="",
+                            label_serving_unionai_dev_project!="",
+                            label_serving_unionai_dev_app_name!="",
+                            label_serving_knative_dev_revision!=""
+                          }, # this filters for apps only
+                          "label_entity_type", "app", "", ""
+                        ),
+                        "label_entity_id", "$1", "label_serving_knative_dev_revision", "(.*)" # set label_entity_id to the app name (so we have label_entity_id with both execution ids and app versions)
+                      ),
+                      "label_domain", "$1", "label_serving_unionai_dev_domain", "(.*)" # cast to joinable name
+                    ),
+                    "label_project", "$1", "label_serving_unionai_dev_project", "(.*)" # cast to joinable name
+                  )
+                )
+              )
+              # Then filter for pods only in the "Running" or "Pending" phase
+              * on (namespace, pod) group_left() (
+                max by (namespace, pod) (
+                  kube_pod_status_phase{phase=~"Running|Pending"} == 1
+                )
+              )
+              # Now join in node identifiers which are used for subsequent overhead calculations
+              * on (namespace, pod) group_left(node) (
+                max by (namespace, pod, node) (kube_pod_info{node!=""}) # needed to add node!="" to dedupe
+              )
+            )
+        - record: entity_id:allocated_mem_cost:sum # Allocated cost of memory for each workflow/task execution and app.
+          expr: |
+            sum by (label_entity_type, label_domain, label_project, label_entity_id, type) (
+              entity_id:mem_usage_bytes_total_per_node:sum / (1024 * 1024 * 1024) # convert bytes to GB
+              * on (node) group_left(type) label_replace(avg by (node) (node_ram_hourly_cost * (15 / 3600)), "type", "mem", "", "") # convert hourly cost to 15-secondly cost and add type
+            )
+        - record: entity_id:allocated_cpu_cost:sum # Allocated cost of cpu for each workflow/task execution and app.
+          expr: |
+            sum by (label_entity_type, label_domain, label_project, label_entity_id, type)(
+              entity_id:cpu_usage_per_node:sum
+              * on (node) group_left(type) label_replace(avg by (node) (node_cpu_hourly_cost * (15 / 3600)), "type", "cpu", "", "") # convert hourly cost to 15-secondly cost and add type
+            )
+        - record: entity_id:allocated_gpu_cost:sum # Allocated cost of gpu for each workflow/task execution and app.
+          expr: |
+            sum by (label_entity_type, label_domain, label_project, label_entity_id, type)(
+              entity_id:gpu_usage_per_node:sum
+              * on (node) group_left(type) label_replace(avg by (node) (node_gpu_hourly_cost * (15 / 3600)), "type", "gpu", "", "") # convert hourly cost to 15-secondly cost and add type
+            )
+        - record: entity_id:allocated_cost:sum # Allocated cost of memory, cpu, and gpu for each workflow/task execution and app.
+          expr: |
+            label_replace(
+              sum by (label_entity_type, label_domain, label_project, label_entity_id) ( # for the sum to work, the labels need to be different on each "or" element (type label)
+                entity_id:allocated_mem_cost:sum
+                or
+                entity_id:allocated_cpu_cost:sum
+                or
+                entity_id:allocated_gpu_cost:sum
+              ),
+              "type", "allocated", "", "" # add type info
+            )
+        - record: entity_id:overhead_cost:sum # The amount of overhead costs (node costs that we can't allocate with container resources) to allocate to each entity (workflow/task execution or app)
+          expr: |
+            label_replace(
+              sum by (label_entity_type, label_entity_id, label_domain, label_project)( # Aggregate the per-node metrics up to workflow/task execution or app (label_entity_id)
+                # Start with each execution's and app's allocated cost per node
+                sum by (label_entity_type, label_domain, label_project, label_entity_id, node) ( # for the sum to work, the labels need to be different on each "or" element (type label)
+                  entity_id:mem_usage_bytes_total_per_node:sum / (1024 * 1024 * 1024) # convert bytes to GB
+                  * on (node) group_left(type) label_replace(avg by (node) (node_ram_hourly_cost * (15 / 3600)), "type", "mem", "", "") # convert hourly cost to 15-secondly cost and add type
+                  or
+                  entity_id:cpu_usage_per_node:sum
+                  * on (node) group_left(type) label_replace(avg by (node) (node_cpu_hourly_cost * (15 / 3600)), "type", "cpu", "", "") # convert hourly cost to 15-secondly cost and add type
+                  or
+                  entity_id:gpu_usage_per_node:sum
+                  * on (node) group_left(type) label_replace(avg by (node) (node_gpu_hourly_cost * (15 / 3600)), "type", "gpu", "", "") # convert hourly cost to 15-secondly cost and add type
+                )
+                # Then divide out the total allocated cost per node to get the proportion of allocated cost associated with each entity
+                / on (node) group_left()(
+                  sum by (node) ( # for the sum to work, the labels need to be different on each "or" element (type label)
+                    entity_id:mem_usage_bytes_total_per_node:sum / (1024 * 1024 * 1024) # convert bytes to GB
+                    * on (node) group_left(type) label_replace(avg by (node) (node_ram_hourly_cost * (15 / 3600)), "type", "mem", "", "") # convert hourly cost to 15-secondly cost and add type
+                    or
+                    entity_id:cpu_usage_per_node:sum
+                    * on (node) group_left(type) label_replace(avg by (node) (node_cpu_hourly_cost * (15 / 3600)), "type", "cpu", "", "") # convert hourly cost to 15-secondly cost and add type
+                    or
+                    entity_id:gpu_usage_per_node:sum
+                    * on (node) group_left(type) label_replace(avg by (node) (node_gpu_hourly_cost * (15 / 3600)), "type", "gpu", "", "") # convert hourly cost to 15-secondly cost and add type
+                  )
+                )
+                # Then multiply by the overhead cost per node
+                * on (node) group_left() (
+                  # To calculate overhead, start with the true cost of running each node
+                  avg by (node)(kube_node_labels{label_flyte_org_node_role="worker"}) # only look at worker nodes
+                  * on (node) max by (node) (
+                    node_total_hourly_cost
+                  ) * (15 / 3600) # convert hourly cost to 15-secondly cost
+                  # Then subtract out the total allocated cost on each node
+                  - on (node) group_left()(
+                    sum by (node) ( # for the sum to work, the labels need to be different on each "or" element (type label)
+                      entity_id:mem_usage_bytes_total_per_node:sum / (1024 * 1024 * 1024) # convert bytes to GB
+                      * on (node) group_left(type) label_replace(avg by (node) (node_ram_hourly_cost * (15 / 3600)), "type", "mem", "", "") # convert hourly cost to 15-secondly cost and add type
+                      or
+                      entity_id:cpu_usage_per_node:sum
+                      * on (node) group_left(type) label_replace(avg by (node) (node_cpu_hourly_cost * (15 / 3600)), "type", "cpu", "", "") # convert hourly cost to 15-secondly cost and add type
+                      or
+                      entity_id:gpu_usage_per_node:sum
+                      * on (node) group_left(type) label_replace(avg by (node) (node_gpu_hourly_cost * (15 / 3600)), "type", "gpu", "", "") # convert hourly cost to 15-secondly cost and add type
+                    )
+                  )
+                )
+              ),
+              "type", "overhead", "", "" # add type info
+            )
+        - record: entity_id:total_cost:sum # Total cost of each entity (workflow/task execution or app), including allocated (from container resources) and overhead (proportion of unallocated node costs)
+          expr: |
+            label_replace(
+              sum by (label_domain, label_project, label_entity_id, label_entity_type) (
+                entity_id:allocated_cost:sum
+                or
+                entity_id:overhead_cost:sum
+              ),
+              "type", "total", "", "" # add type info
+            )
+        - record: node:total_cost:sum # Total cost of all nodes
+          expr: |
+            sum (
+              avg by (node)(kube_node_labels{label_flyte_org_node_role="worker", label_node_kubernetes_io_instance_type!=""}) # only look at worker nodes
+              * on (node) group_left() node_total_hourly_cost * (15 / 3600) # convert hourly cost to 15-secondly cost
+            )
+        - record: node_type:total_cost:sum # Total cost of nodes grouped by node type
+          expr: |
+            sum by (node_type)(
+              avg by (node)(kube_node_labels{label_flyte_org_node_role="worker", label_node_kubernetes_io_instance_type!=""}) # only look at worker nodes
+              * on (node) group_left(node_type) label_replace(node_total_hourly_cost, "node_type", "$1", "instance_type", "(.*)") * (15 / 3600) # convert hourly cost to 15-secondly cost and rename label
+            )
+        - record: node_type:uptime_hours:sum # Total uptime of nodes grouped by node type
+          expr: |
+            sum by (node_type)(
+              avg by (node, node_type)( # dedupe
+                label_replace(kube_node_labels{label_flyte_org_node_role="worker", label_node_kubernetes_io_instance_type!=""}, "node_type", "$1", "label_node_kubernetes_io_instance_type", "(.*)") # relabel
+              )
+            ) * (15 / 3600) # convert to number of hours per 15-second observation
+    # Aggregate the above into visible metrics
+    - name: cost_rollup_15m
+      interval: 15m
+      rules:
+        - record: entity_id:allocated_mem_cost:sum15m
+          expr: |
+            sum_over_time(entity_id:allocated_mem_cost:sum[15m:15s])
+        - record: entity_id:allocated_cpu_cost:sum15m
+          expr: |
+            sum_over_time(entity_id:allocated_cpu_cost:sum[15m:15s])
+        - record: entity_id:allocated_gpu_cost:sum15m
+          expr: |
+            sum_over_time(entity_id:allocated_gpu_cost:sum[15m:15s])
+        - record: entity_id:allocated_cost:sum15m
+          expr: |
+            sum_over_time(entity_id:allocated_cost:sum[15m:15s])
+        - record: entity_id:overhead_cost:sum15m
+          expr: |
+            sum_over_time(entity_id:overhead_cost:sum[15m:15s])
+        - record: entity_id:total_cost:sum15m
+          expr: |
+            sum_over_time(entity_id:total_cost:sum[15m:15s])
+        - record: node:total_cost:sum15m
+          expr: |
+            sum_over_time(node:total_cost:sum[15m:15s])
+        - record: node_type:total_cost:sum15m
+          expr: |
+            sum_over_time(node_type:total_cost:sum[15m:15s])
+        - record: node_type:uptime_hours:sum15m
+          expr: |
+            sum_over_time(node_type:uptime_hours:sum[15m:15s])
+{{- end -}}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -421,7 +421,7 @@ fluent-bit:
           Name loki
           Match kube.*
           Host unionai-dataplane-loki.union.svc.cluster.local
-          Labels service_name=$kubernetes['container_name']
+          Labels service_name=$kubernetes['container_name'] namespace=$kubernetes['namespace_name']
 
       [OUTPUT]
           Name loki

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -421,7 +421,7 @@ fluent-bit:
           Name loki
           Match kube.*
           Host unionai-dataplane-loki.union.svc.cluster.local
-          Labels service_name=$kubernetes['container_name'] namespace=$kubernetes['namespace_name']
+          Labels service_name=$kubernetes['container_name'], namespace=$kubernetes['namespace_name']
 
       [OUTPUT]
           Name loki

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -365,6 +365,69 @@ dcgmExporter:
       mountPath: /usr/local/nvidia
       readOnly: true
 
+fluent-bit:
+  enabled: true
+  prometheusRule:
+    enabled: false
+  dashboards:
+    enabled: true
+    labelKey: grafana_dashboard
+    labelValue: 1
+    annotations: { }
+    namespace: union
+    deterministicUid: false
+  config:
+    service: |
+      [SERVICE]
+          Daemon Off
+          Flush {{ .Values.flush }}
+          Log_Level {{ .Values.logLevel }}
+          Parsers_File /fluent-bit/etc/parsers.conf
+          Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
+          HTTP_Server On
+          HTTP_Listen 0.0.0.0
+          HTTP_Port {{ .Values.metricsPort }}
+          Health_Check On
+
+    ## https://docs.fluentbit.io/manual/pipeline/inputs
+    inputs: |
+      [INPUT]
+          Name tail
+          Path /var/log/containers/*.log
+          multiline.parser docker, cri
+          Tag kube.*
+          Mem_Buf_Limit 5MB
+          Skip_Long_Lines On
+
+      [INPUT]
+          Name systemd
+          Tag host.*
+          Systemd_Filter _SYSTEMD_UNIT=kubelet.service
+          Read_From_Tail On
+
+    ## https://docs.fluentbit.io/manual/pipeline/filters
+    filters: |
+      [FILTER]
+          Name kubernetes
+          Match kube.*
+          Merge_Log On
+          Keep_Log Off
+          K8S-Logging.Parser On
+          K8S-Logging.Exclude On
+
+    ## https://docs.fluentbit.io/manual/pipeline/outputs
+    outputs: |
+      [OUTPUT]
+          Name loki
+          Match kube.*
+          Host unionai-dataplane-loki.union.svc.cluster.local
+          Labels service_name=$kubernetes['container_name']
+
+      [OUTPUT]
+          Name loki
+          Match host.*
+          Host unionai-dataplane-loki.union.svc.cluster.local
+
 flyteagent:
   enabled: false
   plugin_config: { }
@@ -515,6 +578,81 @@ integration:
   spark: false
   ray: false
   databricks: false
+  opencost: false
+
+loki:
+  enabled: true
+  memberlist:
+    service:
+      publishNotReadyAddresses: true
+  loki:
+    auth_enabled: false
+    commonConfig:
+      replication_factor: 1
+    schemaConfig:
+      configs:
+        - from: "2024-04-01"
+          store: tsdb
+          object_store: s3
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+    storage:
+      type: s3
+      bucketNames:
+        chunks: union-loki-dev-chunk
+        ruler: union-loki-dev-ruler
+        admin: union-loki-dev-admin
+      s3:
+        endpoint: null
+        region: null
+        secretAccessKey: null
+        accessKeyId: null
+        signatureVersion: null
+        s3ForcePathStyle: false
+        insecure: false
+        http_config: { }
+        # -- Check https://grafana.com/docs/loki/latest/configure/#s3_storage_config for more info on how to provide a backoff_config
+        backoff_config: { }
+        disable_dualstack: false
+    pattern_ingester:
+      enabled: true
+    limits_config:
+      allow_structured_metadata: true
+      volume_enabled: true
+    ruler:
+      enable_api: true
+  deploymentMode: SingleBinary
+
+  singleBinary:
+    replicas: 1
+
+  backend:
+    replicas: 0
+  read:
+    replicas: 0
+  write:
+    replicas: 0
+  ingester:
+    replicas: 0
+  querier:
+    replicas: 0
+  queryFrontend:
+    replicas: 0
+  queryScheduler:
+    replicas: 0
+  distributor:
+    replicas: 0
+  compactor:
+    replicas: 0
+  indexGateway:
+    replicas: 0
+  bloomCompactor:
+    replicas: 0
+  bloomGateway:
+    replicas: 0
+  isDefault: true
 
 monitoring:
   kubeStateMetrics:
@@ -575,29 +713,32 @@ prometheus:
 
   namespaceOverride: "union"
 
+  kubeApiServer:
+    enabled: true
+
   nodeExporter:
-    enabled: false
+    enabled: true
 
   defaultRules:
-    create: false
+    create: true
     rules:
       alertmanager: false
-      etcd: false
+      etcd: true
       configReloaders: false
-      general: false
-      k8sContainerCpuUsageSecondsTotal: false
+      general: true
+      k8sContainerCpuUsageSecondsTotal: true
       k8sContainerMemoryCache: false
       k8sContainerMemoryRss: false
       k8sContainerMemorySwap: false
       k8sContainerResource: false
       k8sContainerMemoryWorkingSetBytes: false
       k8sPodOwner: false
-      kubeApiserverAvailability: false
-      kubeApiserverBurnrate: false
-      kubeApiserverHistogram: false
-      kubeApiserverSlos: false
-      kubeControllerManager: false
-      kubelet: false
+      kubeApiserverAvailability: true
+      kubeApiserverBurnrate: true
+      kubeApiserverHistogram: true
+      kubeApiserverSlos: true
+      kubeControllerManager: true
+      kubelet: true
       kubeProxy: false
       kubePrometheusGeneral: false
       kubePrometheusNodeRecording: false
@@ -607,11 +748,11 @@ prometheus:
       kubernetesSystem: false
       kubeSchedulerAlerting: false
       kubeSchedulerRecording: false
-      kubeStateMetrics: false
+      kubeStateMetrics: true
       network: false
-      node: false
-      nodeExporterAlerting: false
-      nodeExporterRecording: false
+      node: true
+      nodeExporterAlerting: true
+      nodeExporterRecording: true
       prometheus: false
       prometheusOperator: false
       windows: false
@@ -619,7 +760,26 @@ prometheus:
   crds:
     enabled: true
   grafana:
-    enabled: false
+    enabled: true
+    ingress:
+      enabled: false
+    dashboardsConfigMaps: { }
+    # default: ""
+    adminUser: admin
+    adminPassword: union-dataplane
+    additionalDataSources:
+      - name: loki
+        type: loki
+        url: http://unionai-dataplane-loki.union.svc.cluster.local:3100
+        jsonData:
+          timeout: 60
+          maxLines: 1000
+
+    admin:
+      existingSecret: ""
+      userKey: admin-user
+      passwordKey: admin-password
+
   prometheus:
     enabled: true
     prometheusSpec:
@@ -702,6 +862,7 @@ storage:
   accessKey: ""
   secretKey: ""
   endpoint: ""
+  s3ForcePathStyle: true
   enableMultiContainer: false
   limits:
     maxDownloadMBs: 10


### PR DESCRIPTION
* [x] Enable several prometheus rules
* [x] Add support for both Loki and Fluentbit.  These will be enabled by default.
* [x] Adds a the Loki datasource to grafana.
* [x] Fixes the spelling of the operator container.  I noticed that it was misspelled as we are now using the container name as the service name in the logs.
* [ ] Put together some union service dashboards.
* [ ] Clean up the metrics dashboards.  I may revisit having the Kube monitoring stack create them and statically define the ones we want in the charts.

## Logs
<img width="1481" alt="Screenshot 2025-02-04 at 4 04 35 PM" src="https://github.com/user-attachments/assets/cd6ab6aa-7fd3-410c-b292-8b2289479f4d" />

