### PR TITLE
ctx/feat(dataplane): add scheduling constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KUBECONFIG ?= $(HOME)/.kube/config
-CHART_DIR := charts/union-operator
+CHART_DIR := charts/dataplane
 
 BUILD_DIR := build
 $(BUILD_DIR):
@@ -10,7 +10,7 @@ $(TARGET_DIR): $(BUILD_DIR)
 	mkdir $(BUILD_DIR)/helm
 
 helm-gen-tests: $(TARGET_DIR)
-	helm dep update $(CHART_DIR)/
+	helm dep update $(CHART_DIR)
 	helm template dataplane $(CHART_DIR) \
 		--namespace union \
 		--values $(CHART_DIR)/values.yaml \
@@ -22,6 +22,6 @@ helm-gen-tests: $(TARGET_DIR)
 		--set storage.secretKey="xxxxxxx" \
 		--set secrets.admin.enabled=true \
 		--set secrets.admin.clientSecret="supersecret" \
-		> $(TARGET_DIR)/union_operator_helm_test_generated.yaml
-	# helm lint charts/union-operator -f $(TARGET_DIR)/union_operator_helm_test_generated.yaml
-	kubeconform -ignore-missing-schemas -skip CustomResourceDefinition $(TARGET_DIR)/union_operator_helm_test_generated.yaml
+		> $(TARGET_DIR)/union_dataplane_helm_test_generated.yaml
+	# helm lint charts/union-dataplane -f $(TARGET_DIR)/union_dataplane_helm_test_generated.yaml
+	kubeconform -ignore-missing-schemas -skip CustomResourceDefinition $(TARGET_DIR)/union_dataplane_helm_test_generated.yaml

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,8 +4,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.2.2
-appVersion: 2025.2.2
+version: 2025.2.3
+appVersion: 2025.2.3
 kubeVersion: ">= 1.28.0"
 dependencies:
   - name: kube-prometheus-stack

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -56,6 +56,68 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end -}}
 
