### PR TITLE
fix(helm): support vendor-specific versions of k8s

### DIFF
--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
 version: 2025.1.2
 appVersion: 2025.1.2
-kubeVersion: ">= 1.28.0"
+kubeVersion: ">= 1.28.0-0"

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 icon: "https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png"
 version: 2025.3.2
 appVersion: 2025.3.0
-kubeVersion: ">= 1.28.0"
+kubeVersion: ">= 1.28.0-0"
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
When installing these charts on an AWS EKS cluster, we're currently failing with

```
Error: chart requires kubeVersion: >= 1.28.0 which is incompatible with Kubernetes v1.32.2-eks-bc803b4
```

Changing the constraint to `>= 1.28.0-0` allows us to support pre-release and vendor-specific versions.

### Test Plan
Tested this locally, the fix works.

### Internal Use
fixes D-1111