### PR TITLE
ctx/chore(monitoring): clean annotations and values

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -263,11 +263,6 @@ http://operator-proxy.{{ .Release.Namespace }}.svc.cluster.local:10254
 Global pod annotations
 */}}
 {{- define "global.podAnnotations" -}}
-{{- if .Values.monitoring.prometheus }}
-prometheus.io/scrape: "true"
-{{- end }}
-prometheus.io/path: "/metrics"
-prometheus.io/port: "10254"
 {{- with .Values.additionalPodAnnotations }}
 {{- toYaml . }}
 {{- end }}

--- a/charts/dataplane/templates/dcgm-exporter/daemonset.yaml
+++ b/charts/dataplane/templates/dcgm-exporter/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.dcgmExporter.enabled -}}
+{{- if .Values.dcgmExporter.enabled -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/dataplane/templates/dcgm-exporter/service.yaml
+++ b/charts/dataplane/templates/dcgm-exporter/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.dcgmExporter.enabled -}}
+{{- if .Values.dcgmExporter.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/dataplane/templates/dcgm-exporter/serviceaccount.yaml
+++ b/charts/dataplane/templates/dcgm-exporter/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.dcgmExporter.enabled -}}
+{{- if .Values.dcgmExporter.enabled -}}
 {{- if .Values.dcgmExporter.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -333,6 +333,7 @@ databricks:
   plugin_config: { }
 
 dcgmExporter:
+  enabled: false
   arguments: ["-f", "/etc/dcgm-exporter/dcp-metrics-included.csv"]
   serviceAccount:
     create: true


### PR DESCRIPTION
* [x] With the move to a service monitor we can remove the unused prometheus annotations.
* [x] Remove the monitoring values block.  Most of the values were not used and cleaned up in the last PR.  This removes the final DCGM exporter value in favor of an enable value nested under the `dcgmExporter` block (to match what other services are doing).