### PR TITLE
fix(terraform-aws): use larger default instance type, helm token

### DIFF
--- a/providers/aws/provider.tf
+++ b/providers/aws/provider.tf
@@ -18,8 +18,8 @@ provider "aws" {
 
 provider "helm" {
   kubernetes {
-    host = module.eks.cluster_endpoint
-    # token                  = data.aws_eks_cluster_auth.default.token
+    host                   = module.eks.cluster_endpoint
+    token                  = data.aws_eks_cluster_auth.default.token
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -19,7 +19,7 @@ variable "node_groups" {
   }))
   default = {
     worker-on-demand = {
-      instance_type       = "m7i.xlarge"
+      instance_type       = "m7i.2xlarge"
       dedicated_node_role = "worker"
       min_size            = 2
       max_size            = 5


### PR DESCRIPTION
I had some trouble getting all of the default components (operator, operator-proxy, prometheus) to schedule on `m7i.xlarge`.  Changes the default to `m7i.2xlarge`.

Also uncomments the `token` field for the Helm provider.