### PR TITLE
fix(serving): add permissions for serving, fix configuration

### DIFF
--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -21,10 +21,6 @@ data:
     authorizer: {{ tpl (toYaml .) $ | nindent 6 }}
   {{- end }}
     operator:
-      {{- if .Values.serving.enabled }}
-      apps:
-        enabled: true
-      {{- end }}
       enabled: {{ .Values.config.operator.enabled }}
       enableTunnelService: {{ .Values.config.operator.enableTunnelService }}
       tunnel:

--- a/charts/dataplane/templates/operator/serviceaccount.yaml
+++ b/charts/dataplane/templates/operator/serviceaccount.yaml
@@ -86,6 +86,21 @@ rules:
       - /metrics
     verbs:
       - get
+  {{- if .Values.serving.enabled }}
+  - apiGroups:
+      - serving.knative.dev
+    resources:
+      - revisions
+      - configurations
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -306,7 +306,7 @@ config:
   operator:
     enabled: true
     apps:
-      enabled: {{ .Values.serving.enabled }}
+      enabled: "{{ .Values.serving.enabled }}"
     syncClusterConfig:
       enabled: false
     enableTunnelService: true

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -306,7 +306,7 @@ config:
   operator:
     enabled: true
     apps:
-      enabled: false
+      enabled: {{ .Values.serving.enabled }}
     syncClusterConfig:
       enabled: false
     enableTunnelService: true

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -340,7 +340,7 @@ data:
       tunnel:
         enableDirectToAppIngress: false
       apps: 
-        enabled: false
+        enabled: 'false'
       syncClusterConfig: 
         enabled: false
       clusterId: 
@@ -1942,7 +1942,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "499b3e771fc3588f2f119d7328b519f38270214f75a35dda193d63231308338"
+        configChecksum: "d002db360c440832d298fa551e30e674693274d31c353da9e7b4126e7f630b8"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2082,7 +2082,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "499b3e771fc3588f2f119d7328b519f38270214f75a35dda193d63231308338"
+        configChecksum: "d002db360c440832d298fa551e30e674693274d31c353da9e7b4126e7f630b8"
         
       labels:
         


### PR DESCRIPTION
- Adds RBAC permissions to interact with KnativeServing resources when serving is enabled
- Prefers to use top-level `serving.enabled` flag for a better UX