### PR TITLE
ctx/fix(prom): rename prometheus components

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
-version: 2025.3.1
+version: 2025.3.2
 appVersion: 2025.3.0
 kubeVersion: ">= 1.28.0"
 dependencies:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -766,7 +766,7 @@ prometheus:
 
   nameOverride: ""
 
-  fullnameOverride: "union"
+  fullnameOverride: "union-operator"
 
   namespaceOverride: "union"
 


### PR DESCRIPTION
* [x] Some of the control plane components expect a specific name to access services.  This fixes the naming.