### PR TITLE
ctx/fix(dataplane): remove newline trim when using fastRegistrationURL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,12 +27,3 @@ jobs:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      # TODO: Rethink the automerge now that aviator is in the mix
-      - name: Automerge PR
-        uses: juliangruber/merge-pull-request-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          number: 1
-          method: squash
-          repo: juliangruber/octokit-action

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2025.3.5
+version: 2025.3.6
 appVersion: 2025.3.1
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -15,7 +15,7 @@ the stow based options to provide additional configuration flexibility.
       disable_ssl: {{ .Values.storage.disableSSL }}
       endpoint: {{ .Values.storage.endpoint }}
       region: {{ .Values.storage.region }}
-{{- with .Values.storage.fastRegistrationURL -}}
+{{- with .Values.storage.fastRegistrationURL }}
   signedURL:
     stowConfigOverride:
       endpoint: {{- (toYaml .) }}


### PR DESCRIPTION
* [x] Removes an inadvertent trim from the `fastRegistrationURL` block that caused the rendered config value to be added to previous line.