### PR TITLE
ctx/fix(dataplane): update default value to array

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
-# TODO: consider renaming this.
 name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.2.7
+version: 2025.2.8
 appVersion: 2025.2.1
 kubeVersion: ">= 1.28.0"
 dependencies:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -41,7 +41,7 @@ scheduling:
   #                - zoneC
   nodeSelector: { }
   #  key: "value"
-  tolerations: { }
+  tolerations: [ ]
   #  - key: "key1"
   #    operator: "Equal"
   #    value: "value1"


### PR DESCRIPTION
* [x] Fixes a coalesce warning at render time.  I'd inadvertently set the default value of `scheduling.tolerations` to a map instead of an array which emitted a warning when used correctly in overrides.
* [x] Bump version to `2025.2.8`