### PR TITLE
Union services control plane charts

### DIFF
--- a/charts/controlplane/.helmignore
+++ b/charts/controlplane/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: controlplane
+description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud.
+type: application
+icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
+version: 2025.5.6
+appVersion: 2025.5.6
+kubeVersion: '>= 1.28.0-0'

--- a/charts/controlplane/templates/NOTES.txt
+++ b/charts/controlplane/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{/* Intentionally left blank */}}

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -1,0 +1,381 @@
+{{- define "unionai.imagePullSecrets" -}}
+{{- if and (hasKey .config "imagePullSecrets") }}
+{{ toYaml .config.imagePullSecrets }}
+{{- else if and (hasKey .Values.global "imagePullSecrets") }}
+{{ toYaml .Values.global.imagePullSecrets }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.resources" -}}
+{{- if and (hasKey .config "resources") }}
+{{ toYaml .config.resources }}
+{{- else if and (hasKey .Values.global "resources") }}
+{{ toYaml .Values.global.resources }}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.nodeSelector" -}}
+{{- if and (hasKey .config "nodeSelector") }}
+{{ toYaml .config.nodeSelector }}
+{{- else if and (hasKey .Values.global "nodeSelector") }}
+{{ toYaml .Values.global.nodeSelector }}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.service" -}}
+{{- if and (hasKey .config "service") }}
+{{ toYaml .config.service }}
+{{- else if and (hasKey .Values.global "service") }}
+{{ toYaml .Values.global.service }}
+{{- end }}
+{{- end }}
+
+
+{{- define "unionai.affinity" -}}
+{{- if and (hasKey .config "affinity") }}
+{{ toYaml .config.affinity }}
+{{- else if and (hasKey .Values.global "affinity") }}
+{{ toYaml .Values.global.affinity }}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.tolerations" -}}
+{{- if and (hasKey .config "tolerations") }}
+{{ toYaml .config.tolerations }}
+{{- else if and (hasKey .Values.global "tolerations") }}
+{{ toYaml .Values.global.tolerations }}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.env" -}}
+{{- if and (hasKey .config "env") -}}
+{{- toYaml .config.env -}}
+{{- else if and (hasKey .Values.global "env") }}
+{{- toYaml .Values.global.env -}}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.securityContext" -}}
+{{- if and (hasKey .config "securityContext") }}
+    {{- toYaml .config.securityContext -}}
+{{- else if and (hasKey .Values.global "securityContext") }}
+    {{- toYaml .Values.global.securityContext -}}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.podSecurityContext" -}}
+{{- if and (hasKey .config "podSecurityContext") .config.podSecurityContext }}
+    {{- toYaml .config.podSecurityContext }}
+{{- else if and (hasKey .Values.global "podSecurityContext") .Values.global.podSecurityContext }}
+    {{- toYaml .Values.global.podSecurityContext }}
+{{- end }}
+{{- end }}
+
+
+{{- define "unionai.serviceAccount.create" -}}
+{{- if and (hasKey .config "serviceAccount") (hasKey .config.serviceAccount "create") }}
+{{ .config.serviceAccount.create }}
+{{- else if and (hasKey .Values.global "serviceAccount") (hasKey .Values.global.serviceAccount "create") }}
+{{ .Values.global.serviceAccount.create }}
+{{- else }}
+false
+{{- end }}
+{{- end }}
+
+{{- define "unionai.serviceAccount.annotations" -}}
+{{- if and (hasKey .config "serviceAccount") (hasKey .config.serviceAccount "annotations") }}
+{{- toYaml .config.serviceAccount.annotations }}
+{{- else if and (hasKey .Values.global "serviceAccount") (hasKey .Values.global.serviceAccount "annotations") }}
+{{- toYaml .Values.global.serviceAccount.annotations }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.replicaCount" -}}
+{{- if and (hasKey .config "replicaCount") }}
+{{ .config.replicaCount }}
+{{- else if and (hasKey .Values.global "replicaCount") }}
+{{ .Values.global.replicaCount }}
+{{- else }}
+1
+{{- end }}
+{{- end }}
+
+{{- define "unionai.image.repository" -}}
+{{- if and (hasKey .config "image") (hasKey .config.image "repository") }}
+{{ .config.image.repository }}
+{{- else if and (hasKey .Values.global "image") (hasKey .Values.global.image "repository") }}
+{{ .Values.global.image.repository }}
+{{- else }}
+""
+{{- end }}
+{{- end }}
+
+{{- define "unionai.image.tag" -}}
+{{- if and (hasKey .config "image") (hasKey .config.image "tag") }}
+{{ .config.image.tag }}
+{{- else if and (hasKey .Values.global "image") (hasKey .Values.global.image "tag") }}
+{{ .Values.global.image.tag }}
+{{- else }}
+""
+{{- end }}
+{{- end }}
+
+{{- define "unionai.podAnnotations" -}}
+{{- if and (hasKey .config "podAnnotations") }}
+{{ toYaml .config.podAnnotations }}
+{{- else if and (hasKey .Values.global "podAnnotations") }}
+{{ toYaml .Values.global.podAnnotations }}
+{{- else }}
+null
+{{- end }}
+{{- end }}
+
+{{- define "unionai.podMonitor" -}}
+{{- if and (hasKey .config "podMonitor") }}
+{{ .config.podMonitor }}
+{{- else if and (hasKey .Values.global "podMonitor") }}
+{{ .Values.global.podMonitor }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.serviceProfile" -}}
+{{- if and (hasKey .config "serviceProfile") }}
+{{ .config.serviceProfile }}
+{{- else if and (hasKey .Values.global "serviceProfile") }}
+{{ .Values.global.serviceProfile }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.autoscaling" -}}
+{{- if and (hasKey .config "autoscaling") }}
+{{ toYaml .config.autoscaling }}
+{{- else if and (hasKey .Values.global "autoscaling") }}
+{{ toYaml .Values.global.autoscaling }}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.spreadConstraints" -}}
+{{- if and (hasKey .config "spreadConstraints") }}
+{{ .config.spreadConstraints }}
+{{- else if and (hasKey .Values.global "spreadConstraints") }}
+{{ .Values.global.spreadConstraints }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.probe" -}}
+{{- if and (hasKey .config "probe") }}
+{{ .config.probe }}
+{{- else if and (hasKey .Values.global "probe") }}
+{{ .Values.global.probe }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+
+{{- define "unionai.name" -}}
+{{- .key | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "unionai.fullname" -}}
+{{- if .config.fullnameOverride }}
+{{- .config.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $.Release.Name .name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "unionai.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "unionai.labels" -}}
+helm.sh/chart: {{ include "unionai.chart" . }}
+{{ include "unionai.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+{{- define "unionai.namespace" -}}
+{{- default .Release.Namespace .Values.forceNamespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "unionai.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unionai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "sync.fullname" -}}
+{{- default (printf "%s-sync" (include "unionai.name" .)) .Values.sync.fullnameOverride }}
+{{- end }}
+{{- define "sync.labels" -}}
+helm.sh/chart: {{ include "unionai.chart" . }}
+linkerd.io/inject: enabled
+{{ include "sync.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- define "sync.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unionai.name" . }}-sync
+app.kubernetes.io/instance: {{ .Release.Name }}-sync
+{{- end }}
+
+{{- define "executions.clean.fullname" -}}
+{{- default (printf "%s-clean" (include "unionai.name" .)) .Values.executions.clean.fullnameOverride }}
+{{- end }}
+{{- define "executions.clean.labels" -}}
+helm.sh/chart: {{ include "unionai.chart" . }}
+linkerd.io/inject: enabled
+{{ include "executions.clean.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- define "executions.clean.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unionai.name" . }}-clean
+app.kubernetes.io/instance: {{ .Release.Name }}-clean
+{{- end }}
+
+{{- define "unionai.image" -}}
+{{- $repo := "" }}
+{{- $tag := "" }}
+
+{{- if and (hasKey .config "image") (hasKey .config.image "repository") }}
+  {{- $repo = .config.image.repository }}
+{{- else if and (hasKey .Values.global "image") (hasKey .Values.global.image "repository") }}
+  {{- $repo = .Values.global.image.repository }}
+{{- end }}
+
+{{- if and (hasKey .config "image") (hasKey .config.image "tag") }}
+  {{- $tag = .config.image.tag }}
+{{- else if and (hasKey .Values.global "image") (hasKey .Values.global.image "tag") }}
+  {{- $tag = .Values.global.image.tag }}
+{{- else if hasKey .Chart "AppVersion" }}
+  {{- $tag = .Chart.AppVersion }}
+{{- end }}
+
+{{- if and $repo $tag }}
+{{ printf "%s:%s" $repo $tag }}
+{{- else if $repo }}
+{{ $repo }}
+{{- else }}
+""  # empty string to avoid template error
+{{- end }}
+{{- end }}
+
+{{- define "unionai.serviceAccountName" -}}
+{{- if eq (include "unionai.serviceAccount.create" . | trim) "true" }}
+  {{- if and (hasKey .config "serviceAccount") (hasKey .config.serviceAccount "name") }}
+{{ .config.serviceAccount.name }}
+  {{- else if and (hasKey .Values.global "serviceAccount") (hasKey .Values.global.serviceAccount "name") }}
+{{ .Values.global.serviceAccount.name }}
+  {{- else }}
+{{- include "unionai.fullname" . | trim -}}
+  {{- end }}
+{{- else }}
+default
+{{- end }}
+{{- end }}
+
+{{- define "unionai.sharedService" -}}
+{{- if and (hasKey .config "sharedService") }}
+{{ .config.sharedService }}
+{{- else if and (hasKey .Values.global "sharedService") }}
+{{ .Values.global.sharedService }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+{{- define "unionai.sync" -}}
+{{- if and (hasKey .config "sync") }}
+{{ .config.sync }}
+{{- else if and (hasKey .Values.global "sync") }}
+{{ .Values.global.sync }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}
+
+
+{{- define "unionai.imagePullPolicy" -}}
+{{- if and (hasKey .config "image") (hasKey .config.image "pullPolicy") }}
+{{ .config.image.pullPolicy }}
+{{- else if and (hasKey .Values.global "image") (hasKey .Values.global.image "pullPolicy") }}
+{{ .Values.global.image.pullPolicy }}
+{{- else }}
+IfNotPresent
+{{- end }}
+{{- end }}
+
+{{- define "unionai.strategy" -}}
+{{- if and (hasKey .config "strategy") .config.strategy }}
+{{ toYaml .config.strategy }}
+{{- else if and (hasKey .Values.global "strategy") .Values.global.strategy }}
+{{ toYaml .Values.global.strategy }}
+{{- end }}
+{{- end }}
+
+
+{{- define "unionai.deepMerge" -}}
+{{- $dest := deepCopy .dest -}}
+{{- $source := .source -}}
+
+{{- range $key, $value := $source }}
+  {{- if hasKey $dest $key }}
+    {{- if and (kindIs "map" (get $dest $key)) (kindIs "map" $value) }}
+      {{- $_ := set $dest $key (include "unionai.deepMerge" (dict "dest" (get $dest $key) "source" $value) | fromYaml) }}
+    {{- else }}
+      {{- $_ := set $dest $key $value }}
+    {{- end }}
+  {{- else }}
+    {{- $_ := set $dest $key $value }}
+  {{- end }}
+{{- end }}
+
+{{- toYaml $dest }}
+{{- end }}
+
+
+{{- define "unionai.configMap" -}}
+{{- $global := dict }}
+{{- $svc := dict }}
+
+{{- if hasKey .Values.global "configMap" }}
+  {{- $global = .Values.global.configMap }}
+{{- end }}
+
+{{- if hasKey .config "configMap" }}
+  {{- $svc = .config.configMap }}
+{{- end }}
+
+{{- include "unionai.deepMerge" (dict "dest" $global "source" $svc) }}
+{{- end }}
+
+

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -228,40 +228,6 @@ app.kubernetes.io/name: {{ include "unionai.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{- define "sync.fullname" -}}
-{{- default (printf "%s-sync" (include "unionai.name" .)) .Values.sync.fullnameOverride }}
-{{- end }}
-{{- define "sync.labels" -}}
-helm.sh/chart: {{ include "unionai.chart" . }}
-linkerd.io/inject: enabled
-{{ include "sync.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-{{- define "sync.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "unionai.name" . }}-sync
-app.kubernetes.io/instance: {{ .Release.Name }}-sync
-{{- end }}
-
-{{- define "executions.clean.fullname" -}}
-{{- default (printf "%s-clean" (include "unionai.name" .)) .Values.executions.clean.fullnameOverride }}
-{{- end }}
-{{- define "executions.clean.labels" -}}
-helm.sh/chart: {{ include "unionai.chart" . }}
-linkerd.io/inject: enabled
-{{ include "executions.clean.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-{{- define "executions.clean.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "unionai.name" . }}-clean
-app.kubernetes.io/instance: {{ .Release.Name }}-clean
-{{- end }}
-
 {{- define "unionai.image" -}}
 {{- $repo := "" }}
 {{- $tag := "" }}

--- a/charts/controlplane/templates/configmap.yaml
+++ b/charts/controlplane/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
+{{- if not $service.config.disabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "unionai.fullname" $service }}
+  labels:
+    {{- include "unionai.labels" $service | nindent 4 }}
+data:
+  config.yaml: |
+    {{- include "unionai.configMap" $service | nindent 4 }}
+---
+{{- end }}
+{{- end }}
+

--- a/charts/controlplane/templates/configmap.yaml
+++ b/charts/controlplane/templates/configmap.yaml
@@ -1,4 +1,6 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
+---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
 {{- if not $service.config.disabled }}
 apiVersion: v1
@@ -11,6 +13,7 @@ data:
   config.yaml: |
     {{- include "unionai.configMap" $service | nindent 4 }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/controlplane/templates/deployment.yaml
+++ b/charts/controlplane/templates/deployment.yaml
@@ -1,4 +1,6 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
+---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
 {{- if not $service.config.disabled }}
 apiVersion: apps/v1
@@ -165,5 +167,6 @@ spec:
       tolerations:
         {{- $tolerations | fromYaml | toYaml | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/controlplane/templates/deployment.yaml
+++ b/charts/controlplane/templates/deployment.yaml
@@ -18,6 +18,11 @@ spec:
   selector:
     matchLabels:
       {{- include "unionai.selectorLabels" $service | nindent 6 }}
+  {{- $strategy := include "unionai.strategy" $service }}
+  {{- if $strategy }}
+  strategy:
+  {{- $strategy | fromYaml | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -44,11 +49,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "unionai.serviceAccountName" $service }}
-      {{- $strategy := include "unionai.strategy" $service }}
-      {{- if $strategy }}
-      strategy:
-      {{- $strategy | fromYaml | toYaml | nindent 8 }}
-      {{- end }}
       {{- $podSecurityContext := include "unionai.podSecurityContext" $service }}
       {{- if $podSecurityContext }}
       securityContext:

--- a/charts/controlplane/templates/deployment.yaml
+++ b/charts/controlplane/templates/deployment.yaml
@@ -1,0 +1,169 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
+{{- if not $service.config.disabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "unionai.fullname" $service }}
+  labels:
+    {{- include "unionai.labels" $service | nindent 4 }}
+spec:
+  {{- $autoscaling := (include "unionai.autoscaling" $service | fromYaml) }}
+  {{- $replicaCount := include "unionai.replicaCount" $service | trim }}
+  {{- if and $autoscaling (not $autoscaling.enabled) (ne $replicaCount "") }}
+  replicas: {{ $replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "unionai.selectorLabels" $service | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: {{ include "unionai.name" $service }}
+        {{- $podAnnotations := include "unionai.podAnnotations" $service | fromYaml }}
+        {{- with $podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "unionai.selectorLabels" $service | nindent 8 }}
+    spec:
+      {{- $spreadConstraints := include "unionai.spreadConstraints" $service | fromYaml }}
+      {{- if $spreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "unionai.fullname" $service }}
+      {{- end }}
+      {{- with (include "unionai.imagePullSecrets" $service | fromYaml) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "unionai.serviceAccountName" $service }}
+      {{- $strategy := include "unionai.strategy" $service }}
+      {{- if $strategy }}
+      strategy:
+      {{- $strategy | fromYaml | toYaml | nindent 8 }}
+      {{- end }}
+      {{- $podSecurityContext := include "unionai.podSecurityContext" $service }}
+      {{- if $podSecurityContext }}
+      securityContext:
+        {{- $podSecurityContext | fromYaml | toYaml | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: secrets
+        secret:
+          secretName: {{ include "unionai.fullname" $service }}
+      - name: config
+        configMap:
+          name: {{ include "unionai.fullname" $service }}
+      {{- with $service.config.initContainers }}
+      initContainers:
+        {{- range . }}
+        - name: {{ include "unionai.name" $service }}-{{ .name }}
+          {{- $sec := include "unionai.securityContext" $service }}
+          {{- if $sec }}
+          securityContext:
+            {{- $sec | fromYaml | toYaml | nindent 12 }}
+          {{- end }}
+          image: {{ include "unionai.image" $service | trim }}
+          imagePullPolicy: {{ include "unionai.imagePullPolicy" $service | trim }}
+          args:
+            {{- toYaml .args | nindent 10 }}
+          volumeMounts:
+          - name: secrets
+            mountPath: /etc/secrets/
+          - name: config
+            mountPath: /etc/config/
+          {{- with .resources }}
+          resources:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ include "unionai.name" $service }}
+          {{- $sec := include "unionai.securityContext" $service }}
+          {{- if $sec }}
+          securityContext:
+            {{- $sec | fromYaml | toYaml | nindent 12 }}
+          {{- end }}
+          image: {{ include "unionai.image" $service | trim }}
+          imagePullPolicy: {{ include "unionai.imagePullPolicy" $service | trim }}
+          {{- with $service.config.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          {{- with (include "unionai.sharedService" $service | fromYaml) }}
+          {{- if .connectPort }}
+            - name: connect
+              containerPort: {{ .connectPort }}
+              protocol: TCP
+          {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          {{- $env := include "unionai.env" $service }}
+          {{- if $env }}
+          env:
+            {{- $env | nindent 12 }}
+          {{- end }}
+          {{- $res := include "unionai.resources" $service }}
+          {{- if $res }}
+          resources:
+            {{- $res | fromYaml | toYaml | nindent 14 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      {{- $node := include "unionai.nodeSelector" $service }}
+      {{- if $node }}
+      nodeSelector:
+        {{- $node | fromYaml | toYaml | nindent 8 }}
+      {{- end }}
+      {{- $aff := include "unionai.affinity" $service }}
+      {{- if $aff }}
+      affinity:
+        {{- $aff | fromYaml | toYaml | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "unionai.selectorLabels" $service | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
+      {{- end }}
+      {{- $tolerations := include "unionai.tolerations" $service }}
+      {{- if $tolerations }}
+      tolerations:
+        {{- $tolerations | fromYaml | toYaml | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/controlplane/templates/hpa.yaml
+++ b/charts/controlplane/templates/hpa.yaml
@@ -1,0 +1,35 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
+{{- $autoscaling := include "unionai.autoscaling" $service | fromYaml }}
+{{- if $autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "unionai.fullname" $service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "unionai.fullname" $service }}
+  minReplicas: {{ $autoscaling.minReplicas }}
+  maxReplicas: {{ $autoscaling.maxReplicas }}
+  metrics:
+    {{- if $autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/controlplane/templates/hpa.yaml
+++ b/charts/controlplane/templates/hpa.yaml
@@ -1,4 +1,6 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
+---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
 {{- $autoscaling := include "unionai.autoscaling" $service | fromYaml }}
 {{- if $autoscaling.enabled }}
@@ -30,6 +32,7 @@ spec:
           type: Utilization
           averageUtilization: {{ $autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/controlplane/templates/pdb.yaml
+++ b/charts/controlplane/templates/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
 ---
@@ -13,6 +14,7 @@ spec:
   selector:
     matchLabels:
       {{- include "unionai.selectorLabels" $service | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/controlplane/templates/pdb.yaml
+++ b/charts/controlplane/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
+---
+{{- if not $service.config.disabled }}
+{{- $replicaCount := include "unionai.replicaCount" $service | trim | int}}
+{{- if ge $replicaCount 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "unionai.fullname" $service }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "unionai.selectorLabels" $service | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/controlplane/templates/probe.yaml
+++ b/charts/controlplane/templates/probe.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- if .Values.global.probe.enabled }}
 kind: Probe
 apiVersion: monitoring.coreos.com/v1
@@ -18,3 +19,4 @@ spec:
       static:
       - {{ .Values.probe.url }}
 {{- end}}
+{{- end }}

--- a/charts/controlplane/templates/probe.yaml
+++ b/charts/controlplane/templates/probe.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.global.probe.enabled }}
+kind: Probe
+apiVersion: monitoring.coreos.com/v1
+metadata:
+  name: {{ include "unionai.fullname" . }}-probe-http
+  labels:
+    {{- include "unionai.labels" . | nindent 4 }}
+    instance: union
+spec:
+  interval: 60s
+  jobName: 'integrations/blackbox/service'
+  module: http_2xx
+  prober:
+    url: blackbox.kube-prometheus-stack.svc.cluster.local:9115
+    path: /probe
+  targets:
+    staticConfig:
+      static:
+      - {{ .Values.probe.url }}
+{{- end}}

--- a/charts/controlplane/templates/secret.yaml
+++ b/charts/controlplane/templates/secret.yaml
@@ -1,4 +1,6 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
+---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
 {{- if not $service.config.disabled }}
 apiVersion: v1
@@ -12,6 +14,7 @@ stringData:
   {{- with $service.config.secrets }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
-  {{- end }}   {{/* closes the `if not disabled` */}}
-{{- end }}     {{/* closes the `range` */}}
+  {{- end }}
+{{- end }}
+{{- end }}
 

--- a/charts/controlplane/templates/secret.yaml
+++ b/charts/controlplane/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
+{{- if not $service.config.disabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "unionai.fullname" $service }}
+  labels:
+    {{- include "unionai.labels" $service | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with $service.config.secrets }}
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}   {{/* closes the `if not disabled` */}}
+{{- end }}     {{/* closes the `range` */}}
+

--- a/charts/controlplane/templates/service.yaml
+++ b/charts/controlplane/templates/service.yaml
@@ -1,4 +1,6 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
+---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
 {{- if not $service.config.disabled }}
 apiVersion: v1
@@ -32,5 +34,6 @@ spec:
   selector:
     {{- include "unionai.selectorLabels" $service | nindent 4 }}
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/controlplane/templates/service.yaml
+++ b/charts/controlplane/templates/service.yaml
@@ -1,0 +1,36 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
+{{- if not $service.config.disabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unionai.fullname" $service }}
+  labels:
+    {{- include "unionai.labels" $service | nindent 4 }}
+spec:
+  {{- $svc := include "unionai.service" $service | fromYaml }}
+  type: {{ $svc.type | default "ClusterIP" }}
+  ports:
+    - name: grpc
+      port: {{ $svc.grpcport | default 8080 }}
+      protocol: TCP
+      targetPort: 8080
+    {{- if $svc.connectport }}
+    - name: connect
+      port:  {{ $svc.connectport }}
+      protocol: TCP
+      targetPort: 8081
+    {{- end }}
+    - name: http
+      port: {{ $svc.httpport | default 8089 }}
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: {{ $svc.debugport | default 10254 }}
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    {{- include "unionai.selectorLabels" $service | nindent 4 }}
+
+{{- end }}
+{{- end }}

--- a/charts/controlplane/templates/serviceaccount.yaml
+++ b/charts/controlplane/templates/serviceaccount.yaml
@@ -1,4 +1,6 @@
+{{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
+---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
 {{- if not $service.config.disabled }}
 {{- if eq (include "unionai.serviceAccount.create" $service | trim) "true" }}
@@ -13,6 +15,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/controlplane/templates/serviceaccount.yaml
+++ b/charts/controlplane/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- range $serviceKey, $serviceConfig := .Values.services }}
+{{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
+{{- if not $service.config.disabled }}
+{{- if eq (include "unionai.serviceAccount.create" $service | trim) "true" }}
+{{- $annotations := include "unionai.serviceAccount.annotations" $service | fromYaml }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "unionai.serviceAccountName" $service }}
+  labels:
+    {{- include "unionai.labels" $service | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1,11 +1,13 @@
 # This section contains the default values for the controlplane chart.
 # Currently this includes only for union services and also values have been populated for testing only.
+controlplane:
+  enabled: true
 global:
   replicaCount: 1 # Keeping low replica count for testing purposes.
   image:
-    repository: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud # only for testing
+    repository: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud # only for testing
     pullPolicy: Always # Will be changed once iteration is done.
-    tag: 0.0.2-updated-2 # Will be changed once iteration is done.
+    tag: 5851360e4ba391b6bef72c333e497d1cac5b7c9d # Will be changed once iteration is done.
   imagePullSecrets:
   nameOverride: ""
   fullnameOverride: ""
@@ -73,8 +75,6 @@ global:
       labels:
         instance: union
   configMap:
-    cloudProvider:
-      provider: mock
     cache:
       identity:
         enabled: false
@@ -209,11 +209,8 @@ services:
           maxOpenConnections: 20
           maxConnectionLifetime: 1m
       cluster:
-        aws:
-          region: "us-east-2"
         cloudflare:
-          serviceTokenId: "4ba70f3f-4347-4c4a-a986-b92964aecf46"
-          domain: "tunnel-staging.unionai.cloud"
+          active: false
   dataproxy:
     fullnameOverride: "dataproxy"
     args:
@@ -306,3 +303,17 @@ services:
       sharedService:
         metrics:
           scope: "usage:"
+      cloudProvider:
+        awsConfig:
+          region: us-east-2
+        provider: aws
+      timeseries:
+        timestream:
+          databaseName: staging-timestream
+          derivedTableName: cloudMetricsDerived
+          query:
+            enabled: true
+            includeQuotaBasedResourceMetrics: true
+          tableName: cloudMetricsRaw
+          tags:
+            - environment: staging

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1,13 +1,9 @@
-# This section contains the default values for the controlplane chart.
-# Currently this includes only for union services and also values have been populated for testing only.
-controlplane:
-  enabled: true
 global:
-  replicaCount: 1 # Keeping low replica count for testing purposes.
+  replicaCount: 1
   image:
-    repository: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud # only for testing
-    pullPolicy: Always # Will be changed once iteration is done.
-    tag: 5851360e4ba391b6bef72c333e497d1cac5b7c9d # Will be changed once iteration is done.
+    repository: "" # Placeholder for the actual image repository
+    pullPolicy: IfNotPresent
+    tag: latest # Placeholder for the actual image tag
   imagePullSecrets:
   nameOverride: ""
   fullnameOverride: ""
@@ -43,7 +39,7 @@ global:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 1 # again keeping this for testing and would be changed.
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
   secrets: {}
@@ -101,7 +97,7 @@ global:
         urlPattern: "{{ service }}.union.svc.cluster.local:80"
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       auth:
         enable: false
     logger:
@@ -127,8 +123,8 @@ services:
         metrics:
           scope: "artifacts:"
       db:
-        host: "database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com"
-        username: "postgres"
+        host: dbhost # Placeholder for the actual DB host
+        username: "postgres" # Placeholder for the actual DB username
         passwordPath: /etc/secrets/db-pass.txt
         connectionPool:
           maxIdleConnections: 20
@@ -139,7 +135,7 @@ services:
           adminClient:
             hackFlagUntilCellIsolation: true
           artifactBlobStoreConfig:
-            container: artifacts-offloaded-byocp-test-us-east-2
+            container: artifacts-bucket # Placeholder for the actual bucket name used by artifacts
             stow:
               config:
                 auth_type: iam
@@ -152,11 +148,11 @@ services:
             maxOpenConnections: 30
             postgres:
               dbname: postgres
-              host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+              host: dbhost # Placeholder for the actual DB host
               options: sslmode=disable
               passwordPath: /etc/secrets/db-pass.txt
               port: 5432
-              readReplicaHost: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+              readReplicaHost: dbhost # Placeholder for the actual read replica host
               username: postgres
           artifactServerConfig:
             httpPort: 8089
@@ -194,15 +190,15 @@ services:
           scope: "cluster:"
       timeseries:
         timestream:
-          databaseName: "byocp-test-timestream-db"
+          databaseName: dbName # Placeholder for the actual DB name
           tableName: "cloudMetricsRaw"
           derivedTableName: "cloudMetricsDerived"
           region: "us-east-2"
           tags:
             - environment: "staging"
       db:
-        host: "database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com"
-        username: "postgres"
+        host: dbhost # Placeholder for the actual DB host
+        username: "postgres" # Placeholder for the actual DB username
         passwordPath: /etc/secrets/db-pass.txt
         connectionPool:
           maxIdleConnections: 20
@@ -231,14 +227,14 @@ services:
       - /etc/config/*.yaml
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-executions-role
+        eks.amazonaws.com/role-arn: executions-role # Placeholder for the actual role ARN
     configMap:
       sharedService:
         metrics:
           scope: "executions:"
       db:
-        host: "database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com"
-        username: "postgres"
+        host: dbhost # Placeholder for the actual DB host
+        username: "postgres" # Placeholder for the actual DB username
         passwordPath: /etc/secrets/db-pass.txt
         connectionPool:
           maxIdleConnections: 20
@@ -248,20 +244,20 @@ services:
         cloudProvider: AWS
         region: us-east-2
         subscriber:
-          accountId: "440744229819"
-          queueName: staging-us-east-2-executions-cloudEventsQueue
+          accountId: accountId # Placeholder for the actual account ID
+          queueName: cloudEventQueue # Placeholder for the actual queue name
       executions:
         app:
           adminClient:
             connection:
               authorizationHeader: flyte-authorization
-              clientId: 0oa2n55xystvEjmOD5d7
+              clientId: clientID # Placeholder for the actual client ID
               scopes:
                 - all
           taskValidation:
             serverlessTaskPodSpecValidation:
               enabled: "true"
-            skipOrgs: utt-mgdp-stg-us-east-2,utt-mgdp-stg-us-west-2,hosted
+            skipOrgs: []
         apps:
           enrichIdentities: true
           publicURLPattern: https://%s.apps.%s.cloud-staging.union.ai
@@ -282,10 +278,10 @@ services:
           env: staging
           identityProviderConfig:
             okta:
-              clientRegistrationEndpointUrl: https://unionai.oktapreview.com
+              clientRegistrationEndpointUrl: idpurl # Placeholder for the actual IDP URL
           adminClient:
             connection:
-              clientId: 0oa2n55xystvEjmOD5d7
+              clientId: clientID # Placeholder for the actual client ID
               authorizationHeader: "flyte-authorization"
               scopes:
                 - all
@@ -298,7 +294,7 @@ services:
       - /etc/config/*.yaml
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-usage-usageRole
+        eks.amazonaws.com/role-arn: usage-role # Placeholder for the actual role ARN
     configMap:
       sharedService:
         metrics:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1,0 +1,308 @@
+# This section contains the default values for the controlplane chart.
+# Currently this includes only for union services and also values have been populated for testing only.
+global:
+  replicaCount: 1 # Keeping low replica count for testing purposes.
+  image:
+    repository: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud # only for testing
+    pullPolicy: Always # Will be changed once iteration is done.
+    tag: 0.0.2-updated-2 # Will be changed once iteration is done.
+  imagePullSecrets:
+  nameOverride: ""
+  fullnameOverride: ""
+  serviceAccount:
+    create: true
+    annotations: {}
+  podAnnotations:
+    linkerd.io/inject: disabled
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+  service:
+    type: ClusterIP
+    grpcport: 80
+    httpport: 81
+    debugport: 82
+    connectport: 83
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 250Mi
+  env:
+  - name: GOMEMLIMIT
+    valueFrom:
+      resourceFieldRef:
+        resource: limits.memory
+  - name: GOMAXPROCS
+    valueFrom:
+      resourceFieldRef:
+        resource: limits.cpu
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 1 # again keeping this for testing and would be changed.
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+  secrets: {}
+  podMonitor:
+    custom:
+      enabled: false
+      metricRelabelings: []
+  probe:
+    enabled: false
+  serviceProfile:
+    enabled: false
+  spreadConstraints:
+    enabled: false
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  argo:
+    enabled: false
+  externalSecrets:
+    refreshInterval: 1h
+    refs: {}
+  postgres-exporter:
+    enabled: false
+    fullnameOverride: postgres-exporter
+    serviceMonitor:
+      enabled: false
+      labels:
+        instance: union
+  configMap:
+    cloudProvider:
+      provider: mock
+    cache:
+      identity:
+        enabled: false
+    sharedService:
+      connectPort: 8081
+    authorizer:
+      type: "Noop"
+      internalCommunicationConfig:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    otel:
+      type: otlpgrpc
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+    union:
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: "{{ service }}.union.svc.cluster.local:80"
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      auth:
+        enable: false
+    logger:
+      level: 6
+
+services:
+  artifacts:
+    fullnameOverride: "artifacts"
+    initContainers:
+      - name: migrate
+        args:
+          - artifacts
+          - migrate
+          - --config
+          - "/etc/config/*.yaml"
+    args:
+      - artifacts
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    configMap:
+      sharedService:
+        metrics:
+          scope: "artifacts:"
+      db:
+        host: "database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com"
+        username: "postgres"
+        passwordPath: /etc/secrets/db-pass.txt
+        connectionPool:
+          maxIdleConnections: 20
+          maxOpenConnections: 20
+          maxConnectionLifetime: 1m
+      artifactsConfig:
+        app:
+          adminClient:
+            hackFlagUntilCellIsolation: true
+          artifactBlobStoreConfig:
+            container: artifacts-offloaded-byocp-test-us-east-2
+            stow:
+              config:
+                auth_type: iam
+                region: us-east-2
+              kind: s3
+            type: stow
+          artifactDatabaseConfig:
+            connMaxLifeTime: 1m
+            maxIdleConnections: 20
+            maxOpenConnections: 30
+            postgres:
+              dbname: postgres
+              host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+              options: sslmode=disable
+              passwordPath: /etc/secrets/db-pass.txt
+              port: 5432
+              readReplicaHost: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+              username: postgres
+          artifactServerConfig:
+            httpPort: 8089
+            port: 8080
+            respectUserOrgsForServerless: true
+          artifactTriggerConfig:
+            executionMaxRetryCount: 3
+            executionSchedulerQuerySize: 20
+            executionSchedulers: 1
+            executionSchedulersWait: 10
+            triggerProcessorQuerySize: 100
+            triggerProcessors: 1
+            triggerProcessorsWait: 10
+  authorizer:
+    fullnameOverride: "authorizer"
+    args:
+      - authorizer
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    configMap:
+      sharedService:
+        metrics:
+          scope: "authorizer:"
+  cluster:
+    fullnameOverride: "cluster"
+    args:
+      - cloudcluster
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    configMap:
+      sharedService:
+        metrics:
+          scope: "cluster:"
+      timeseries:
+        timestream:
+          databaseName: "byocp-test-timestream-db"
+          tableName: "cloudMetricsRaw"
+          derivedTableName: "cloudMetricsDerived"
+          region: "us-east-2"
+          tags:
+            - environment: "staging"
+      db:
+        host: "database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com"
+        username: "postgres"
+        passwordPath: /etc/secrets/db-pass.txt
+        connectionPool:
+          maxIdleConnections: 20
+          maxOpenConnections: 20
+          maxConnectionLifetime: 1m
+      cluster:
+        aws:
+          region: "us-east-2"
+        cloudflare:
+          serviceTokenId: "4ba70f3f-4347-4c4a-a986-b92964aecf46"
+          domain: "tunnel-staging.unionai.cloud"
+  dataproxy:
+    fullnameOverride: "dataproxy"
+    args:
+      - dataproxy
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    configMap:
+      sharedService:
+        metrics:
+          scope: "usage:"
+  executions:
+    fullnameOverride: "executions"
+    args:
+      - cloudpropeller
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-executions-role
+    configMap:
+      sharedService:
+        metrics:
+          scope: "executions:"
+      db:
+        host: "database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com"
+        username: "postgres"
+        passwordPath: /etc/secrets/db-pass.txt
+        connectionPool:
+          maxIdleConnections: 20
+          maxOpenConnections: 20
+          maxConnectionLifetime: 1m
+      cloudEventsProcessor:
+        cloudProvider: AWS
+        region: us-east-2
+        subscriber:
+          accountId: "440744229819"
+          queueName: staging-us-east-2-executions-cloudEventsQueue
+      executions:
+        app:
+          adminClient:
+            connection:
+              authorizationHeader: flyte-authorization
+              clientId: 0oa2n55xystvEjmOD5d7
+              scopes:
+                - all
+          taskValidation:
+            serverlessTaskPodSpecValidation:
+              enabled: "true"
+            skipOrgs: utt-mgdp-stg-us-east-2,utt-mgdp-stg-us-west-2,hosted
+        apps:
+          enrichIdentities: true
+          publicURLPattern: https://%s.apps.%s.cloud-staging.union.ai
+  identity:
+    fullnameOverride: "identity"
+    args:
+      - cloudidentity
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    configMap:
+      sharedService:
+        metrics:
+          scope: "identity:"
+      identity:
+        app:
+          rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+          env: staging
+          identityProviderConfig:
+            okta:
+              clientRegistrationEndpointUrl: https://unionai.oktapreview.com
+          adminClient:
+            connection:
+              clientId: 0oa2n55xystvEjmOD5d7
+              authorizationHeader: "flyte-authorization"
+              scopes:
+                - all
+  usage:
+    fullnameOverride: "usage"
+    args:
+      - usage
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-usage-usageRole
+    configMap:
+      sharedService:
+        metrics:
+          scope: "usage:"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -94,6 +94,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -104,6 +106,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -114,6 +118,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -124,6 +130,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -136,6 +144,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-executions-role
+---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -146,6 +156,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -171,7 +183,9 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
-stringData:   
+stringData:
+---
+# Source: controlplane/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -183,7 +197,9 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
-stringData:   
+stringData:
+---
+# Source: controlplane/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -195,7 +211,9 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
-stringData:   
+stringData:
+---
+# Source: controlplane/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -207,7 +225,9 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
-stringData:   
+stringData:
+---
+# Source: controlplane/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -219,7 +239,9 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
-stringData:   
+stringData:
+---
+# Source: controlplane/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -231,7 +253,9 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
-stringData:   
+stringData:
+---
+# Source: controlplane/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -339,6 +363,7 @@ data:
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
 ---
 # Source: controlplane/templates/configmap.yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -388,6 +413,7 @@ data:
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
 ---
 # Source: controlplane/templates/configmap.yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -459,6 +485,7 @@ data:
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
 ---
 # Source: controlplane/templates/configmap.yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -508,6 +535,7 @@ data:
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
 ---
 # Source: controlplane/templates/configmap.yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -586,6 +614,7 @@ data:
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
 ---
 # Source: controlplane/templates/configmap.yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -648,6 +677,7 @@ data:
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
 ---
 # Source: controlplane/templates/configmap.yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -729,6 +759,8 @@ spec:
   selector:
     app.kubernetes.io/name: artifacts
     app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -761,6 +793,8 @@ spec:
   selector:
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -793,6 +827,8 @@ spec:
   selector:
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -825,6 +861,8 @@ spec:
   selector:
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -857,6 +895,8 @@ spec:
   selector:
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -889,6 +929,8 @@ spec:
   selector:
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -1038,6 +1080,8 @@ spec:
                     app.kubernetes.io/name: artifacts
                     app.kubernetes.io/instance: release-name
                 topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1139,6 +1183,8 @@ spec:
                     app.kubernetes.io/name: authorizer
                     app.kubernetes.io/instance: release-name
                 topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1240,6 +1286,8 @@ spec:
                     app.kubernetes.io/name: cluster
                     app.kubernetes.io/instance: release-name
                 topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1341,6 +1389,8 @@ spec:
                     app.kubernetes.io/name: dataproxy
                     app.kubernetes.io/instance: release-name
                 topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1442,6 +1492,8 @@ spec:
                     app.kubernetes.io/name: executions
                     app.kubernetes.io/instance: release-name
                 topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1543,6 +1595,8 @@ spec:
                     app.kubernetes.io/name: identity
                     app.kubernetes.io/instance: release-name
                 topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1670,6 +1724,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -1694,6 +1750,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -1718,6 +1776,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -1742,6 +1802,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -1766,6 +1828,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -1790,6 +1854,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -325,8 +325,6 @@ data:
     cache:
       identity:
         enabled: false
-    cloudProvider:
-      provider: mock
     connection:
       environment: staging
       region: us-east-2
@@ -383,8 +381,6 @@ data:
     cache:
       identity:
         enabled: false
-    cloudProvider:
-      provider: mock
     connection:
       environment: staging
       region: us-east-2
@@ -433,14 +429,9 @@ data:
     cache:
       identity:
         enabled: false
-    cloudProvider:
-      provider: mock
     cluster:
-      aws:
-        region: us-east-2
       cloudflare:
-        domain: tunnel-staging.unionai.cloud
-        serviceTokenId: 4ba70f3f-4347-4c4a-a986-b92964aecf46
+        active: false
     connection:
       environment: staging
       region: us-east-2
@@ -505,8 +496,6 @@ data:
     cache:
       identity:
         enabled: false
-    cloudProvider:
-      provider: mock
     connection:
       environment: staging
       region: us-east-2
@@ -561,8 +550,6 @@ data:
       subscriber:
         accountId: "440744229819"
         queueName: staging-us-east-2-executions-cloudEventsQueue
-    cloudProvider:
-      provider: mock
     connection:
       environment: staging
       region: us-east-2
@@ -634,8 +621,6 @@ data:
     cache:
       identity:
         enabled: false
-    cloudProvider:
-      provider: mock
     connection:
       environment: staging
       region: us-east-2
@@ -698,7 +683,9 @@ data:
       identity:
         enabled: false
     cloudProvider:
-      provider: mock
+      awsConfig:
+        region: us-east-2
+      provider: aws
     connection:
       environment: staging
       region: us-east-2
@@ -716,6 +703,16 @@ data:
       connectPort: 8081
       metrics:
         scope: 'usage:'
+    timeseries:
+      timestream:
+        databaseName: staging-timestream
+        derivedTableName: cloudMetricsDerived
+        query:
+          enabled: true
+          includeQuotaBasedResourceMetrics: true
+        tableName: cloudMetricsRaw
+        tags:
+        - environment: staging
     union:
       auth:
         enable: false
@@ -980,6 +977,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: artifacts
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -992,11 +994,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: artifacts
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1006,7 +1003,7 @@ spec:
           name: artifacts
       initContainers:
         - name: artifacts-migrate
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
           - artifacts
@@ -1020,7 +1017,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: artifacts
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - artifacts
@@ -1097,6 +1094,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: authorizer
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -1109,11 +1111,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: authorizer
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1123,7 +1120,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - authorizer
@@ -1200,6 +1197,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: cluster
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -1212,11 +1214,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: cluster
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1226,7 +1223,7 @@ spec:
           name: cluster
       containers:
         - name: cluster
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - cloudcluster
@@ -1303,6 +1300,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: dataproxy
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -1315,11 +1317,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: dataproxy
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1329,7 +1326,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - dataproxy
@@ -1406,6 +1403,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: executions
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -1418,11 +1420,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: executions
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1432,7 +1429,7 @@ spec:
           name: executions
       containers:
         - name: executions
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - cloudpropeller
@@ -1509,6 +1506,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: identity
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -1521,11 +1523,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: identity
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1535,7 +1532,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - cloudidentity
@@ -1612,6 +1609,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: usage
       app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -1624,11 +1626,6 @@ spec:
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: usage
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
       volumes:
       - name: secrets
         secret:
@@ -1638,7 +1635,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
           imagePullPolicy: Always
           args:
             - usage

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -1,0 +1,1816 @@
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: artifacts
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: artifacts
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: authorizer
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authorizer
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cluster
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dataproxy
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dataproxy
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: executions
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: executions
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: identity
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: identity
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: usage
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: usage
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-executions-role
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-usage-usageRole
+---
+# Source: controlplane/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:   
+apiVersion: v1
+kind: Secret
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:   
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:   
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:   
+apiVersion: v1
+kind: Secret
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:   
+apiVersion: v1
+kind: Secret
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:   
+apiVersion: v1
+kind: Secret
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    artifactsConfig:
+      app:
+        adminClient:
+          hackFlagUntilCellIsolation: true
+        artifactBlobStoreConfig:
+          container: artifacts-offloaded-byocp-test-us-east-2
+          stow:
+            config:
+              auth_type: iam
+              region: us-east-2
+            kind: s3
+          type: stow
+        artifactDatabaseConfig:
+          connMaxLifeTime: 1m
+          maxIdleConnections: 20
+          maxOpenConnections: 30
+          postgres:
+            dbname: postgres
+            host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+            options: sslmode=disable
+            passwordPath: /etc/secrets/db-pass.txt
+            port: 5432
+            readReplicaHost: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+            username: postgres
+        artifactServerConfig:
+          httpPort: 8089
+          port: 8080
+          respectUserOrgsForServerless: true
+        artifactTriggerConfig:
+          executionMaxRetryCount: 3
+          executionSchedulerQuerySize: 20
+          executionSchedulers: 1
+          executionSchedulersWait: 10
+          triggerProcessorQuerySize: 100
+          triggerProcessors: 1
+          triggerProcessorsWait: 10
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+      passwordPath: /etc/secrets/db-pass.txt
+      username: postgres
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'artifacts:'
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'authorizer:'
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: mock
+    cluster:
+      aws:
+        region: us-east-2
+      cloudflare:
+        domain: tunnel-staging.unionai.cloud
+        serviceTokenId: 4ba70f3f-4347-4c4a-a986-b92964aecf46
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+      passwordPath: /etc/secrets/db-pass.txt
+      username: postgres
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'cluster:'
+    timeseries:
+      timestream:
+        databaseName: byocp-test-timestream-db
+        derivedTableName: cloudMetricsDerived
+        region: us-east-2
+        tableName: cloudMetricsRaw
+        tags:
+        - environment: staging
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'usage:'
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudEventsProcessor:
+      cloudProvider: AWS
+      region: us-east-2
+      subscriber:
+        accountId: "440744229819"
+        queueName: staging-us-east-2-executions-cloudEventsQueue
+    cloudProvider:
+      provider: mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+      passwordPath: /etc/secrets/db-pass.txt
+      username: postgres
+    executions:
+      app:
+        adminClient:
+          connection:
+            authorizationHeader: flyte-authorization
+            clientId: 0oa2n55xystvEjmOD5d7
+            scopes:
+            - all
+        taskValidation:
+          serverlessTaskPodSpecValidation:
+            enabled: "true"
+          skipOrgs: utt-mgdp-stg-us-east-2,utt-mgdp-stg-us-west-2,hosted
+      apps:
+        enrichIdentities: true
+        publicURLPattern: https://%s.apps.%s.cloud-staging.union.ai
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'executions:'
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    identity:
+      app:
+        adminClient:
+          connection:
+            authorizationHeader: flyte-authorization
+            clientId: 0oa2n55xystvEjmOD5d7
+            scopes:
+            - all
+        env: staging
+        identityProviderConfig:
+          okta:
+            clientRegistrationEndpointUrl: https://unionai.oktapreview.com
+        rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'identity:'
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
+    logger:
+      level: 6
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'usage:'
+    union:
+      auth:
+        enable: false
+      connection:
+        trustedIdentityClaims:
+          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '{{ service }}.union.svc.cluster.local:80'
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+apiVersion: v1
+kind: Service
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+apiVersion: v1
+kind: Service
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+apiVersion: v1
+kind: Service
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+apiVersion: v1
+kind: Service
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: 8081
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: 10254
+  selector:
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: artifacts
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: artifacts
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: artifacts
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: artifacts
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: artifacts
+      - name: config
+        configMap:
+          name: artifacts
+      initContainers:
+        - name: artifacts-migrate
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+          - artifacts
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: secrets
+            mountPath: /etc/secrets/
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: artifacts
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - artifacts
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: artifacts
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authorizer
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: authorizer
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: authorizer
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: authorizer
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: authorizer
+      - name: config
+        configMap:
+          name: authorizer
+      containers:
+        - name: authorizer
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - authorizer
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: authorizer
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: cluster
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: cluster
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: cluster
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: cluster
+      - name: config
+        configMap:
+          name: cluster
+      containers:
+        - name: cluster
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - cloudcluster
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: cluster
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dataproxy
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: dataproxy
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: dataproxy
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: dataproxy
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: dataproxy
+      - name: config
+        configMap:
+          name: dataproxy
+      containers:
+        - name: dataproxy
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - dataproxy
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: dataproxy
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: executions
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: executions
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: executions
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: executions
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: executions
+      - name: config
+        configMap:
+          name: executions
+      containers:
+        - name: executions
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - cloudpropeller
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: executions
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: identity
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: identity
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: identity
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: identity
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: identity
+      - name: config
+        configMap:
+          name: identity
+      containers:
+        - name: identity
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - cloudidentity
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: identity
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2025.5.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: usage
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: usage
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: usage
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: usage
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      volumes:
+      - name: secrets
+        secret:
+          secretName: usage
+      - name: config
+        configMap:
+          name: usage
+      containers:
+        - name: usage
+          image: 479331373192.dkr.ecr.us-east-2.amazonaws.com/cloud:0.0.2-updated-2
+          imagePullPolicy: Always
+          args:
+            - usage
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: usage
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: artifacts
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: artifacts
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authorizer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: authorizer
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cluster
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cluster
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: dataproxy
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: dataproxy
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: executions
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: executions
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: identity
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: identity
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: usage
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: usage
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-executions-role
+    eks.amazonaws.com/role-arn: executions-role
 ---
 # Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
@@ -169,7 +169,7 @@ metadata:
     app.kubernetes.io/version: "2025.5.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::440744229819:role/staging-usage-usageRole
+    eks.amazonaws.com/role-arn: usage-role
 ---
 # Source: controlplane/templates/secret.yaml
 apiVersion: v1
@@ -287,7 +287,7 @@ data:
         adminClient:
           hackFlagUntilCellIsolation: true
         artifactBlobStoreConfig:
-          container: artifacts-offloaded-byocp-test-us-east-2
+          container: artifacts-bucket
           stow:
             config:
               auth_type: iam
@@ -300,11 +300,11 @@ data:
           maxOpenConnections: 30
           postgres:
             dbname: postgres
-            host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+            host: dbhost
             options: sslmode=disable
             passwordPath: /etc/secrets/db-pass.txt
             port: 5432
-            readReplicaHost: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+            readReplicaHost: dbhost
             username: postgres
         artifactServerConfig:
           httpPort: 8089
@@ -334,7 +334,7 @@ data:
         maxConnectionLifetime: 1m
         maxIdleConnections: 20
         maxOpenConnections: 20
-      host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+      host: dbhost
       passwordPath: /etc/secrets/db-pass.txt
       username: postgres
     logger:
@@ -355,7 +355,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -403,7 +403,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -441,7 +441,7 @@ data:
         maxConnectionLifetime: 1m
         maxIdleConnections: 20
         maxOpenConnections: 20
-      host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+      host: dbhost
       passwordPath: /etc/secrets/db-pass.txt
       username: postgres
     logger:
@@ -459,7 +459,7 @@ data:
         scope: 'cluster:'
     timeseries:
       timestream:
-        databaseName: byocp-test-timestream-db
+        databaseName: dbName
         derivedTableName: cloudMetricsDerived
         region: us-east-2
         tableName: cloudMetricsRaw
@@ -470,7 +470,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -518,7 +518,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -548,8 +548,8 @@ data:
       cloudProvider: AWS
       region: us-east-2
       subscriber:
-        accountId: "440744229819"
-        queueName: staging-us-east-2-executions-cloudEventsQueue
+        accountId: accountId
+        queueName: cloudEventQueue
     connection:
       environment: staging
       region: us-east-2
@@ -559,7 +559,7 @@ data:
         maxConnectionLifetime: 1m
         maxIdleConnections: 20
         maxOpenConnections: 20
-      host: database-1-instance-1.c982kkq6ghd1.us-east-2.rds.amazonaws.com
+      host: dbhost
       passwordPath: /etc/secrets/db-pass.txt
       username: postgres
     executions:
@@ -567,13 +567,13 @@ data:
         adminClient:
           connection:
             authorizationHeader: flyte-authorization
-            clientId: 0oa2n55xystvEjmOD5d7
+            clientId: clientID
             scopes:
             - all
         taskValidation:
           serverlessTaskPodSpecValidation:
             enabled: "true"
-          skipOrgs: utt-mgdp-stg-us-east-2,utt-mgdp-stg-us-west-2,hosted
+          skipOrgs: []
       apps:
         enrichIdentities: true
         publicURLPattern: https://%s.apps.%s.cloud-staging.union.ai
@@ -595,7 +595,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -630,13 +630,13 @@ data:
         adminClient:
           connection:
             authorizationHeader: flyte-authorization
-            clientId: 0oa2n55xystvEjmOD5d7
+            clientId: clientID
             scopes:
             - all
         env: staging
         identityProviderConfig:
           okta:
-            clientRegistrationEndpointUrl: https://unionai.oktapreview.com
+            clientRegistrationEndpointUrl: idpurl
         rootTenantURLPattern: dns:///{{ organization }}.cloud-staging.union.ai
     logger:
       level: 6
@@ -656,7 +656,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -718,7 +718,7 @@ data:
         enable: false
       connection:
         trustedIdentityClaims:
-          externalIdentityClaim: 0oa2n55xystvEjmOD5d7
+          externalIdentityClaim: ""
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
@@ -1003,8 +1003,8 @@ spec:
           name: artifacts
       initContainers:
         - name: artifacts-migrate
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
           - artifacts
           - migrate
@@ -1017,8 +1017,8 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: artifacts
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - artifacts
             - serve
@@ -1120,8 +1120,8 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - authorizer
             - serve
@@ -1223,8 +1223,8 @@ spec:
           name: cluster
       containers:
         - name: cluster
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
             - serve
@@ -1326,8 +1326,8 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - dataproxy
             - serve
@@ -1429,8 +1429,8 @@ spec:
           name: executions
       containers:
         - name: executions
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
             - serve
@@ -1532,8 +1532,8 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
             - serve
@@ -1635,8 +1635,8 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 440744229819.dkr.ecr.us-east-2.amazonaws.com/cloud:5851360e4ba391b6bef72c333e497d1cac5b7c9d
-          imagePullPolicy: Always
+          image: ""  # empty string to avoid template error
+          imagePullPolicy: IfNotPresent
           args:
             - usage
             - serve

--- a/tests/values/controlplane.aws.yaml
+++ b/tests/values/controlplane.aws.yaml
@@ -1,0 +1,2 @@
+controlplane:
+  enabled: true


### PR DESCRIPTION
* Adds green field templates working of the existing one in union cloud
* The templates are refactored to be able to install multiple services with single values file
* Adds helper to do recursive merges of the values
* Add override for controlplane chart to be installed with flag enabled for it
* Adds  generated tests


Tested this on internal EKS cluster and all services come up