### PR TITLE
chore(charts/dataplane): add dependency on k8s-sigs metrics-server chart

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -14,5 +14,5 @@ dependencies:
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server/
     version: 3.12.2
-    condition: monitoring.metricsServer.enabled
-    alias: metricsServer
+    condition: metrics-server.enabled
+    alias: metrics-server

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -12,3 +12,8 @@ dependencies:
     version: 68.2.2
     condition: monitoring.prometheus.enabled
     alias: prometheus
+  - name: metrics-server
+    repository: https://kubernetes-sigs.github.io/metrics-server/
+    version: 3.12.2
+    condition: monitoring.metricsServer.enabled
+    alias: metricsServer

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -10,7 +10,6 @@ dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
     version: 68.2.2
-    condition: monitoring.prometheus.enabled
     alias: prometheus
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -712,6 +712,13 @@ loki:
   #   replicas: 0
   # isDefault: true
 
+monitoring:
+  prometheus:
+    enabled: true
+
+  metricsServer:
+    enabled: false
+
 objectStore:
   service:
     httpPort: 8080

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -712,9 +712,8 @@ loki:
   #   replicas: 0
   # isDefault: true
 
-monitoring:
-  metricsServer:
-    enabled: false
+metrics-server:
+  enabled: false
 
 objectStore:
   service:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -713,9 +713,6 @@ loki:
   # isDefault: true
 
 monitoring:
-  prometheus:
-    enabled: true
-
   metricsServer:
     enabled: false
 


### PR DESCRIPTION
We depend on `metrics-server` for billable usage.  Because `metrics-server` creates an `APIService`, we can only run this component once per cluster.  This change assumes cluster administrators will likely already be running `metrics-server`, so we won't install it by default.

Should cluster administrators not want to worry about installing `metrics-server` themselves, they can set:
```
monitoring:
  metricsServer:
    enabled: true
```

And this chart will install it.

### Test Plan
Tested this against `byok-aws`

### Internal Use
fixes D-1124