+{{- define "flytepropeller.scheduling.topologySpreadConstraints" -}}
+{{ with .Values.flytepropeller.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropeller.scheduling.affinity" -}}
+{{ with .Values.flytepropeller.affinity }}
+affinity:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropeller.scheduling.nodeSelector" -}}
+{{ with .Values.flytepropeller.nodeSelector }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropeller.scheduling.nodeName" -}}
+{{ with .Values.flytepropeller.nodeName }}
+nodeName: {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropeller.scheduling.tolerations" -}}
+{{ with .Values.flytepropeller.tolerations }}
+tolerations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropeller.scheduling" -}}
+{{- if .Values.flytepropeller.topologySpreadConstraints }}
+{{- include "flytepropeller.scheduling.topologySpreadConstraints" . }}
+{{- else }}
+{{- include "global.scheduling.topologySpreadConstraints" . }}
+{{- end }}
+{{- if .Values.flytepropeller.affinity }}
+{{- include "flytepropeller.scheduling.affinity" . }}
+{{- else }}
+{{- include "global.scheduling.affinity" . }}
+{{- end }}
+{{- if .Values.flytepropeller.nodeSelector }}
+{{- include "flytepropeller.scheduling.nodeSelector" . }}
+{{- else }}
+{{- include "global.scheduling.nodeSelector" . }}
+{{- end }}
+{{- if .Values.flytepropeller.nodeName }}
+{{- include "flytepropeller.scheduling.nodeName" . }}
+{{- else }}
+{{- include "global.scheduling.nodeName" . }}
+{{- end }}
+{{- if .Values.flytepropeller.tolerations }}
+{{- include "flytepropeller.scheduling.tolerations" . }}
+{{- else }}
+{{- include "global.scheduling.tolerations" . }}
+{{- end }}
+{{- end -}}
+
 {{- define "flytepropellerwebhook.selectorLabels" -}}
 app.kubernetes.io/name: flytepropellerwebhook
 app.kubernetes.io/instance: {{ .Release.Name }}
@@ -75,6 +137,68 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end -}}
 
+{{- define "flytepropellerwebhook.scheduling.topologySpreadConstraints" -}}
+{{ with .Values.flytepropellerwebhook.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropellerwebhook.scheduling.affinity" -}}
+{{ with .Values.flytepropellerwebhook.affinity }}
+affinity:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropellerwebhook.scheduling.nodeSelector" -}}
+{{ with .Values.flytepropellerwebhook.nodeSelector }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropellerwebhook.scheduling.nodeName" -}}
+{{ with .Values.flytepropellerwebhook.nodeName }}
+nodeName: {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropellerwebhook.scheduling.tolerations" -}}
+{{ with .Values.flytepropellerwebhook.tolerations }}
+tolerations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "flytepropellerwebhook.scheduling" -}}
+{{- if .Values.flytepropellerwebhook.topologySpreadConstraints }}
+{{- include "flytepropellerwebhook.scheduling.topologySpreadConstraints"}}
+{{- else }}
+{{- include "global.scheduling.topologySpreadConstraints" . }}
+{{- end }}
+{{- if .Values.flytepropellerwebhook.affinity }}
+{{- include "flytepropellerwebhook.scheduling.affinity" . }}
+{{- else }}
+{{- include "global.scheduling.affinity" . }}
+{{- end }}
+{{- if .Values.flytepropellerwebhook.nodeSelector }}
+{{- include "flytepropellerwebhook.scheduling.nodeSelector" . }}
+{{- else }}
+{{- include "global.scheduling.nodeSelector" . }}
+{{- end }}
+{{- if .Values.flytepropellerwebhook.nodeName }}
+{{- include "flytepropellerwebhook.scheduling.nodeName" . }}
+{{- else }}
+{{- include "global.scheduling.nodeName" . }}
+{{- end }}
+{{- if .Values.flytepropellerwebhook.tolerations }}
+{{- include "flytepropellerwebhook.scheduling.tolerations" . }}
+{{- else }}
+{{- include "global.scheduling.tolerations" . }}
+{{- end }}
+{{- end -}}
+
 {{- define "clusterresourcesync.selectorLabels" -}}
 app.kubernetes.io/name: clusterresourcesync
 app.kubernetes.io/instance: {{ .Release.Name }}
@@ -90,6 +214,68 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "clusterresourcesync.labels" . }}
 {{- with .Values.clusterresourcesync.podLabels }}
 {{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "clusterresourcesync.scheduling.topologySpreadConstraints" -}}
+{{ with .Values.clusterresourcesync.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "clusterresourcesync.scheduling.affinity" -}}
+{{ with .Values.clusterresourcesync.affinity }}
+affinity:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "clusterresourcesync.scheduling.nodeSelector" -}}
+{{ with .Values.clusterresourcesync.nodeSelector }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "clusterresourcesync.scheduling.nodeName" -}}
+{{ with .Values.clusterresourcesync.nodeName }}
+nodeName: {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "clusterresourcesync.scheduling.tolerations" -}}
+{{ with .Values.clusterresourcesync.tolerations }}
+tolerations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "clusterresourcesync.scheduling" -}}
+{{- if .Values.clusterresourcesync.topologySpreadConstraints }}
+{{- include "clusterresourcesync.scheduling.topologySpreadConstraints" . }}
+{{- else }}
+{{- include "global.scheduling.topologySpreadConstraints" . }}
+{{- end }}
+{{- if .Values.clusterresourcesync.affinity }}
+{{- include "clusterresourcesync.scheduling.affinity" . }}
+{{- else }}
+{{- include "global.scheduling.affinity" . }}
+{{- end }}
+{{- if .Values.clusterresourcesync.nodeSelector }}
+{{- include "clusterresourcesync.scheduling.nodeSelector" . }}
+{{- else }}
+{{- include "global.scheduling.nodeSelector" . }}
+{{- end }}
+{{- if .Values.clusterresourcesync.nodeName }}
+{{- include "clusterresourcesync.scheduling.nodeName" . }}
+{{- else }}
+{{- include "global.scheduling.nodeName" . }}
+{{- end }}
+{{- if .Values.clusterresourcesync.tolerations }}
+{{- include "clusterresourcesync.scheduling.tolerations" . }}
+{{- else }}
+{{- include "global.scheduling.tolerations" . }}
 {{- end }}
 {{- end -}}
 
@@ -115,6 +301,68 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "operator.labels" . }}
 {{- with .Values.operator.podLabels }}
 {{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "operator.scheduling.topologySpreadConstraints" -}}
