### PR TITLE
ctx/fix(dataplane): fast registration config invalid

### DIFF
--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -4,10 +4,8 @@ Storage helpers.  This migrates all of the storage configurations to
 the stow based options to provide additional configuration flexibility.
 */}}
 {{- define "storage.base" -}}
-storage:
 {{- if or (eq .Values.storage.provider "compat") (eq .Values.storage.provider "oci") }}
   type: stow
-  container: {{ .Values.storage.bucketName }}
   stow:
     kind: s3
     config:
@@ -27,6 +25,8 @@ storage:
 {{- end }}
 
 {{- define "storage" -}}
+storage:
+  container: {{ .Values.storage.bucketName }}
 {{- include "storage.base" .}}
   enable-multicontainer: {{ .Values.storage.enableMultiContainer }}
   limits:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -264,8 +264,10 @@ config:
       bucketRegion: "{{ .Values.storage.region }}"
       userRoleKey: "{{ tpl (.Values.userRoleAnnotationKey | toString) $ }}"
       userRole: "{{ tpl (.Values.userRoleAnnotationValue | toString) $ }}"
-      # TODO: this will most likely be stow/custom for everything I do here.
-      storageType: "{{ .Values.provider }}"
+      # -- storageType is only used when syncClusterConfig is enabled. It is intentionally disabled and it should not be used.
+      storageType: custom
+      # -- customStorageConfig is only used when syncClusterConfig is enabled. It is intentionally disabled and it should not be used.
+      customStorageConfig: ""
       gcpProjectId: "{{ .Values.storage.gcp.projectId }}"
     collectUsages:
       enabled: true
@@ -276,8 +278,6 @@ config:
         endpoint: '{{ include "proxy.health.url" . }}'
       prometheus:
         endpoint: '{{ include "prometheus.health.url" . }}'
-    # TODO: Remove me.  I need to get the included text and dump it.
-    customStorageConfig: "" # this is another thing that needs conditional work
   qubole: { }
   remoteData:
     remoteData:

--- a/providers/oci/outputs.tf
+++ b/providers/oci/outputs.tf
@@ -5,7 +5,7 @@ output "compartment_id" {
 output "bucket_info" {
   value = {
     "bucket_name" : oci_objectstorage_bucket.union-dp-bucket.name,
-    "compatibility_endpoint" : "https://${oci_identity_tag_namespace.unionai.name}.compat.objectstorage.${var.region}.oraclecloud.com",
+    "compatibility_endpoint" : "https://${oci_objectstorage_bucket.union-dp-bucket.namespace}.compat.objectstorage.${var.region}.oraclecloud.com",
     "access_key" : oci_identity_customer_secret_key.union-storage-access.id,
     "secret_key" : oci_identity_customer_secret_key.union-storage-access.key,
   }

--- a/providers/oci/storage.tf
+++ b/providers/oci/storage.tf
@@ -51,3 +51,13 @@ resource "oci_objectstorage_bucket" "union-dp-bucket" {
   access_type           = "NoPublicAccess"
   object_events_enabled = false
 }
+
+resource "oci_identity_policy" "union-storage-access" {
+  compartment_id = var.tenancy_ocid
+  description    = "Union storage access policy"
+  name           = "union-storage-access"
+  statements = [
+    "Allow group 'Default'/'union-storage' to manage buckets in compartment unionai",
+    "Allow group 'Default'/'union-storage' to manage objects in compartment unionai",
+  ]
+}

--- a/providers/oci/variables.tf
+++ b/providers/oci/variables.tf
@@ -52,18 +52,18 @@ variable "services_cidr" {
 # https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengrunninggpunodes.htm#contengrunninggpunodes_topic-supportedgpushapes
 variable "node_shape" {
   type    = string
-  # default = "VM.Standard3.Flex"
-  default = "VM.GPU.A10.1"
+  default = "VM.Standard3.Flex"
+  # default = "VM.GPU.A10.1"
 }
 
 variable "node_cpus" {
   type    = number
-  default = 4
+  default = 6
 }
 
 variable "node_memory_gb" {
   type    = number
-  default = 16
+  default = 24
 }
 
 variable "node_boot_volume_size_gb" {
@@ -74,14 +74,14 @@ variable "node_boot_volume_size_gb" {
 variable "image_id" {
   type = string
   # Oracle-Linux-8.10-2024.09.30-0-OKE-1.31.1-748
-  # default = "ocid1.image.oc1.us-sanjose-1.aaaaaaaac4onum4ux63szstw3ykptcyayamk6473zex6lba7kv63astrd6vq"
+  default = "ocid1.image.oc1.us-sanjose-1.aaaaaaaac4onum4ux63szstw3ykptcyayamk6473zex6lba7kv63astrd6vq"
   # Oracle-Linux-8.10-Gen2-GPU-2024.09.30-0-OKE-1.31.1-747
-  default = "ocid1.image.oc1.us-sanjose-1.aaaaaaaahq4jtk5oteo5zwumf235rtlx6fcsgs4cftrvrwcayq5vmcr4uhxa"
+  # default = "ocid1.image.oc1.us-sanjose-1.aaaaaaaahq4jtk5oteo5zwumf235rtlx6fcsgs4cftrvrwcayq5vmcr4uhxa"
 }
 
 variable "node_count" {
   type    = number
-  default = 1
+  default = 3
 }
 
 variable "storage_user_email" {


### PR DESCRIPTION
* [x] The fast registration config generation was including the nested storage configuration instead of the contents.  This change moves allows the `storage.base` template helper to return only the contents so it can be reused in fast registration.
* [x] I've intentionally disabled and commented the storage fields in `config.operator.clusterData` as they are only used for config sync which is disabled and it's usage is discouraged. 
* [x] While testing on OCI, I noticed that  there was an issue with the output of the terraform configuration for OCI so there are a couple of adjustments there including: 1) Output now emits the actual bucket namespace, 2) Added back a policy block that I'd intentionally taken out for testing and accidentally committed, and 3) Made a couple changes to the defaults.
