### PR TITLE
ctx/chore(dataplane): set default prom retention to 3 days

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -769,6 +769,7 @@ prometheus:
     service:
       port: 80
     prometheusSpec:
+      retention: 3d
       # Disable the nil uses helm values for the selectors.  This is disabled to make sure that
       # prometheus can scrape other externally managed services beyond the scope of the helm release.
       # If you want to limit the scope of the prometheus service to only the helm release, set this to true

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2915,7 +2915,7 @@ spec:
     requests:
       cpu: "4"
       memory: 8Gi
-  retention: "10d"
+  retention: "3d"
   tsdb:
     outOfOrderTimeWindow: 0s
   walCompression: true

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3224,7 +3224,7 @@ spec:
     requests:
       cpu: "4"
       memory: 8Gi
-  retention: "10d"
+  retention: "3d"
   tsdb:
     outOfOrderTimeWindow: 0s
   walCompression: true

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -2988,7 +2988,7 @@ spec:
     requests:
       cpu: "4"
       memory: 8Gi
-  retention: "10d"
+  retention: "3d"
   tsdb:
     outOfOrderTimeWindow: 0s
   walCompression: true


### PR DESCRIPTION
* [x] Set the default prometheus retention to 3 days.