+{{ with .Values.operator.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "operator.scheduling.affinity" -}}
+{{ with .Values.operator.affinity }}
+affinity:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "operator.scheduling.nodeSelector" -}}
+{{ with .Values.operator.nodeSelector }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "operator.scheduling.nodeName" -}}
+{{ with .Values.operator.nodeName }}
+nodeName: {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "operator.scheduling.tolerations" -}}
+{{ with .Values.operator.tolerations }}
+tolerations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "operator.scheduling" -}}
+{{- if .Values.operator.topologySpreadConstraints }}
+{{- include "operator.scheduling.topologySpreadConstraints" . }}
+{{- else }}
+{{- include "global.scheduling.topologySpreadConstraints" . }}
+{{- end }}
+{{- if .Values.operator.affinity }}
+{{- include "operator.scheduling.affinity" . }}
+{{- else }}
+{{- include "global.scheduling.affinity" . }}
+{{- end }}
+{{- if .Values.operator.nodeSelector }}
+{{- include "operator.scheduling.nodeSelector" . }}
+{{- else }}
+{{- include "global.scheduling.nodeSelector" . }}
+{{- end }}
+{{- if .Values.operator.nodeName }}
+{{- include "operator.scheduling.nodeName" . }}
+{{- else }}
+{{- include "global.scheduling.nodeName" . }}
+{{- end }}
+{{- if .Values.operator.tolerations }}
+{{- include "operator.scheduling.tolerations" . }}
+{{- else }}
+{{- include "global.scheduling.tolerations" . }}
 {{- end }}
 {{- end -}}
 
@@ -259,6 +507,68 @@ http://flytepropeller.{{ .Release.Namespace }}.svc.cluster.local:10254
 http://operator-proxy.{{ .Release.Namespace }}.svc.cluster.local:10254
 {{- end -}}
 
+{{- define "proxy.scheduling.topologySpreadConstraints" -}}
+{{ with .Values.proxy.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "proxy.scheduling.affinity" -}}
+{{ with .Values.proxy.affinity }}
+affinity:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "proxy.scheduling.nodeSelector" -}}
+{{ with .Values.proxy.nodeSelector }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "proxy.scheduling.nodeName" -}}
+{{ with .Values.proxy.nodeName }}
+nodeName: {{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "proxy.scheduling.tolerations" -}}
+{{ with .Values.proxy.tolerations }}
+tolerations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "proxy.scheduling" -}}
+{{- if .Values.proxy.topologySpreadConstraints }}
+{{- include "proxy.scheduling.topologySpreadConstraints" . }}
+{{- else }}
+{{- include "global.scheduling.topologySpreadConstraints" . }}
+{{- end }}
+{{- if .Values.proxy.affinity }}
+{{- include "proxy.scheduling.affinity" . }}
+{{- else }}
+{{- include "global.scheduling.affinity" . }}
+{{- end }}
+{{- if .Values.proxy.nodeSelector }}
+{{- include "proxy.scheduling.nodeSelector" . }}
+{{- else }}
+{{- include "global.scheduling.nodeSelector" . }}
+{{- end }}
+{{- if .Values.proxy.nodeName }}
+{{- include "proxy.scheduling.nodeName" . }}
+{{- else }}
+{{- include "global.scheduling.nodeName" . }}
+{{- end }}
+{{- if .Values.proxy.tolerations }}
+{{- include "proxy.scheduling.tolerations" . }}
+{{- else }}
+{{- include "global.scheduling.tolerations" . }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Global pod annotations
 */}}
@@ -307,5 +617,39 @@ Global pod environment variables
 {{- range $k, $v := .Values.additionalPodEnvVars }}
 - name: {{ $k }}
   value: {{ $v }}
+{{- end }}
+{{- end -}}
+
+{{- define "global.scheduling.topologySpreadConstraints" -}}
+{{- with .Values.scheduling.topologySpreadConstraints }}
+topologySpreadConstraints
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "global.scheduling.affinity" -}}
+{{- with .Values.scheduling.affinity }}
+affinity:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "global.scheduling.nodeSelector" -}}
+{{- with .Values.scheduling.nodeSelector }}
+nodeSelector:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "global.scheduling.tolerations" -}}
+{{- with .Values.scheduling.tolerations }}
+tolerations:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "global.scheduling.nodeName" -}}
+{{- with .Values.scheduling.nodeName }}
+nodeName: {{- toYaml . }}
 {{- end }}
 {{- end -}}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -37,6 +37,15 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Adds custom PodSpec values.
