### PR TITLE
Image Builder support.

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,7 +4,7 @@ description: Deploys the Union dataplane components to onboard a kubernetes clus
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
 version: 2025.4.2
-appVersion: 2025.4.0
+appVersion: 2025.5.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -903,3 +903,49 @@ Name of the serving-envoy-bootstrap ConfigMap
 {{- define "serving.envoyBootstrapConfigMapName" -}}
 {{- include "serving.fullname" . }}-envoy-bootstrap
 {{- end }}
+
+# Image Builder helpers
+
+{{/*
+The name of the buildkit deployment, service, etc
+*/}}
+{{- define "imagebuilder.buildkit.fullname" -}}
+{{- if .Values.imageBuilder.buildkit.fullnameOverride }}
+{{- .Values.imageBuilder.buildkit.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" (include "union-operator.fullname" .) "buildkit" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "imagebuilder.buildkit.selectorLabels" -}}
+app.kubernetes.io/name: imagebuilder-buildkit
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "imagebuilder.buildkit.labels" -}}
+{{ include "imagebuilder.buildkit.selectorLabels" . }}
+platform.union.ai/service-group: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Check if both imageBuilder and imageBuilder.buildkit are enabled
+*/}}
+{{- define "imagebuilder.buildkit.enabled" -}}
+{{- if and .Values.imageBuilder.enabled .Values.imageBuilder.buildkit.enabled }}
+{{- true }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- end }}
+
+{{/*
+The URI to connect to buildkit
+*/}}
+{{- define "imagebuilder.buildkit.uri" -}}
+{{- if .Values.imageBuilder.buildkitUri -}}
+{{- .Values.imageBuilder.buildkitUri | quote -}}
+{{- else -}}
+tcp://{{ include "imagebuilder.buildkit.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.imageBuilder.buildkit.service.port }}
+{{- end -}}
+{{- end -}}

