### PR TITLE
bump max download limit

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -968,7 +968,7 @@ storage:
   s3ForcePathStyle: true
   enableMultiContainer: false
   limits:
-    maxDownloadMBs: 10
+    maxDownloadMBs: 1024
   cache:
     maxSizeMBs: 0
     targetGCPercent: 70

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -389,7 +389,7 @@ data:
         region: us-east-2
       enable-multicontainer: true
       limits:
-        maxDownloadMBs: 10
+        maxDownloadMBs: 1024
       cache:
         max_size_mbs: 0
         target_gc_percent: 70
@@ -523,7 +523,7 @@ data:
         region: us-east-2
       enable-multicontainer: true
       limits:
-        maxDownloadMBs: 10
+        maxDownloadMBs: 1024
       cache:
         max_size_mbs: 0
         target_gc_percent: 70
@@ -1914,7 +1914,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2b8bb9c492b4d8c338c9c2b41ef821e11e04907dd5f05b7ba2f6662a0dc5b67"
+        configChecksum: "a025346ec20f7d34fb2cfc21cf232b32e644f065db3142c3889accd309da4b9"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2044,7 +2044,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2b8bb9c492b4d8c338c9c2b41ef821e11e04907dd5f05b7ba2f6662a0dc5b67"
+        configChecksum: "a025346ec20f7d34fb2cfc21cf232b32e644f065db3142c3889accd309da4b9"
         
       labels:
         
@@ -2162,7 +2162,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8e574cfa81d4566c699a7270638955450938f3023239997db4ae5fdbfa6c43d"
+        configChecksum: "43c663b1636fe4965bfcc9ab7741e5c3cb21e96963da23e78df3763607e92b7"
         
     spec:
       securityContext: 
@@ -2312,7 +2312,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8e574cfa81d4566c699a7270638955450938f3023239997db4ae5fdbfa6c43d"
+        configChecksum: "43c663b1636fe4965bfcc9ab7741e5c3cb21e96963da23e78df3763607e92b7"
         
       labels:
         

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -392,7 +392,7 @@ data:
           region: us-ashburn-1
       enable-multicontainer: false
       limits:
-        maxDownloadMBs: 10
+        maxDownloadMBs: 1024
       cache:
         max_size_mbs: 0
         target_gc_percent: 70
@@ -543,7 +543,7 @@ data:
           region: us-ashburn-1
       enable-multicontainer: false
       limits:
-        maxDownloadMBs: 10
+        maxDownloadMBs: 1024
       cache:
         max_size_mbs: 0
         target_gc_percent: 70
@@ -1944,7 +1944,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a48d0d5fb55a415afeb6b53aeb545dc967c45d0d7ebaf07d4d6fee66153cad"
+        configChecksum: "2b09bc5fa6f792425e53028c788a2657d90b009ca26890eeca9e4fd6930cea5"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2084,7 +2084,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a48d0d5fb55a415afeb6b53aeb545dc967c45d0d7ebaf07d4d6fee66153cad"
+        configChecksum: "2b09bc5fa6f792425e53028c788a2657d90b009ca26890eeca9e4fd6930cea5"
         
       labels:
         
@@ -2212,7 +2212,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "18b431e507fdd3382f70dbbacb74f33585985c3451a988d4ee286109b0c322e"
+        configChecksum: "674e09caa80cbb4f6cd711016015f83c69ad66d92a331b28178eb8f1352ae31"
         
     spec:
       securityContext: 
@@ -2374,7 +2374,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "18b431e507fdd3382f70dbbacb74f33585985c3451a988d4ee286109b0c322e"
+        configChecksum: "674e09caa80cbb4f6cd711016015f83c69ad66d92a331b28178eb8f1352ae31"
         
       labels:
         


### PR DESCRIPTION
This config sets the maximum file size allowed for download. The example in https://linear.app/unionai/issue/D-1184/troubleshoot-and-fix-data-offloading-in-byok failed with hitting the limit. Typically we set this to 1024.