### PR TITLE
fix(dataplane): Misc fixes related to secrets and AWS IAM roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ helm-gen-tests: $(TARGET_DIR)
 		--set storage.endpoint="http://s3.default.svc:9000" \
 		--set storage.accessKey="xxxxxxx" \
 		--set storage.secretKey="xxxxxxx" \
-		--set secrets.admin.enabled=true \
+		--set secrets.admin.create=true \
 		--set secrets.admin.clientSecret="supersecret" \
 		> $(TARGET_DIR)/union_dataplane_helm_test_generated.yaml
 	# helm lint charts/union-dataplane -f $(TARGET_DIR)/union_dataplane_helm_test_generated.yaml

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ storage:
   region: <CLOUD_REGION> #not needed for on-prem deployments
 secrets:
   admin:
-    enabled: true
+    create: true
     # Insert values from step 4
     clientSecret: <MY_CLIENT_SECRET> #you can also provide this as a command-line argument
     clientId: "dataplane-operator"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ storage:
   region: <CLOUD_REGION> #not needed for on-prem deployments
 secrets:
   admin:
-    create: true
+    enabled: true
     # Insert values from step 4
     clientSecret: <MY_CLIENT_SECRET> #you can also provide this as a command-line argument
     clientId: "dataplane-operator"

--- a/charts/dataplane/README.md
+++ b/charts/dataplane/README.md
@@ -326,7 +326,7 @@ Kubernetes: `>= 1.28.0`
 | resourcequota.create | bool | `false` |  |
 | secrets.admin.clientId | string | `"dataplane-operator"` |  |
 | secrets.admin.clientSecret | string | `""` |  |
-| secrets.admin.enabled | bool | `true` |  |
+| secrets.admin.create | bool | `true` |  |
 | sparkoperator.enabled | bool | `false` |  |
 | sparkoperator.plugin_config | object | `{}` |  |
 | storage.accessKey | string | `""` |  |

--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -23,6 +23,7 @@ the stow based options to provide additional configuration flexibility.
 {{- end }}
 {{- else if eq .Values.storage.provider "aws" }}
   type: s3
+  container: {{ .Values.storage.bucketName }}
   connection:
     auth-type: {{ .Values.storage.authType }}
     region: {{ .Values.storage.region }}

--- a/charts/dataplane/templates/clusterresourcesync/deployment.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/deployment.yaml
@@ -42,10 +42,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if .Values.secrets.admin.enabled }}
             - name: auth
               mountPath: /etc/union/secret
-          {{- end }}
             - name: resource-templates
               mountPath: /etc/flyte/clusterresource/templates
             - name: config-volume

--- a/charts/dataplane/templates/clusterresourcesync/deployment.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/deployment.yaml
@@ -68,11 +68,9 @@ spec:
             secretName: cluster-credentials
         {{- end }}
         {{- if .Values.clusterresourcesync.config.cluster_resources.standaloneDeployment }}
-        {{- if .Values.secrets.admin.enabled }}
         - name: auth
           secret:
             secretName: union-secret-auth
-        {{- end }}
         {{- end }}
       {{- include "clusterresourcesync.scheduling" . | nindent 6 }}
       {{- include "additionalPodSpec" . | nindent 6 }}

--- a/charts/dataplane/templates/common/auth-secret.yaml
+++ b/charts/dataplane/templates/common/auth-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.secrets.admin.enabled) }}
+{{- if and (.Values.secrets.admin.create) }}
 {{- $secret := .Values.secrets.admin.clientSecret | required ".Values.secrets.admin.clientSecret is required when admin client credentials has been enabled." -}}
 ---
 apiVersion: v1

--- a/charts/dataplane/templates/propeller/deployment.yaml
+++ b/charts/dataplane/templates/propeller/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           name: config-volume
         - name: auth
           secret:
-            secretName: {{.Values.flytepropeller.secretName}}
+            secretName: {{ .Values.flytepropeller.secretName }}
       {{- with .Values.flytepropeller.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/dataplane/templates/propeller/deployment.yaml
+++ b/charts/dataplane/templates/propeller/deployment.yaml
@@ -53,10 +53,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/flyte/config
-        {{- if .Values.secrets.admin.enabled }}
             - name: auth
               mountPath: /etc/union/secret
-        {{- end }}
         {{- with .Values.flytepropeller.additionalVolumeMounts -}}
         {{ tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/dataplane/templates/propeller/deployment.yaml
+++ b/charts/dataplane/templates/propeller/deployment.yaml
@@ -71,11 +71,9 @@ spec:
         - configMap:
             name: flyte-propeller-config
           name: config-volume
-      {{- if .Values.secrets.admin.enabled }}
         - name: auth
           secret:
-            secretName: union-secret-auth
-      {{- end }}
+            secretName: {{.Values.flytepropeller.secretName}}
       {{- with .Values.flytepropeller.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -921,7 +921,7 @@ resourcequota:
 
 secrets:
   admin:
-    enabled: true
+    create: true
     clientSecret: ""
     clientId: "dataplane-operator"
 

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -552,6 +552,8 @@ flytepropeller:
 
   podEnv: { }
 
+  secretName: union-secret-auth
+
 flytepropellerwebhook:
   # -- enable or disable secrets webhook
   enabled: true

--- a/providers/aws/iam.tf
+++ b/providers/aws/iam.tf
@@ -50,7 +50,7 @@ module "union_backend_irsa_role" {
   oidc_providers = {
     default = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["flyte:flytepropeller", "flyte:flyteadmin", "flyte:datacatalog"]
+      namespace_service_accounts = ["union:flytepropeller-system", "union:operator-system"]
     }
   }
 }


### PR DESCRIPTION
## Overview
I've been iterating on standing up a cluster in AWS and ran into some issues, details below.

- I wanted to manage the client secret manually, think via something like ExternalSecrets or HashiCorp Vault.  This meant I didn't want to pass the secret via Helm values
  - Currently the chart creates the secret if `secrets.admin.enabled` is set
  - It also assumes that if `secrets.admin.enabled=false`, it does not need to wire up the volume mounts.  This feels incorrect to me, we should wire them up regardless and only use `secrets.admin.enabled` to manage creation of the secret.  If that's the case, `secrets.admin.create` is probably the better variable to use here -- which lines up with the example in the README
  - 👉 **tl;dr** - Refactored to `secrets.admin.create` to guard secret creation, always wire up volumes & volume mounts.

- I ran into issues using `storage.provider == "aws"`.  Unfortunately I don't recall the specifics, but setting `container` in the storage config fixed the problems I was having.  This lines up with the `compat` provider.
- The reference implementation assumed users were installing this chart into the `flyte` namespace.  I think we should lean into the Union brand here, and assume by default this will get installed into `union`. 

## Test Plan
This was tested internally

## Internal Use
ref D-1112