### PR TITLE
ctx/feat(dataplane): add fast registration URL overrides

### DIFF
--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -15,6 +15,11 @@ the stow based options to provide additional configuration flexibility.
       disable_ssl: {{ .Values.storage.disableSSL }}
       endpoint: {{ .Values.storage.endpoint }}
       region: {{ .Values.storage.region }}
+{{- with .Values.storage.fastRegistrationURL -}}
+  signedURL:
+    stowConfigOverride:
+      endpoint: {{- (toYaml .) }}
+{{- end }}
 {{- else if eq .Values.storage.provider "custom" }}
 {{- with .Values.storage.custom -}}
   {{ tpl (toYaml .) $ | nindent 2 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -913,6 +913,8 @@ storage:
   provider: "compat"
   bucketName: ""
   fastRegistrationBucketName: ""
+  # -- Override the URL for signed fast registration uploads.  This is only used for local/sandbox installations.
+  fastRegistrationUrl: ""
   region: us-east-1
   disableSSL: false
   authType: "accesskey"


### PR DESCRIPTION
* [x] Allows for overrides to the signed URLs for fast registration uploads when working in local/sandbox environments.