### PR TITLE
ctx/feat(sandbox): add chart for sandbox deps

### DIFF
--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: sandbox
+description: Deploys extras for sandbox testing.
+type: application
+icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
+version: 2025.2.0
+appVersion: 2025.2.0
+kubeVersion: ">= 1.28.0"

--- a/charts/sandbox/README.md
+++ b/charts/sandbox/README.md
@@ -1,0 +1,1 @@
+# sandbox

--- a/charts/sandbox/templates/minio/deployment.yaml
+++ b/charts/sandbox/templates/minio/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: union-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/instance: union-sandbox
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        app.kubernetes.io/instance: union-sandbox
+    spec:
+      containers:
+        - image: {{ .Values.minio.image }}
+          imagePullPolicy: {{ .Values.minio.imagePullPolicy }}
+          name: minio
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - minio server /data --console-address :9001
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: {{ .Values.minio.accessKey }}
+            - name: MINIO_SECRET_KEY
+              value: {{ .Values.minio.secretKey }}
+            - name: MINIO_DEFAULT_BUCKETS
+              value: {{ .Values.minio.defaultBucket }}
+          ports:
+            - containerPort: 9000
+              name: minio
+            - containerPort: 9001
+              name: minio-console
+          {{- with .Values.minio.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.minio.volumeMounts }}
+          volumeMounts: {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.minio.volumes }}
+      volumes: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.affinity }}
+      affinity: {{ toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sandbox/templates/minio/service.yaml
+++ b/charts/sandbox/templates/minio/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: sandbox
+spec:
+  type: ClusterIP
+  ports:
+    - name: minio
+      port: 9000
+      protocol: TCP
+      targetPort: minio
+    - name: minio-console
+      port: 9001
+      protocol: TCP
+      targetPort: minio-console
+  selector:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: union-sandbox

--- a/charts/sandbox/values-dataplane.yaml
+++ b/charts/sandbox/values-dataplane.yaml
@@ -1,0 +1,10 @@
+# Values to inject into your dataplane helm deployment to utilize the defaulted
+# sandbox applications and services.
+storage:
+  endpoint: "http://minio.union.svc.cluster.local"
+  bucketName: union-dp-bucket
+  accessKey: "minio"
+  secretKey: "miniostorage"
+  region: "us-east-1"
+  fastRegistrationBucketName: union-dp-bucket
+  fastRegistrationURL: http://localhost:9000

--- a/charts/sandbox/values.yaml
+++ b/charts/sandbox/values.yaml
@@ -1,0 +1,19 @@
+minio:
+  image: "quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z"
+  imagePullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 10m
+      memory: 128Mi
+  accessKey: minio
+  secretKey: miniostorage
+  defaultBucket: union-dp-bucket
+  volumes:
+    - name: minio-storage
+      emptyDir: { }
+  volumeMounts:
+    - name: minio-storage
+      mountPath: /data


### PR DESCRIPTION
* [x] Add chart for extra sandbox dependencies.  Currently this only includes minio as the only dependency, but will most likely grow as control plane services are added.