+*/}}
+{{- define "additionalPodSpec" -}}
+{{- with .Values.additionalPodSpec }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
 {{- define "flytepropeller.selectorLabels" -}}
 app.kubernetes.io/name: flytepropeller
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/dataplane/templates/clusterresourcesync/deployment.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/deployment.yaml
@@ -77,4 +77,5 @@ spec:
         {{- end }}
         {{- end }}
       {{- include "clusterresourcesync.scheduling" . | nindent 6 }}
+      {{- include "additionalPodSpec" . | nindent 6 }}
 {{- end }}

--- a/charts/dataplane/templates/clusterresourcesync/deployment.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/deployment.yaml
@@ -76,7 +76,5 @@ spec:
             secretName: union-secret-auth
         {{- end }}
         {{- end }}
-      {{- with .Values.clusterresourcesync.nodeSelector }}
-      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
-      {{- end }}
+      {{- include "clusterresourcesync.scheduling" . | nindent 6 }}
 {{- end }}

--- a/charts/dataplane/templates/operator/deployment-proxy.yaml
+++ b/charts/dataplane/templates/operator/deployment-proxy.yaml
@@ -71,15 +71,4 @@ spec:
             {{- with .Values.proxy.podEnv }}
             {{- toYaml . | nindent 10 }}
             {{- end }}
-      {{- with .Values.proxy.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.proxy.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.proxy.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "proxy.scheduling" . | nindent 6 }}

--- a/charts/dataplane/templates/operator/deployment-proxy.yaml
+++ b/charts/dataplane/templates/operator/deployment-proxy.yaml
@@ -72,3 +72,4 @@ spec:
             {{- toYaml . | nindent 10 }}
             {{- end }}
       {{- include "proxy.scheduling" . | nindent 6 }}
+      {{- include "additionalPodSpec" . | nindent 6 }}

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -96,3 +96,4 @@ spec:
                   optional: true
         {{- end }}
       {{- include "operator.scheduling" . | nindent 6 }}
+      {{- include "additionalPodSpec" . | nindent 6 }}

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -95,15 +95,4 @@ spec:
                   key: tunnel_token
                   optional: true
         {{- end }}
-      {{- with .Values.operator.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.operator.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.operator.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "operator.scheduling" . | nindent 6 }}

--- a/charts/dataplane/templates/propeller/deployment-webhook.yaml
+++ b/charts/dataplane/templates/propeller/deployment-webhook.yaml
@@ -101,6 +101,4 @@ spec:
         - name: webhook-certs
           secret:
             secretName: flyte-pod-webhook
-      {{- with .Values.flytepropellerwebhook.nodeSelector }}
-      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
-      {{- end }}
+      {{- include "flytepropellerwebhook.scheduling" . | nindent 6 }}

--- a/charts/dataplane/templates/propeller/deployment-webhook.yaml
+++ b/charts/dataplane/templates/propeller/deployment-webhook.yaml
@@ -102,3 +102,4 @@ spec:
           secret:
             secretName: flyte-pod-webhook
       {{- include "flytepropellerwebhook.scheduling" . | nindent 6 }}
+      {{- include "additionalPodSpec" . | nindent 6 }}

--- a/charts/dataplane/templates/propeller/deployment.yaml
+++ b/charts/dataplane/templates/propeller/deployment.yaml
@@ -79,12 +79,4 @@ spec:
       {{- with .Values.flytepropeller.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
-      {{- with .Values.flytepropeller.nodeSelector }}
-      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
-      {{- end }}
-      {{- with .Values.flytepropeller.affinity }}
-      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
-      {{- end }}
-      {{- with .Values.flytepropeller.tolerations }}
-      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
-      {{- end }}
+      {{- include "flytepropeller.scheduling" . | nindent 6 }}

--- a/charts/dataplane/templates/propeller/deployment.yaml
+++ b/charts/dataplane/templates/propeller/deployment.yaml
@@ -80,3 +80,4 @@ spec:
       {{ tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- include "flytepropeller.scheduling" . | nindent 6 }}
+      {{- include "additionalPodSpec" . | nindent 6 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -5,9 +5,20 @@ clusterName: ""
 orgName: ""
 provider: "metal"
 
+# -- Define additional pod environment variables for all of the Union pods.
 additionalPodEnvVars: { }
+#  key1: "value1"
+#  key2: "value2"
+# -- Define additional pod annotations for all of the Union pods.
 additionalPodAnnotations: { }
+#  annotation1: "value1"
+#  annotation2: "value2"
+# -- Define additional pod labels for all of the Union pods.
 additionalPodLabels: { }
+#  label1: "value1"
+#  label2: "value2"
+# -- Define additional PodSpec values for all of the Union pods.
+additionalPodSpec: { }
 
 # -- Global kubernetes scheduling constraints that will be applied to the
 # pods.  Application specific constraints will always take precedence.

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -9,8 +9,34 @@ additionalPodEnvVars: { }
 additionalPodAnnotations: { }
 additionalPodLabels: { }
 
-# TODO(rob): Figure out what a good general non-provider specific value would be
-#   for these.
+# -- Global kubernetes scheduling constraints that will be applied to the
+# pods.  Application specific constraints will always take precedence.
+scheduling:
+  topologySpreadConstraints: { }
+  #  - maxSkew: 1
+  #    topologyKey: zone
+  #    whenUnsatisfiable: DoNotSchedule
+  #    labelSelector:
+  #      matchLabels:
+  #        foo: bar
+  affinity: { }
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: zone
+  #              operator: NotIn
+  #              values:
+  #                - zoneC
+  nodeSelector:
+    key: "value"
+  tolerations: { }
+  #  - key: "key1"
+  #    operator: "Equal"
+  #    value: "value1"
+  #    effect: "NoSchedule"
+  nodeName: ""
+
 userRoleAnnotationKey: "eks.amazonaws.com/role-arn"
 userRoleAnnotationValue: "arn:aws:iam::ACCOUNT_ID:role/flyte_project_role"
 
@@ -21,7 +47,16 @@ clusterresourcesync:
   serviceAccountName: ""
   podAnnotations: { }
   podEnv: { }
+  # -- nodeSelector constraints for the syncresources pods
   nodeSelector: { }
+  # -- topologySpreadConstraints for the syncresources pods
+  topologySpreadConstraints: { }
+  # -- tolerations for the syncresources pods
+  tolerations: [ ]
+  # -- affinity configurations for the syncresources pods
+  affinity: { }
+  # -- nodeName constraints for the syncresources pods
+  nodeName: ""
   config:
     cluster_resources:
       standaloneDeployment: true
@@ -470,6 +505,10 @@ flytepropeller:
   tolerations: [ ]
   # -- affinity for Flytepropeller deployment
   affinity: { }
+  # -- topologySpreadConstraints for Flytepropeller deployment
+  topologySpreadConstraints: { }
+  # -- nodeName constraints for Flytepropeller deployment
+  nodeName: ""
   # -- extra arguments to pass to propeller.
   extraArgs: { }
 
@@ -516,8 +555,16 @@ flytepropellerwebhook:
   podEnv: {}
   # -- Labels for webhook pods
   podLabels: {}
+  # -- affinity for webhook deployment
+  affinity: { }
   # -- nodeSelector for webhook deployment
-  nodeSelector: {}
+  nodeSelector: { }
+  # -- topologySpreadConstraints for webhook deployment
+  topologySpreadConstraints: { }
+  # -- nodeName constraints for webhook deployment
+  nodeName: ""
+  # -- tolerations for webhook deployment
+  tolerations: [ ]
   # -- Sets securityContext for webhook pod(s).
   securityContext:
     fsGroup: 65534
@@ -678,9 +725,16 @@ operator:
   priorityClassName: ""
   imagePullSecrets: { }
   podEnv: { }
+  # -- nodeSelector constraints for the operator pods
   nodeSelector: { }
+  # -- topologySpreadConstraints for the operator pods
+  topologySpreadConstraints: { }
+  # -- tolerations for the operator pods
   tolerations: [ ]
+  # -- affinity configurations for the operator pods
   affinity: { }
+  # -- nodeName constraints for the operator pods
+  nodeName: ""
   podSecurityContext: { }
   enableTunnelService: true
   secretName: union-secret-auth
@@ -819,9 +873,16 @@ proxy:
   priorityClassName: ""
   imagePullSecrets: { }
   podEnv: { }
+  # -- topologySpreadConstraints for the proxy pods
+  topologySpreadConstraints: { }
+  # -- nodeSelector constraints for the proxy pods
   nodeSelector: { }
+  # -- tolerations for the proxy pods
   tolerations: [ ]
+  # -- affinity configurations for the proxy pods
   affinity: { }
+  # -- nodeName constraint for the proxy pods
+  nodeName: ""
   podSecurityContext: { }
   enableTunnelService: true
   secretName: union-secret-auth


### PR DESCRIPTION
* [x] Adds global scheduling constraints and standardizes all the deployments to include all constraint configurations. Global constraints will be applied to all Union application deployments and can be overridden on a per-app basis.
* [x] Fix some Makefile issues left over from the chart rename.