### PR TITLE
ctx/chore(dataplane): use chart appVersion

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,8 +4,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.2.3
-appVersion: 2025.2.3
+version: 2025.2.4
+appVersion: 2025.2.0
 kubeVersion: ">= 1.28.0"
 dependencies:
   - name: kube-prometheus-stack

--- a/charts/dataplane/templates/clusterresourcesync/deployment.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             {{- with .Values.clusterresourcesync.podEnv -}}
             {{- toYaml . | nindent 10 }}
             {{- end }}
-          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"
+          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.union.pullPolicy }}"
           name: sync-cluster-resources
           {{- with .Values.clusterresourcesync.resources }}

--- a/charts/dataplane/templates/operator/deployment-proxy.yaml
+++ b/charts/dataplane/templates/operator/deployment-proxy.yaml
@@ -43,7 +43,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {{- toYaml .Values.proxy.securityContext | nindent 12 }}
-          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"
+          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.union.pullPolicy }}
           terminationMessagePolicy: FallbackToLogsOnError
           resources:

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: operator
           securityContext:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}
-          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"
+          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.union.pullPolicy }}
           terminationMessagePolicy: FallbackToLogsOnError
           resources:

--- a/charts/dataplane/templates/propeller/deployment-webhook.yaml
+++ b/charts/dataplane/templates/propeller/deployment-webhook.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       initContainers:
         - name: generate-secrets
-          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"
+          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.union.pullPolicy }}"
           command:
             - flytepropeller
@@ -62,7 +62,7 @@ spec:
               mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"
+          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.union.pullPolicy }}"
           command:
             - flytepropeller

--- a/charts/dataplane/templates/propeller/deployment.yaml
+++ b/charts/dataplane/templates/propeller/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             {{- with .Values.flytepropeller.podEnv -}}
             {{- toYaml . | nindent 10 }}
             {{- end }}
-          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag }}"
+          image: "{{ .Values.image.union.repository }}:{{ .Values.image.union.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.union.pullPolicy }}"
           name: flytepropeller
           ports:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -39,8 +39,8 @@ scheduling:
   #              operator: NotIn
   #              values:
   #                - zoneC
-  nodeSelector:
-    key: "value"
+  nodeSelector: { }
+  #  key: "value"
   tolerations: { }
   #  - key: "key1"
   #    operator: "Equal"
@@ -616,7 +616,7 @@ image:
     pullPolicy: IfNotPresent
   union:
     repository: public.ecr.aws/p0i0a9q8/unionoperator
-    tag: 2025.01.0
+    tag: ""
     pullPolicy: IfNotPresent
   kubeStateMetrics:
     repository: registry.k8s.io/kube-state-metrics/kube-state-metrics


### PR DESCRIPTION
* [x] Use the chart appVersion for the union release tag.
* [x] Fix an accidentally uncommented `scheduling.nodesSelector` value that will cause the pods to fail scheduling. 
* [x] Bump chart version to 2025.2.4
* [x] Bump appVersion to 2025.2.0