### PR TITLE
ctx/fix(clusterresourcesync): add rbac

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -208,6 +208,13 @@ tolerations:
 {{- end }}
 {{- end -}}
 
+{{/*
+Create the name of the clusterresources service account
+*/}}
+{{- define "clusterresourcesync.serviceAccountName" -}}
+{{- default "clustersync-system" .Values.clusterresourcesync.serviceAccount.name }}
+{{- end }}
+
 {{- define "clusterresourcesync.selectorLabels" -}}
 app.kubernetes.io/name: clusterresourcesync
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/dataplane/templates/clusterresourcesync/deployment.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           {{- end }}
           ports:
             - containerPort: 10254
-      serviceAccountName: {{ .Values.clusterresourcesync.serviceAccountName }}
+      serviceAccountName: {{ include "clusterresourcesync.serviceAccountName" . }}
       volumes:
         - configMap:
             name: clusterresource-template

--- a/charts/dataplane/templates/clusterresourcesync/serviceaccount.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/serviceaccount.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.clusterresourcesync.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clusterresourcesync.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clustersync-resource
+rules:
+  - apiGroups:
+      - ""
+      - rbac.authorization.k8s.io
+    resources:
+      - configmaps
+      - namespaces
+      - pods
+      - resourcequotas
+      - roles
+      - rolebindings
+      - secrets
+      - services
+      - serviceaccounts
+      - clusterrolebindings
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clustersync-resource
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clustersync-resource
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "clusterresourcesync.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clustersync-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "clusterresourcesync.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/dataplane/templates/operator/serviceaccount.yaml
+++ b/charts/dataplane/templates/operator/serviceaccount.yaml
@@ -97,4 +97,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
+{{- end -}}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -54,8 +54,8 @@ userRoleAnnotationValue: "arn:aws:iam::ACCOUNT_ID:role/flyte_project_role"
 clusterresourcesync:
   enabled: true
   unionCallbackEnabled: true
-  # service_account_name: clustersync-resource
-  serviceAccountName: ""
+  serviceAccount:
+    name: ""
   podAnnotations: { }
   podEnv: { }
   # -- nodeSelector constraints for the syncresources pods
@@ -70,7 +70,9 @@ clusterresourcesync:
   nodeName: ""
   config:
     cluster_resources:
+      refreshInterval: 5m
       standaloneDeployment: true
+      templatePath: /etc/flyte/clusterresource/templates
       customData:
         - production:
             - projectQuotaCpu:
@@ -121,7 +123,7 @@ clusterresourcesync:
   secretName: union-base
   templates:
     # -- Template for namespaces resources
-    - key: a_namespace.yaml
+    - key: a_namespace
       value: |
         apiVersion: v1
         kind: Namespace
@@ -134,7 +136,7 @@ clusterresourcesync:
           - kubernetes
 
     # -- Patch default service account
-    - key: b_default_service_account.yaml
+    - key: b_default_service_account
       value: |
         apiVersion: v1
         kind: ServiceAccount
@@ -144,7 +146,7 @@ clusterresourcesync:
           annotations:
             {{ defaultUserRoleKey }}: {{ defaultUserRoleValue }}
 
-    - key: c_project_resource_quota.yaml
+    - key: c_project_resource_quota
       value: |
         apiVersion: v1
         kind: ResourceQuota


### PR DESCRIPTION
* [x] The cluster resource sync service was not able to properly synchronize k8s resources due to missing (and some misconfigured) roles, bindings, and service accounts.