### PR TITLE
Fix image builder helm-charts

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2025.5.2
+version: 2025.5.3
 appVersion: 2025.5.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane/templates/imagebuilder/deployment.yaml
+++ b/charts/dataplane/templates/imagebuilder/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- if .Values.imageBuilder.buildkit.rootless }}
         container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
         {{- end }}
-        {{- with .Values.imageBuilder.buildkit.podAnnotations -}}
+        {{- with .Values.imageBuilder.buildkit.podAnnotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
@@ -32,12 +32,10 @@ spec:
         - name: "buildkit"
           image: "{{ .Values.imageBuilder.buildkit.image.repository }}:{{ .Values.imageBuilder.buildkit.image.tag }}"
           imagePullPolicy: {{ .Values.imageBuilder.buildkit.image.pullPolicy }}
-          {{- if or .Values.imageBuilder.buildkit.rootless }}
           volumeMounts:
           {{- if .Values.imageBuilder.buildkit.rootless }}
             - mountPath: /home/user/.local/share/buildkit
               name: buildkitd
-          {{- end }}
           {{- end }}
             - mountPath: /etc/buildkit
               name: buildkit-config
@@ -85,12 +83,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.imageBuilder.buildkit.resources | nindent 12 }}
-      {{- if .Values.imageBuilder.buildkit.rootless }}
       volumes:
       {{- if .Values.imageBuilder.buildkit.rootless }}
       - name: buildkitd
         emptyDir: {}
-      {{- end }}
       {{- end }}
       - configMap:
           name: {{ include "imagebuilder.buildkit.fullname" . }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1076,10 +1076,10 @@ imageBuilder:
       # -- Pull policy
       pullPolicy: IfNotPresent
       # -- Image tag
-      tag: "buildx-stable-1-rootless"
+      tag: "latest"
 
-    # -- Run rootless mode, https://github.com/moby/buildkit/blob/master/docs/rootless.md
-    rootless: true
+    # -- Default to non-rootless to support a wider range of linux kernels.
+    rootless: false
 
     # -- Enable debug logging
     log:
@@ -1113,6 +1113,7 @@ imageBuilder:
       requests:
         cpu: 2
         memory: 4Gi
+        ephemeral-storage: 20Gi
 
     # -- Node selector
     nodeSelector: {}


### PR DESCRIPTION
* Bump dataplane version from `2025.5.2` -> `2025.5.3`
* Fix image builder buildkit deployment helm template to remove breaking
  condition when not using rootless
* Default to `non-rootless` buildkit to support a wider varient of out
  of the box kernels. For example EKS AutoMode using bottlerocket which
  limits user namespaces and breaks buildkit deployment
* add ephemeral-storage
