### PR TITLE
fix(serving): Do not use cloudHostName helper, add operator config

### DIFF
--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -21,8 +21,14 @@ data:
     authorizer: {{ tpl (toYaml .) $ | nindent 6 }}
   {{- end }}
     operator:
+      {{- if .Values.serving.enabled }}
+      apps:
+        enabled: true
+      {{- end }}
       enabled: {{ .Values.config.operator.enabled }}
       enableTunnelService: {{ .Values.config.operator.enableTunnelService }}
+      tunnel:
+        enableDirectToAppIngress: {{ .Values.serving.enabled }}
     {{- with .Values.config.operator.apps }}
       apps: {{ tpl (toYaml .) $ | nindent 8 }}
     {{- end }}

--- a/charts/dataplane/templates/serving/knative-serving.yaml
+++ b/charts/dataplane/templates/serving/knative-serving.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.serving.enabled }}
-{{- $cloudHostName := tpl (include "union-operator.cloudHostName" . | toString) $ -}}
 apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
@@ -71,11 +70,11 @@ spec:
     - container: kourier-gateway
       envVars:
       - name: UNION_AUTHZ_TENANTAUTHURL
-        value: "https://{{ $cloudHostName }}/me"
+        value: "https://{{ .Values.host }}/me"
       - name: UNION_AUTHZ_TENANTAUTHSIGNINURL
-        value: "https://{{ $cloudHostName }}/login"
+        value: "https://{{ .Values.host }}/login"
       - name: UNION_AUTHZ_TENANTCONTROLPLANEURL
-        value: "https://{{ $cloudHostName }}"
+        value: "https://{{ .Values.host }}"
     {{- with index .Values.serving.resources "3scale-kourier-gateway" }}
     resources:
     {{- range $container, $resources := . }}

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -337,6 +337,8 @@ data:
     operator:
       enabled: true
       enableTunnelService: true
+      tunnel:
+        enableDirectToAppIngress: false
       apps: 
         enabled: false
       syncClusterConfig: 
@@ -1940,7 +1942,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "93c4140a9a77d88bc0d7954d32be8c29bb698bd6b0adfc5929e6315a8fb5629"
+        configChecksum: "499b3e771fc3588f2f119d7328b519f38270214f75a35dda193d63231308338"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2080,7 +2082,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "93c4140a9a77d88bc0d7954d32be8c29bb698bd6b0adfc5929e6315a8fb5629"
+        configChecksum: "499b3e771fc3588f2f119d7328b519f38270214f75a35dda193d63231308338"
         
       labels:
         


### PR DESCRIPTION
Missed both of these in my previous changes:
- Does not use the `cloudHostName` helper which was an internal implementation detail
- Adds missing operator config