### PR TITLE
ctx/fix(dataplane): disable identity caching

### DIFF
--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -54,8 +54,9 @@ data:
 {{- with .Values.config.logger }}
     logger: {{ tpl (toYaml .) $ | nindent 6 }}
 {{- end }}
-  # TODO: We used to have configmap-overrides here.  Do we even use those?
-  # config-overrides.yaml | ...
+{{- with .Values.config.configOverrides }}
+  config-overrides.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
   storage.yaml: | {{ tpl (include "storage" .) $ | nindent 4 }}
 {{- if .Values.storage.fastRegistrationBucketName }}
   fast_registration_storage.yaml: | {{ tpl (include "fast-registration-storage" .) $ | nindent 4 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -195,6 +195,12 @@ config:
   clusters:
     labelClusterMap: { }
     clusterConfigs: [ ]
+  # -- Override configuration settings.
+  configOverrides:
+    cache:
+      # Overrides identity caching which is not available in the dataplane.
+      identity:
+        enabled: false
   # -- Copilot configuration
   copilot:
     plugins:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -376,8 +376,10 @@ data:
     logger: 
       level: 6
       show-source: true
-  # TODO: We used to have configmap-overrides here.  Do we even use those?
-  # config-overrides.yaml | ...
+  config-overrides.yaml: | 
+    cache:
+      identity:
+        enabled: false
   storage.yaml: | 
     storage:
       container: bucket
@@ -1912,7 +1914,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "802d295814e9e95b10e7285b9ad500ac7e6ad239e8b99db4c20d3f2b37fd660"
+        configChecksum: "2b8bb9c492b4d8c338c9c2b41ef821e11e04907dd5f05b7ba2f6662a0dc5b67"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2042,7 +2044,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "802d295814e9e95b10e7285b9ad500ac7e6ad239e8b99db4c20d3f2b37fd660"
+        configChecksum: "2b8bb9c492b4d8c338c9c2b41ef821e11e04907dd5f05b7ba2f6662a0dc5b67"
         
       labels:
         

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -373,8 +373,10 @@ data:
     logger: 
       level: 6
       show-source: true
-  # TODO: We used to have configmap-overrides here.  Do we even use those?
-  # config-overrides.yaml | ...
+  config-overrides.yaml: | 
+    cache:
+      identity:
+        enabled: false
   storage.yaml: | 
     storage:
       container: bucket
@@ -1942,7 +1944,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d002db360c440832d298fa551e30e674693274d31c353da9e7b4126e7f630b8"
+        configChecksum: "4a48d0d5fb55a415afeb6b53aeb545dc967c45d0d7ebaf07d4d6fee66153cad"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2082,7 +2084,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d002db360c440832d298fa551e30e674693274d31c353da9e7b4126e7f630b8"
+        configChecksum: "4a48d0d5fb55a415afeb6b53aeb545dc967c45d0d7ebaf07d4d6fee66153cad"
         
       labels:
         


### PR DESCRIPTION
* [x] Disables identity caching for the dataplane.  This functionality is only available in the control plane which results in emitted errors.