### PR TITLE
ctx/fix(dataplane): prom svc to port 80

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -509,11 +509,11 @@ access the storage is injected.
 {{- end -}}
 
 {{- define "prometheus.health.url" -}}
-http://union-prometheus:9090/-/healthy
+http://{{ include "union-operator.fullname" . }}-prometheus:80/-/healthy
 {{- end -}}
 
 {{- define "prometheus.service.url" -}}
-http://union-prometheus:9090
+http://{{ include "union-operator.fullname" . }}-prometheus:80
 {{- end -}}
 
 {{- define "propeller.health.url" -}}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -840,6 +840,8 @@ prometheus:
 
   prometheus:
     enabled: true
+    service:
+      port: 80
     prometheusSpec:
       resources:
         limits:


### PR DESCRIPTION
* [x] Control plane services expect the prom service to expose port 80 for requests.
* [x] Fix an omission from yesterday where the helpers referred to the old name.