### PR TITLE
ctx/chore(dataplane): disable extra obs features by default

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,7 +4,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.2.4
+version: 2025.2.5
 appVersion: 2025.2.0
 kubeVersion: ">= 1.28.0"
 dependencies:
@@ -13,12 +13,3 @@ dependencies:
     version: 68.2.2
     condition: monitoring.prometheus.enabled
     alias: prometheus
-  - name: loki
-    version: "6.25.*"
-    repository: https://grafana.github.io/helm-charts
-    condition: loki.enabled
-  - name: fluent-bit
-    version: "0.48.*"
-    repository: https://fluent.github.io/helm-charts
-    condition: fluentbit.enabled
-    alias: fluentbit

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -413,7 +413,7 @@ dcgmExporter:
       readOnly: true
 
 fluentbit:
-  enabled: true
+  enabled: false
   prometheusRule:
     enabled: false
   dashboards:
@@ -638,82 +638,75 @@ integration:
   opencost: false
 
 loki:
-  enabled: true
-  memberlist:
-    service:
-      publishNotReadyAddresses: true
-  loki:
-    auth_enabled: false
-    commonConfig:
-      replication_factor: 1
-    schemaConfig:
-      configs:
-        - from: "2024-04-01"
-          store: tsdb
-          object_store: s3
-          schema: v13
-          index:
-            prefix: loki_index_
-            period: 24h
-    storage:
-      type: s3
-      bucketNames:
-        chunks: union-loki-dev-chunk
-        ruler: union-loki-dev-ruler
-        admin: union-loki-dev-admin
-      s3:
-        endpoint: null
-        region: null
-        secretAccessKey: null
-        accessKeyId: null
-        signatureVersion: null
-        s3ForcePathStyle: false
-        insecure: false
-        http_config: { }
-        # -- Check https://grafana.com/docs/loki/latest/configure/#s3_storage_config for more info on how to provide a backoff_config
-        backoff_config: { }
-        disable_dualstack: false
-    pattern_ingester:
-      enabled: true
-    limits_config:
-      allow_structured_metadata: true
-      volume_enabled: true
-    ruler:
-      enable_api: true
-  deploymentMode: SingleBinary
-
-  singleBinary:
-    replicas: 1
-
-  backend:
-    replicas: 0
-  read:
-    replicas: 0
-  write:
-    replicas: 0
-  ingester:
-    replicas: 0
-  querier:
-    replicas: 0
-  queryFrontend:
-    replicas: 0
-  queryScheduler:
-    replicas: 0
-  distributor:
-    replicas: 0
-  compactor:
-    replicas: 0
-  indexGateway:
-    replicas: 0
-  bloomCompactor:
-    replicas: 0
-  bloomGateway:
-    replicas: 0
-  isDefault: true
-
-monitoring:
-  dcgmExporter:
-    enabled: false
+  enabled: false
+  # memberlist:
+  #  service:
+  #    publishNotReadyAddresses: true
+  #loki:
+  #  auth_enabled: false
+  #  commonConfig:
+  #    replication_factor: 1
+  #  schemaConfig:
+  #    configs:
+  #      - from: "2024-04-01"
+  #        store: tsdb
+  #        object_store: s3
+  #        schema: v13
+  #        index:
+  #          prefix: loki_index_
+  #          period: 24h
+  #  storage:
+  #    type: s3
+  #    bucketNames:
+  #      chunks: union-loki-dev-chunk
+  #      ruler: union-loki-dev-ruler
+  #      admin: union-loki-dev-admin
+  #    s3:
+  #      endpoint: null
+  #      region: null
+  #      secretAccessKey: null
+  #      accessKeyId: null
+  #      signatureVersion: null
+  #      s3ForcePathStyle: false
+  #      insecure: false
+  #      http_config: { }
+  #      backoff_config: { }
+  #      disable_dualstack: false
+  #  pattern_ingester:
+  #    enabled: true
+  #  limits_config:
+  #    allow_structured_metadata: true
+  #    volume_enabled: true
+  #  ruler:
+  #    enable_api: true
+  # deploymentMode: SingleBinary
+  # singleBinary:
+  #   replicas: 1
+  # backend:
+  #  replicas: 0
+  # read:
+  #   replicas: 0
+  # write:
+  #   replicas: 0
+  # ingester:
+  #   replicas: 0
+  # querier:
+  #   replicas: 0
+  # queryFrontend:
+  #   replicas: 0
+  # queryScheduler:
+  #   replicas: 0
+  # distributor:
+  #   replicas: 0
+  # compactor:
+  #   replicas: 0
+  # indexGateway:
+  #   replicas: 0
+  # bloomCompactor:
+  #   replicas: 0
+  # bloomGateway:
+  #   replicas: 0
+  # isDefault: true
 
 objectStore:
   service:
@@ -774,31 +767,31 @@ prometheus:
   namespaceOverride: "union"
 
   kubeApiServer:
-    enabled: true
+    enabled: false
 
   nodeExporter:
-    enabled: true
+    enabled: false
 
   defaultRules:
-    create: true
+    create: false
     rules:
       alertmanager: false
-      etcd: true
+      etcd: false
       configReloaders: false
-      general: true
-      k8sContainerCpuUsageSecondsTotal: true
+      general: false
+      k8sContainerCpuUsageSecondsTotal: false
       k8sContainerMemoryCache: false
       k8sContainerMemoryRss: false
       k8sContainerMemorySwap: false
       k8sContainerResource: false
       k8sContainerMemoryWorkingSetBytes: false
       k8sPodOwner: false
-      kubeApiserverAvailability: true
-      kubeApiserverBurnrate: true
-      kubeApiserverHistogram: true
-      kubeApiserverSlos: true
-      kubeControllerManager: true
-      kubelet: true
+      kubeApiserverAvailability: false
+      kubeApiserverBurnrate: false
+      kubeApiserverHistogram: false
+      kubeApiserverSlos: false
+      kubeControllerManager: false
+      kubelet: false
       kubeProxy: false
       kubePrometheusGeneral: false
       kubePrometheusNodeRecording: false
@@ -808,32 +801,33 @@ prometheus:
       kubernetesSystem: false
       kubeSchedulerAlerting: false
       kubeSchedulerRecording: false
-      kubeStateMetrics: true
+      kubeStateMetrics: false
       network: false
-      node: true
-      nodeExporterAlerting: true
-      nodeExporterRecording: true
+      node: false
+      nodeExporterAlerting: false
+      nodeExporterRecording: false
       prometheus: false
       prometheusOperator: false
       windows: false
 
   crds:
     enabled: true
+
   grafana:
-    enabled: true
+    enabled: false
     ingress:
       enabled: false
     dashboardsConfigMaps: { }
     # default: ""
     adminUser: admin
     adminPassword: union-dataplane
-    additionalDataSources:
-      - name: loki
-        type: loki
-        url: http://unionai-dataplane-loki.union.svc.cluster.local:3100
-        jsonData:
-          timeout: 60
-          maxLines: 1000
+    additionalDataSources: [ ]
+    #  - name: loki
+    #    type: loki
+    #    url: http://unionai-dataplane-loki.union.svc.cluster.local:3100
+    #    jsonData:
+    #      timeout: 60
+    #      maxLines: 1000
 
     admin:
       existingSecret: ""


### PR DESCRIPTION
* [x] Disables all of the extra observability features by default.  We made the decision to pull these out and only ship the union specific components and dependencies.  A future release will remove these entirely and add documentation and sample values for how to set up cluster metrics collection, log collection, etc. 