--- a/charts/dataplane/templates/imagebuilder/configmap.yaml
+++ b/charts/dataplane/templates/imagebuilder/configmap.yaml
@@ -1,0 +1,40 @@
+{{- if (include "imagebuilder.buildkit.enabled" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name : {{ include "imagebuilder.buildkit.fullname" . }}
+data:
+  buildkitd.toml: |
+    debug = {{ .Values.imageBuilder.buildkit.log.debug }}
+
+    [log]
+      format = "{{ .Values.imageBuilder.buildkit.log.format }}"
+
+    [worker.oci]
+      enabled = true
+      snapshotter = "auto"
+      gc = true
+      max-parallelism = {{ .Values.imageBuilder.buildkit.oci.maxParallelism }}
+
+      # Should not be used if Policies are defined
+      gckeepstorage = "10%"
+      [[worker.oci.gcpolicy]]
+        # Remove COPY/ADD and git checkout files
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "type==source.local", "type==source.git.checkout" ]
+      [[worker.oci.gcpolicy]]
+        # Remove locally cached image layers after it's unused for 24 hours
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "regular" ]
+      [[worker.oci.gcpolicy]]
+        # Remove shared cache mounts. E.G. Pip cache
+        keepBytes = "10%"
+        keepDuration = "72h"
+        filters = [ "type==exec.cachemount" ]
+      [[worker.oci.gcpolicy]]
+        # Remove everything else to keep the cache size under total file system limit
+        all = true
+        keepBytes = "80%"
+{{- end }}

--- a/charts/dataplane/templates/imagebuilder/deployment.yaml
+++ b/charts/dataplane/templates/imagebuilder/deployment.yaml
@@ -1,0 +1,116 @@
+{{- if (include "imagebuilder.buildkit.enabled" .) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "imagebuilder.buildkit.fullname" . }}
+  labels:
+    {{- include "imagebuilder.buildkit.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: {{ .Values.imageBuilder.buildkit.deploymentStrategy }}
+  {{- if not .Values.imageBuilder.buildkit.autoscaling.enabled }}
+  replicas: {{ .Values.imageBuilder.buildkit.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "imagebuilder.buildkit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.imageBuilder.buildkit.rootless .Values.imageBuilder.buildkit.podAnnotations }}
+      annotations:
+        {{- if .Values.imageBuilder.buildkit.rootless }}
+        container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
+        {{- end }}
+        {{- with .Values.imageBuilder.buildkit.podAnnotations -}}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "imagebuilder.buildkit.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "buildkit"
+          image: "{{ .Values.imageBuilder.buildkit.image.repository }}:{{ .Values.imageBuilder.buildkit.image.tag }}"
+          imagePullPolicy: {{ .Values.imageBuilder.buildkit.image.pullPolicy }}
+          {{- if or .Values.imageBuilder.buildkit.rootless }}
+          volumeMounts:
+          {{- if .Values.imageBuilder.buildkit.rootless }}
+            - mountPath: /home/user/.local/share/buildkit
+              name: buildkitd
+          {{- end }}
+          {{- end }}
+            - mountPath: /etc/buildkit
+              name: buildkit-config
+          {{- with .Values.imageBuilder.buildkit.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - --config
+            - /etc/buildkit/buildkitd.toml
+            - --addr
+            - unix:///run/{{ .Values.imageBuilder.buildkit.rootless | ternary "user/1000" ""}}/buildkit/buildkitd.sock
+            - --addr
+            - tcp://0.0.0.0:1234
+          {{- if .Values.imageBuilder.buildkit.rootless }}
+            - --oci-worker-no-process-sandbox
+          {{- end }}
+          ports:
+            - name: tcp
+              containerPort: 1234
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+          {{- if .Values.imageBuilder.buildkit.rootless }}
+            seccompProfile: # Needs Kubernetes >= 1.19
+              type: Unconfined
+            runAsUser: 1000
+            runAsGroup: 1000
+          {{- else }}
+            privileged: true
+          {{- end }}
+          resources:
+            {{- toYaml .Values.imageBuilder.buildkit.resources | nindent 12 }}
+      {{- if .Values.imageBuilder.buildkit.rootless }}
+      volumes:
+      {{- if .Values.imageBuilder.buildkit.rootless }}
+      - name: buildkitd
+        emptyDir: {}
+      {{- end }}
+      {{- end }}
+      - configMap:
+          name: {{ include "imagebuilder.buildkit.fullname" . }}
+        name: buildkit-config
+      {{- with .Values.imageBuilder.buildkit.additionalVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.imageBuilder.buildkit.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                {{- include "imagebuilder.buildkit.selectorLabels" . | nindent 16 }}
+            topologyKey: "kubernetes.io/hostname"
+      {{- with .Values.imageBuilder.buildkit.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/dataplane/templates/imagebuilder/hpa.yaml
+++ b/charts/dataplane/templates/imagebuilder/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (include "imagebuilder.buildkit.enabled" .) .Values.imageBuilder.buildkit.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "imagebuilder.buildkit.fullname" . }}
+  labels:
+    {{- include "imagebuilder.buildkit.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "imagebuilder.buildkit.fullname" . }}
+  minReplicas: {{ .Values.imageBuilder.buildkit.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.imageBuilder.buildkit.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.imageBuilder.buildkit.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.imageBuilder.buildkit.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.imageBuilder.buildkit.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.imageBuilder.buildkit.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/dataplane/templates/imagebuilder/pdb.yaml
+++ b/charts/dataplane/templates/imagebuilder/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and (include "imagebuilder.buildkit.enabled" .) (gt (.Values.imageBuilder.buildkit.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "imagebuilder.buildkit.labels" . | nindent 4 }}
+  name: {{ include "imagebuilder.buildkit.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "imagebuilder.buildkit.selectorLabels" . | nindent 6 }}
+  minAvailable: {{ .Values.imageBuilder.buildkit.pdb.minAvailable }}
+{{- end }}

--- a/charts/dataplane/templates/imagebuilder/service.yaml
+++ b/charts/dataplane/templates/imagebuilder/service.yaml
@@ -1,0 +1,24 @@
+{{- if (include "imagebuilder.buildkit.enabled" .) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "imagebuilder.buildkit.fullname" . }}
+  labels:
+    {{- include "imagebuilder.buildkit.labels" . | nindent 4 }}
+  {{- with .Values.imageBuilder.buildkit.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.imageBuilder.buildkit.service.type }}
+  {{- if .Values.imageBuilder.buildkit.service.loadbalancerIp }}
+  loadBalancerIP: {{ .Values.imageBuilder.buildkit.service.loadbalancerIp | quote }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.imageBuilder.buildkit.service.port }}
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    {{- include "imagebuilder.buildkit.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -47,6 +47,14 @@ data:
     {{- with .Values.config.operator.org }}
       org: {{ tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
+    {{- if .Values.imageBuilder.enabled }}
+      imageBuilder:
+        enabled: {{ .Values.imageBuilder.enabled }}
+        executionNamespaceLabels:
+          union.ai/namespace-type: flyte
+        referenceConfigmapName: {{ include "union-operator.fullname" . }}
+        targetConfigMapName: {{ .Values.imageBuilder.targetConfigMapName | quote }}
+    {{- end }}
   {{- with .Values.config.proxy }}
     proxy: {{ tpl (toYaml .) $ | nindent 6 }}
   {{- end }}
@@ -60,4 +68,9 @@ data:
   storage.yaml: | {{ tpl (include "storage" .) $ | nindent 4 }}
 {{- if .Values.storage.fastRegistrationBucketName }}
   fast_registration_storage.yaml: | {{ tpl (include "fast-registration-storage" .) $ | nindent 4 }}
+{{- end }}
+{{- if .Values.imageBuilder.enabled }}
+  image-builder.buildkit-uri: {{ (include "imagebuilder.buildkit.uri" .) | quote }}
+  image-builder.default-repository: {{ .Values.imageBuilder.defaultRepository | quote }}
+  image-builder.authentication-type: {{ .Values.imageBuilder.authenticationType | quote }}
 {{- end }}

--- a/charts/dataplane/templates/operator/serviceaccount.yaml
+++ b/charts/dataplane/templates/operator/serviceaccount.yaml
@@ -74,6 +74,8 @@ rules:
       - pods
       - configmaps
       - podtemplates
+      - secrets
+      - namespaces
       - nodes
     verbs:
       - get

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -279,6 +279,8 @@ config:
         type: "{{ .Values.proxy.secretManager.type }}"
         k8sConfig:
           namespace: '{{ include "proxy.secretsNamespace" . }}'
+        imagePullSecrets:
+          enabled: true
   # -- Domains configuration for Union projects. This enables the specified number of domains across all projects in Union.
   domain:
     domains:
@@ -382,6 +384,9 @@ config:
       objectStore:
         prefix: persisted-logs
         pathTemplate: "namespace-{{`{{.KubernetesNamespace}}`}}.pod-{{`{{.KubernetesPodName}}`}}.cont-{{`{{.KubernetesContainerName}}`}}"
+    imageBuilderConfig:
+      authenticationType: "{{ .Values.imageBuilder.authenticationType }}"
+      defaultRepository: "{{ .Values.imageBuilder.defaultRepository }}"
   # -- Resource manager configuration
   resource_manager:
     # -- resource manager configuration
@@ -1009,5 +1014,114 @@ serving:
 # Enable the knative operator.  Required for app serving.
 knative-operator:
   enabled: false
+
   crds:
     install: true
+
+imageBuilder:
+  enabled: false
+
+  # -- The config map build-image container task attempts to reference.
+  # -- Should not change unless coordinated with Union technical support.
+  targetConfigMapName: "build-image-config"
+
+  # -- The URI of the buildkitd service. Used for externally managed buildkitd services.
+  # -- Leaving empty and setting imageBuilder.buildkit.enabled to true will create a buildkitd service.
+  # -- E.g. "tcp://buildkitd.buildkit.svc.cluster.local:1234"
+  buildkitUri: ""
+
+  # -- The default repository to publish images to "registry" is not specified with imagespec.
+  # -- Note, the build-image task will fail unless "registry" is specified or a default repository is provided.
+  defaultRepository: ""
+
+  # -- How build-image task and operator proxy will attempt to authenticate
+  # -- Supported values are "noop", "google", "aws", "azure"
+  # -- "noop" no authentication is attempted
+  # -- "google" uses docker-credential-gcr to authenticate to the default registry
+  # -- "aws" uses docker-credential-ecr-login to authenticate to the default registry
+  # -- "azure" uses az acr login to authenticate to the default registry. Requires Azure Workload Identity to be enabled.
+  authenticationType: "noop"
+
+  buildkit:
+
+    # -- Enable buildkit service within this release.
+    enabled: true
+
+    # -- The name to use for the buildkit deployment, service, configmap, etc.
+    fullnameOverride: ""
+
+    # -- deployment strategy for buildkit deployment
+    deploymentStrategy: Recreate
+
+    # -- Replicas count for Buildkit deployment
+    replicaCount: 1
+
+    # -- buildkit HPA configuration
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 2
+
+      # -- Buildkit aggressively accepts build requests (maybe missing config somewhere)
+      # -- Meaning it will create runc containers correspondingly.
+      # -- max-parallelism limits the number of exec operations (E.G. RUN pip install)
+      # -- However, large burst of requests can leave to significant builds waiting in queue
+      # -- Put CPU utilization a little lower to promote faster scale out and reduce queue times for future requests
+      # -- We can adjust this as needed.
+      targetCPUUtilizationPercentage: 60
+
+    image:
+      # -- Image name
+      repository: moby/buildkit
+      # -- Pull policy
+      pullPolicy: IfNotPresent
+      # -- Image tag
+      tag: "buildx-stable-1-rootless"
+
+    # -- Run rootless mode, https://github.com/moby/buildkit/blob/master/docs/rootless.md
+    rootless: true
+
+    # -- Enable debug logging
+    log:
+      debug: false
+      format: text
+
+    # -- Buildkitd service configuration
+    oci:
+      # -- maxParalelism limits the number of concurrent builds, default is 0 (unbounded)
+      maxParallelism: 0
+
+    pdb:
+      # -- Minimum available pods
+      minAvailable: 1
+
+    # -- Pod annotations
+    podAnnotations: {}
+
+    service:
+      # -- Service type
+      type: ClusterIP
+      # -- Service port
+      port: 1234
+      # -- Static ip address for load balancer
+      loadbalancerIp: ""
+      # -- Service annotations
+      annotations: {}
+
+    # -- Resource definitions
+    resources:
+      requests:
+        cpu: 2
+        memory: 4Gi
+
+    # -- Node selector
+    nodeSelector: {}
+
+    # -- Tolerations
+    tolerations: []
+
+    # -- Additional volumes to add to the pod
+    additionalVolumes: []
+
+    # -- Additional volume mounts to add to the buildkit container
+    additionalVolumeMounts: []

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2382,7 +2382,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -2547,7 +2547,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2615,7 +2615,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -2674,7 +2674,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2781,7 +2781,7 @@ spec:
       serviceAccountName: flytepropeller-webhook-system
       initContainers:
         - name: generate-secrets
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -2831,7 +2831,7 @@ spec:
               mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -2968,7 +2968,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: flytepropeller
           ports:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -378,6 +378,46 @@ data:
         region us-east-2
         bucket bucket
 ---
+# Source: dataplane/templates/imagebuilder/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name : union-operator-buildkit
+data:
+  buildkitd.toml: |
+    debug = false
+
+    [log]
+      format = "text"
+
+    [worker.oci]
+      enabled = true
+      snapshotter = "auto"
+      gc = true
+      max-parallelism = 0
+
+      # Should not be used if Policies are defined
+      gckeepstorage = "10%"
+      [[worker.oci.gcpolicy]]
+        # Remove COPY/ADD and git checkout files
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "type==source.local", "type==source.git.checkout" ]
+      [[worker.oci.gcpolicy]]
+        # Remove locally cached image layers after it's unused for 24 hours
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "regular" ]
+      [[worker.oci.gcpolicy]]
+        # Remove shared cache mounts. E.G. Pip cache
+        keepBytes = "10%"
+        keepDuration = "72h"
+        filters = [ "type==exec.cachemount" ]
+      [[worker.oci.gcpolicy]]
+        # Remove everything else to keep the cache size under total file system limit
+        all = true
+        keepBytes = "80%"
+---
 # Source: dataplane/templates/operator/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -441,6 +481,9 @@ data:
         proxy:
           endpoint: 'http://union-operator-proxy:10254'
     proxy: 
+      imageBuilderConfig:
+        authenticationType: 'noop'
+        defaultRepository: ''
       persistedLogs:
         objectStore:
           pathTemplate: namespace-{{.KubernetesNamespace}}.pod-{{.KubernetesPodName}}.cont-{{.KubernetesContainerName}}
@@ -550,6 +593,8 @@ data:
     webhook:
       certDir: /etc/webhook/certs
       embeddedSecretManagerConfig:
+        imagePullSecrets:
+          enabled: true
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
@@ -1106,6 +1151,8 @@ rules:
       - pods
       - configmaps
       - podtemplates
+      - secrets
+      - namespaces
       - nodes
     verbs:
       - get
@@ -1776,6 +1823,27 @@ spec:
   sessionAffinity: None
   type: "ClusterIP"
 ---
+# Source: dataplane/templates/imagebuilder/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1234
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+---
 # Source: dataplane/templates/operator/service-proxy.yaml
 apiVersion: v1
 kind: Service
@@ -2345,6 +2413,93 @@ spec:
           secret:
             secretName: union-secret-auth
 ---
+# Source: dataplane/templates/imagebuilder/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: imagebuilder-buildkit
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
+      labels:
+        app.kubernetes.io/name: imagebuilder-buildkit
+        app.kubernetes.io/instance: release-name
+    spec:
+      containers:
+        - name: "buildkit"
+          image: "moby/buildkit:buildx-stable-1-rootless"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /home/user/.local/share/buildkit
+              name: buildkitd
+            - mountPath: /etc/buildkit
+              name: buildkit-config
+          args:
+            - --config
+            - /etc/buildkit/buildkitd.toml
+            - --addr
+            - unix:///run/user/1000/buildkit/buildkitd.sock
+            - --addr
+            - tcp://0.0.0.0:1234
+            - --oci-worker-no-process-sandbox
+          ports:
+            - name: tcp
+              containerPort: 1234
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            seccompProfile: # Needs Kubernetes >= 1.19
+              type: Unconfined
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            requests:
+              cpu: 2
+              memory: 4Gi
+      volumes:
+      - name: buildkitd
+        emptyDir: {}
+      - configMap:
+          name: union-operator-buildkit
+        name: buildkit-config
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: imagebuilder-buildkit
+                app.kubernetes.io/instance: release-name
+            topologyKey: "kubernetes.io/hostname"
+---
 # Source: dataplane/templates/operator/deployment-proxy.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -2365,7 +2520,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "692fbb6cc07d7c046914eb4d5fe952090a9713ac90b6ff58ed9e87a2222be2d"
+        configChecksum: "8455a1105a76f5624c134cd411fab08424f0e04c62ba74913722622b85fd798"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2495,7 +2650,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "692fbb6cc07d7c046914eb4d5fe952090a9713ac90b6ff58ed9e87a2222be2d"
+        configChecksum: "8455a1105a76f5624c134cd411fab08424f0e04c62ba74913722622b85fd798"
         
       labels:
         
@@ -2613,7 +2768,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "51505b64155b11d5db295c95640221b086a805b04cb84b333c125e52ecd508c"
+        configChecksum: "903e065d47546547aa284e4c3bee31566735ee2c27c418b3a48dacc92434b34"
         
     spec:
       securityContext: 
@@ -2763,7 +2918,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "51505b64155b11d5db295c95640221b086a805b04cb84b333c125e52ecd508c"
+        configChecksum: "903e065d47546547aa284e4c3bee31566735ee2c27c418b3a48dacc92434b34"
         
       labels:
         

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -472,6 +472,46 @@ data:
         json_date_key false
         region us-east-1
 ---
+# Source: dataplane/templates/imagebuilder/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name : union-operator-buildkit
+data:
+  buildkitd.toml: |
+    debug = false
+
+    [log]
+      format = "text"
+
+    [worker.oci]
+      enabled = true
+      snapshotter = "auto"
+      gc = true
+      max-parallelism = 0
+
+      # Should not be used if Policies are defined
+      gckeepstorage = "10%"
+      [[worker.oci.gcpolicy]]
+        # Remove COPY/ADD and git checkout files
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "type==source.local", "type==source.git.checkout" ]
+      [[worker.oci.gcpolicy]]
+        # Remove locally cached image layers after it's unused for 24 hours
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "regular" ]
+      [[worker.oci.gcpolicy]]
+        # Remove shared cache mounts. E.G. Pip cache
+        keepBytes = "10%"
+        keepDuration = "72h"
+        filters = [ "type==exec.cachemount" ]
+      [[worker.oci.gcpolicy]]
+        # Remove everything else to keep the cache size under total file system limit
+        all = true
+        keepBytes = "80%"
+---
 # Source: dataplane/templates/operator/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -535,6 +575,9 @@ data:
         proxy:
           endpoint: 'http://union-operator-proxy:10254'
     proxy: 
+      imageBuilderConfig:
+        authenticationType: 'noop'
+        defaultRepository: ''
       persistedLogs:
         objectStore:
           pathTemplate: namespace-{{.KubernetesNamespace}}.pod-{{.KubernetesPodName}}.cont-{{.KubernetesContainerName}}
@@ -643,6 +686,8 @@ data:
     webhook:
       certDir: /etc/webhook/certs
       embeddedSecretManagerConfig:
+        imagePullSecrets:
+          enabled: true
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
@@ -1205,6 +1250,8 @@ rules:
       - pods
       - configmaps
       - podtemplates
+      - secrets
+      - namespaces
       - nodes
     verbs:
       - get
@@ -1954,6 +2001,27 @@ spec:
   sessionAffinity: None
   type: "ClusterIP"
 ---
+# Source: dataplane/templates/imagebuilder/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1234
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+---
 # Source: dataplane/templates/operator/service-proxy.yaml
 apiVersion: v1
 kind: Service
@@ -2626,6 +2694,93 @@ spec:
           secret:
             secretName: union-secret-auth
 ---
+# Source: dataplane/templates/imagebuilder/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: imagebuilder-buildkit
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
+      labels:
+        app.kubernetes.io/name: imagebuilder-buildkit
+        app.kubernetes.io/instance: release-name
+    spec:
+      containers:
+        - name: "buildkit"
+          image: "moby/buildkit:buildx-stable-1-rootless"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /home/user/.local/share/buildkit
+              name: buildkitd
+            - mountPath: /etc/buildkit
+              name: buildkit-config
+          args:
+            - --config
+            - /etc/buildkit/buildkitd.toml
+            - --addr
+            - unix:///run/user/1000/buildkit/buildkitd.sock
+            - --addr
+            - tcp://0.0.0.0:1234
+            - --oci-worker-no-process-sandbox
+          ports:
+            - name: tcp
+              containerPort: 1234
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            seccompProfile: # Needs Kubernetes >= 1.19
+              type: Unconfined
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            requests:
+              cpu: 2
+              memory: 4Gi
+      volumes:
+      - name: buildkitd
+        emptyDir: {}
+      - configMap:
+          name: union-operator-buildkit
+        name: buildkit-config
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: imagebuilder-buildkit
+                app.kubernetes.io/instance: release-name
+            topologyKey: "kubernetes.io/hostname"
+---
 # Source: dataplane/templates/operator/deployment-proxy.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -2646,7 +2801,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af36100bf7c87ea29fcaa927f6cfc00a57a8ce51ab7816966944cfb7068367e"
+        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2776,7 +2931,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af36100bf7c87ea29fcaa927f6cfc00a57a8ce51ab7816966944cfb7068367e"
+        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
         
       labels:
         
@@ -2894,7 +3049,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "48ab995b748e422b11d7ab822b9288eacaf62f7045eb5e3e97a6193beef4bd8"
+        configChecksum: "1329c46097add5bb5d6c83519fb82841ccfa453ee322ac8f787208058f1b0e9"
         
     spec:
       securityContext: 
@@ -3044,7 +3199,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "48ab995b748e422b11d7ab822b9288eacaf62f7045eb5e3e97a6193beef4bd8"
+        configChecksum: "1329c46097add5bb5d6c83519fb82841ccfa453ee322ac8f787208058f1b0e9"
         
       labels:
         

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -2663,7 +2663,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -2828,7 +2828,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2896,7 +2896,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -2955,7 +2955,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -3062,7 +3062,7 @@ spec:
       serviceAccountName: flytepropeller-webhook-system
       initContainers:
         - name: generate-secrets
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -3112,7 +3112,7 @@ spec:
               mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -3247,7 +3247,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: flytepropeller
           ports:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -364,6 +364,46 @@ data:
         json_date_key false
         region us-east-1
 ---
+# Source: dataplane/templates/imagebuilder/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name : union-operator-buildkit
+data:
+  buildkitd.toml: |
+    debug = false
+
+    [log]
+      format = "text"
+
+    [worker.oci]
+      enabled = true
+      snapshotter = "auto"
+      gc = true
+      max-parallelism = 0
+
+      # Should not be used if Policies are defined
+      gckeepstorage = "10%"
+      [[worker.oci.gcpolicy]]
+        # Remove COPY/ADD and git checkout files
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "type==source.local", "type==source.git.checkout" ]
+      [[worker.oci.gcpolicy]]
+        # Remove locally cached image layers after it's unused for 24 hours
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "regular" ]
+      [[worker.oci.gcpolicy]]
+        # Remove shared cache mounts. E.G. Pip cache
+        keepBytes = "10%"
+        keepDuration = "72h"
+        filters = [ "type==exec.cachemount" ]
+      [[worker.oci.gcpolicy]]
+        # Remove everything else to keep the cache size under total file system limit
+        all = true
+        keepBytes = "80%"
+---
 # Source: dataplane/templates/nodeobserver/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -437,6 +477,9 @@ data:
         proxy:
           endpoint: 'http://union-operator-proxy:10254'
     proxy: 
+      imageBuilderConfig:
+        authenticationType: 'noop'
+        defaultRepository: ''
       persistedLogs:
         objectStore:
           pathTemplate: namespace-{{.KubernetesNamespace}}.pod-{{.KubernetesPodName}}.cont-{{.KubernetesContainerName}}
@@ -545,6 +588,8 @@ data:
     webhook:
       certDir: /etc/webhook/certs
       embeddedSecretManagerConfig:
+        imagePullSecrets:
+          enabled: true
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
@@ -1120,6 +1165,8 @@ rules:
       - pods
       - configmaps
       - podtemplates
+      - secrets
+      - namespaces
       - nodes
     verbs:
       - get
@@ -1804,6 +1851,27 @@ spec:
   sessionAffinity: None
   type: "ClusterIP"
 ---
+# Source: dataplane/templates/imagebuilder/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1234
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+---
 # Source: dataplane/templates/operator/service-proxy.yaml
 apiVersion: v1
 kind: Service
@@ -2024,7 +2092,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2443,7 +2511,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -2474,6 +2542,93 @@ spec:
           secret:
             secretName: union-secret-auth
 ---
+# Source: dataplane/templates/imagebuilder/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: imagebuilder-buildkit
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
+      labels:
+        app.kubernetes.io/name: imagebuilder-buildkit
+        app.kubernetes.io/instance: release-name
+    spec:
+      containers:
+        - name: "buildkit"
+          image: "moby/buildkit:buildx-stable-1-rootless"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /home/user/.local/share/buildkit
+              name: buildkitd
+            - mountPath: /etc/buildkit
+              name: buildkit-config
+          args:
+            - --config
+            - /etc/buildkit/buildkitd.toml
+            - --addr
+            - unix:///run/user/1000/buildkit/buildkitd.sock
+            - --addr
+            - tcp://0.0.0.0:1234
+            - --oci-worker-no-process-sandbox
+          ports:
+            - name: tcp
+              containerPort: 1234
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            seccompProfile: # Needs Kubernetes >= 1.19
+              type: Unconfined
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            requests:
+              cpu: 2
+              memory: 4Gi
+      volumes:
+      - name: buildkitd
+        emptyDir: {}
+      - configMap:
+          name: union-operator-buildkit
+        name: buildkit-config
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: imagebuilder-buildkit
+                app.kubernetes.io/instance: release-name
+            topologyKey: "kubernetes.io/hostname"
+---
 # Source: dataplane/templates/operator/deployment-proxy.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -2494,7 +2649,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af36100bf7c87ea29fcaa927f6cfc00a57a8ce51ab7816966944cfb7068367e"
+        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2521,7 +2676,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2589,7 +2744,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -2624,7 +2779,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af36100bf7c87ea29fcaa927f6cfc00a57a8ce51ab7816966944cfb7068367e"
+        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
         
       labels:
         
@@ -2648,7 +2803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2742,7 +2897,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "48ab995b748e422b11d7ab822b9288eacaf62f7045eb5e3e97a6193beef4bd8"
+        configChecksum: "1329c46097add5bb5d6c83519fb82841ccfa453ee322ac8f787208058f1b0e9"
         
     spec:
       securityContext: 
@@ -2755,7 +2910,7 @@ spec:
       serviceAccountName: flytepropeller-webhook-system
       initContainers:
         - name: generate-secrets
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -2805,7 +2960,7 @@ spec:
               mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -2892,7 +3047,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "48ab995b748e422b11d7ab822b9288eacaf62f7045eb5e3e97a6193beef4bd8"
+        configChecksum: "1329c46097add5bb5d6c83519fb82841ccfa453ee322ac8f787208058f1b0e9"
         
       labels:
         
@@ -2940,7 +3095,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: flytepropeller
           ports:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -2405,7 +2405,7 @@ spec:
             value: http://kourier-internal
           - name: AWS_REQUEST_CHECKSUM_CALCULATION
             value: when_required
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -2578,7 +2578,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2648,7 +2648,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -2715,7 +2715,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -2832,7 +2832,7 @@ spec:
       serviceAccountName: flytepropeller-webhook-system
       initContainers:
         - name: generate-secrets
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -2884,7 +2884,7 @@ spec:
               mountPath: /etc/flyte/config
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -3033,7 +3033,7 @@ spec:
             value: http://kourier-internal
           - name: AWS_REQUEST_CHECKSUM_CALCULATION
             value: when_required
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.4.0"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2025.5.0"
           imagePullPolicy: "IfNotPresent"
           name: flytepropeller
           ports:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -371,6 +371,46 @@ data:
         bucket bucket
         endpoint https://xxxxxxxxxxx.compat.objectstorage.us-ashburn-1.oraclecloud.com
 ---
+# Source: dataplane/templates/imagebuilder/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name : union-operator-buildkit
+data:
+  buildkitd.toml: |
+    debug = false
+
+    [log]
+      format = "text"
+
+    [worker.oci]
+      enabled = true
+      snapshotter = "auto"
+      gc = true
+      max-parallelism = 0
+
+      # Should not be used if Policies are defined
+      gckeepstorage = "10%"
+      [[worker.oci.gcpolicy]]
+        # Remove COPY/ADD and git checkout files
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "type==source.local", "type==source.git.checkout" ]
+      [[worker.oci.gcpolicy]]
+        # Remove locally cached image layers after it's unused for 24 hours
+        keepBytes = "10%"
+        keepDuration = "24h"
+        filters = [ "regular" ]
+      [[worker.oci.gcpolicy]]
+        # Remove shared cache mounts. E.G. Pip cache
+        keepBytes = "10%"
+        keepDuration = "72h"
+        filters = [ "type==exec.cachemount" ]
+      [[worker.oci.gcpolicy]]
+        # Remove everything else to keep the cache size under total file system limit
+        all = true
+        keepBytes = "80%"
+---
 # Source: dataplane/templates/operator/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -439,6 +479,9 @@ data:
         proxy:
           endpoint: 'http://union-operator-proxy:10254'
     proxy: 
+      imageBuilderConfig:
+        authenticationType: 'noop'
+        defaultRepository: ''
       persistedLogs:
         objectStore:
           pathTemplate: namespace-{{.KubernetesNamespace}}.pod-{{.KubernetesPodName}}.cont-{{.KubernetesContainerName}}
@@ -560,6 +603,8 @@ data:
     webhook:
       certDir: /etc/webhook/certs
       embeddedSecretManagerConfig:
+        imagePullSecrets:
+          enabled: true
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
@@ -1127,6 +1172,8 @@ rules:
       - pods
       - configmaps
       - podtemplates
+      - secrets
+      - namespaces
       - nodes
     verbs:
       - get
@@ -1797,6 +1844,27 @@ spec:
   sessionAffinity: None
   type: "ClusterIP"
 ---
+# Source: dataplane/templates/imagebuilder/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1234
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+---
 # Source: dataplane/templates/operator/service-proxy.yaml
 apiVersion: v1
 kind: Service
@@ -2376,6 +2444,93 @@ spec:
           operator: Equal
           value: worker
 ---
+# Source: dataplane/templates/imagebuilder/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: union-operator-buildkit
+  labels:
+    app.kubernetes.io/name: imagebuilder-buildkit
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: imagebuilder-buildkit
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
+      labels:
+        app.kubernetes.io/name: imagebuilder-buildkit
+        app.kubernetes.io/instance: release-name
+    spec:
+      containers:
+        - name: "buildkit"
+          image: "moby/buildkit:buildx-stable-1-rootless"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /home/user/.local/share/buildkit
+              name: buildkitd
+            - mountPath: /etc/buildkit
+              name: buildkit-config
+          args:
+            - --config
+            - /etc/buildkit/buildkitd.toml
+            - --addr
+            - unix:///run/user/1000/buildkit/buildkitd.sock
+            - --addr
+            - tcp://0.0.0.0:1234
+            - --oci-worker-no-process-sandbox
+          ports:
+            - name: tcp
+              containerPort: 1234
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command:
+              - buildctl
+              - debug
+              - workers
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            seccompProfile: # Needs Kubernetes >= 1.19
+              type: Unconfined
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            requests:
+              cpu: 2
+              memory: 4Gi
+      volumes:
+      - name: buildkitd
+        emptyDir: {}
+      - configMap:
+          name: union-operator-buildkit
+        name: buildkit-config
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: imagebuilder-buildkit
+                app.kubernetes.io/instance: release-name
+            topologyKey: "kubernetes.io/hostname"
+---
 # Source: dataplane/templates/operator/deployment-proxy.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -2396,7 +2551,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aac7aa4b442526e8e3bfe049393daaa569e07737d180345c775db58ae135126"
+        configChecksum: "a849c598014eab30871b2cbadf4763068c5eb6cbdedf1388532920a6f4de37f"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2536,7 +2691,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aac7aa4b442526e8e3bfe049393daaa569e07737d180345c775db58ae135126"
+        configChecksum: "a849c598014eab30871b2cbadf4763068c5eb6cbdedf1388532920a6f4de37f"
         
       labels:
         
@@ -2664,7 +2819,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "7f9b28f1c9c0db7c1c1e3354d9a15d8d18f9590f7603caa6f72db090bc178af"
+        configChecksum: "10a8fcbf8e40b216e72f5b5502c5a9d8a611610647f29b8aa99fdd0c810422f"
         
     spec:
       securityContext: 
@@ -2826,7 +2981,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7f9b28f1c9c0db7c1c1e3354d9a15d8d18f9590f7603caa6f72db090bc178af"
+        configChecksum: "10a8fcbf8e40b216e72f5b5502c5a9d8a611610647f29b8aa99fdd0c810422f"
         
       labels:
         


### PR DESCRIPTION
Update the dataplane helm chart to support Image Builder.

Notable changes:
* Update values.yaml with appropriate configuration.
* Conditionally provision buildkit deployment.
* Update operator service account with additional permissions for
  namespaces and secrets.

Depends on https://github.com/unionai/cloud/pull/11588
