### PR TITLE
ctx/fix(dataplane): allow prom to select anywhere

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -769,6 +769,14 @@ prometheus:
     service:
       port: 80
     prometheusSpec:
+      ruleSelectorNilUsesHelmValues: false
+      ruleSelector: {}
+      scrapeConfigSelectorNilUsesHelmValues: false
+      scrapeConfigSelector: {}
+      serviceMonitorSelectorNilUsesHelmValues: false
+      serviceMonitorSelector: {}
+      podMonitorSelectorNilUsesHelmValues: false
+      podMonitorSelector: {}
       resources:
         limits:
           cpu: "4"

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -769,6 +769,10 @@ prometheus:
     service:
       port: 80
     prometheusSpec:
+      # Disable the nil uses helm values for the selectors.  This is disabled to make sure that
+      # prometheus can scrape other externally managed services beyond the scope of the helm release.
+      # If you want to limit the scope of the prometheus service to only the helm release, set this to true
+      # and/or set the selectors to the appropriate values.
       ruleSelectorNilUsesHelmValues: false
       ruleSelector: {}
       scrapeConfigSelectorNilUsesHelmValues: false

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2959,15 +2959,9 @@ spec:
   walCompression: true
   routePrefix: "/prometheus/"
   serviceAccountName: union-operator-prometheus
-  serviceMonitorSelector:
-    matchLabels:
-      release: "release-name"
-
+  serviceMonitorSelector: {}
   serviceMonitorNamespaceSelector: {}
-  podMonitorSelector:
-    matchLabels:
-      release: "release-name"
-
+  podMonitorSelector: {}
   podMonitorNamespaceSelector: {}
   probeSelector:
     matchLabels:
@@ -2982,14 +2976,8 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   ruleNamespaceSelector: {}
-  ruleSelector:
-    matchLabels:
-      release: "release-name"
-
-  scrapeConfigSelector:
-    matchLabels:
-      release: "release-name"
-
+  ruleSelector: {}
+  scrapeConfigSelector: {}
   scrapeConfigNamespaceSelector: {}
   affinity:
     podAntiAffinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -2595,7 +2595,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -2673,7 +2673,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2741,7 +2741,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -2800,7 +2800,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2907,7 +2907,7 @@ spec:
       serviceAccountName: flytepropeller-webhook-system
       initContainers:
         - name: generate-secrets
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -2957,7 +2957,7 @@ spec:
               mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -3092,7 +3092,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.3.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
           imagePullPolicy: "IfNotPresent"
           name: flytepropeller
           ports:
@@ -3268,15 +3268,9 @@ spec:
   walCompression: true
   routePrefix: "/prometheus/"
   serviceAccountName: union-operator-prometheus
-  serviceMonitorSelector:
-    matchLabels:
-      release: "release-name"
-
+  serviceMonitorSelector: {}
   serviceMonitorNamespaceSelector: {}
-  podMonitorSelector:
-    matchLabels:
-      release: "release-name"
-
+  podMonitorSelector: {}
   podMonitorNamespaceSelector: {}
   probeSelector:
     matchLabels:
@@ -3291,14 +3285,8 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   ruleNamespaceSelector: {}
-  ruleSelector:
-    matchLabels:
-      release: "release-name"
-
-  scrapeConfigSelector:
-    matchLabels:
-      release: "release-name"
-
+  ruleSelector: {}
+  scrapeConfigSelector: {}
   scrapeConfigNamespaceSelector: {}
   affinity:
     podAntiAffinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3032,15 +3032,9 @@ spec:
   walCompression: true
   routePrefix: "/prometheus/"
   serviceAccountName: union-operator-prometheus
-  serviceMonitorSelector:
-    matchLabels:
-      release: "release-name"
-
+  serviceMonitorSelector: {}
   serviceMonitorNamespaceSelector: {}
-  podMonitorSelector:
-    matchLabels:
-      release: "release-name"
-
+  podMonitorSelector: {}
   podMonitorNamespaceSelector: {}
   probeSelector:
     matchLabels:
@@ -3055,14 +3049,8 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   ruleNamespaceSelector: {}
-  ruleSelector:
-    matchLabels:
-      release: "release-name"
-
-  scrapeConfigSelector:
-    matchLabels:
-      release: "release-name"
-
+  ruleSelector: {}
+  scrapeConfigSelector: {}
   scrapeConfigNamespaceSelector: {}
   affinity:
     podAntiAffinity:


### PR DESCRIPTION
* [x] Open up monitor selectors to everything.  This fixes the issue with finding resources on externally managed/installed services.  Wide open for now, but will most likely have some sane defaults in the future.
