### PR TITLE
fix(dataplane-chart): Specify resourceFieldRef.divisor

### DIFF
--- a/charts/dataplane-crds/templates/flyteworkflow.yaml
+++ b/charts/dataplane-crds/templates/flyteworkflow.yaml
@@ -19,4 +19,4 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
-          properties:
+          properties: null

--- a/charts/dataplane-crds/templates/flyteworkflow.yaml
+++ b/charts/dataplane-crds/templates/flyteworkflow.yaml
@@ -19,4 +19,4 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
-          properties: null
+          properties:

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -650,12 +650,12 @@ Global pod environment variables
 - name: GOMEMLIMIT
   valueFrom:
     resourceFieldRef:
-      divisor: '0'
+      divisor: 1
       resource: limits.memory
 - name: GOMAXPROCS
   valueFrom:
     resourceFieldRef:
-      divisor: '0'
+      divisor: 1
       resource: limits.cpu
 - name: CLUSTER_NAME
   valueFrom:

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -650,10 +650,12 @@ Global pod environment variables
 - name: GOMEMLIMIT
   valueFrom:
     resourceFieldRef:
+      divisor: '0'
       resource: limits.memory
 - name: GOMAXPROCS
   valueFrom:
     resourceFieldRef:
+      divisor: '0'
       resource: limits.cpu
 - name: CLUSTER_NAME
   valueFrom:


### PR DESCRIPTION
I'm working on deploying the dataplane chart with ArgoCD.  The `resourceFieldRef.divisor` field isn't specified in our chart, and after applying the generated manifests the server-side state shows `divisor: '0'`.  This is a bit odd, but possibly seems related to https://github.com/kubernetes/kubernetes/issues/128865

This change sets `divisor: 1` which is the default value in Kubernetes.