### PR TITLE
fix(terraform-aws): fix union-health-monitoring permissions

### DIFF
--- a/providers/aws/iam.tf
+++ b/providers/aws/iam.tf
@@ -50,7 +50,7 @@ module "union_backend_irsa_role" {
   oidc_providers = {
     default = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["union:flytepropeller-system", "union:operator-system"]
+      namespace_service_accounts = ["union:flytepropeller-system", "union:operator-system", "union:proxy-system"]
     }
   }
 }

--- a/providers/aws/locals.tf
+++ b/providers/aws/locals.tf
@@ -5,7 +5,7 @@ locals {
   name_prefix = "${local.project}-${local.environment}"
   account_id  = data.aws_caller_identity.current.account_id
 
-  union_projects = ["flytesnacks"]
+  union_projects = ["flytesnacks", "union-health-monitoring"]
   union_domains  = ["development", "staging", "production"]
 
   # move to vars as well


### PR DESCRIPTION
Adds `union-health-monitoring` to the permitted projects for IAM role use.