### PR TITLE
Make operator label same as the one in BYOC

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -389,7 +389,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "operator.selectorLabels" -}}
-app.kubernetes.io/name: operator
+app.kubernetes.io/name: union-operator
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -146,7 +146,7 @@ kind: ServiceAccount
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -384,7 +384,7 @@ kind: ConfigMap
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1083,7 +1083,7 @@ kind: ClusterRole
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1380,7 +1380,7 @@ kind: ClusterRoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1452,7 +1452,7 @@ kind: Role
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1495,7 +1495,7 @@ kind: RoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1814,7 +1814,7 @@ kind: Service
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1826,7 +1826,7 @@ spec:
       protocol: TCP
       name: debug
   selector:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
 ---
 # Source: dataplane/templates/propeller/service-webhook.yaml
@@ -2372,7 +2372,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8455a1105a76f5624c134cd411fab08424f0e04c62ba74913722622b85fd798"
+        configChecksum: "3e2cf7c3bd1435b166aec84fc36c00897355b85bbb5b12da2a5c26bdf339e6d"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2490,23 +2490,23 @@ kind: Deployment
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: operator
+      app.kubernetes.io/name: union-operator
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       annotations:
-        configChecksum: "8455a1105a76f5624c134cd411fab08424f0e04c62ba74913722622b85fd798"
+        configChecksum: "3e2cf7c3bd1435b166aec84fc36c00897355b85bbb5b12da2a5c26bdf339e6d"
         
       labels:
         
-        app.kubernetes.io/name: operator
+        app.kubernetes.io/name: union-operator
         app.kubernetes.io/instance: release-name
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -478,7 +478,7 @@ kind: ConfigMap
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1182,7 +1182,7 @@ kind: ClusterRole
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1479,7 +1479,7 @@ kind: ClusterRoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1570,7 +1570,7 @@ kind: Role
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1635,7 +1635,7 @@ kind: RoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1992,7 +1992,7 @@ kind: Service
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -2004,7 +2004,7 @@ spec:
       protocol: TCP
       name: debug
   selector:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
 ---
 # Source: dataplane/templates/propeller/service-webhook.yaml
@@ -2653,7 +2653,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
+        configChecksum: "abf334179b6c60c8b0872461d2f8f2cb600b9ec9eba38461a396287dde27d83"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2771,23 +2771,23 @@ kind: Deployment
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: operator
+      app.kubernetes.io/name: union-operator
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       annotations:
-        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
+        configChecksum: "abf334179b6c60c8b0872461d2f8f2cb600b9ec9eba38461a396287dde27d83"
         
       labels:
         
-        app.kubernetes.io/name: operator
+        app.kubernetes.io/name: union-operator
         app.kubernetes.io/instance: release-name
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -380,7 +380,7 @@ kind: ConfigMap
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1097,7 +1097,7 @@ kind: ClusterRole
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1408,7 +1408,7 @@ kind: ClusterRoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1480,7 +1480,7 @@ kind: Role
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1523,7 +1523,7 @@ kind: RoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1842,7 +1842,7 @@ kind: Service
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1854,7 +1854,7 @@ spec:
       protocol: TCP
       name: debug
   selector:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
 ---
 # Source: dataplane/templates/propeller/service-webhook.yaml
@@ -2501,7 +2501,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
+        configChecksum: "abf334179b6c60c8b0872461d2f8f2cb600b9ec9eba38461a396287dde27d83"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2619,23 +2619,23 @@ kind: Deployment
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: operator
+      app.kubernetes.io/name: union-operator
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       annotations:
-        configChecksum: "f97c563b681bf497970388f0c28572883dc2c18f09daf4cef957cf7d9e7a8b7"
+        configChecksum: "abf334179b6c60c8b0872461d2f8f2cb600b9ec9eba38461a396287dde27d83"
         
       labels:
         
-        app.kubernetes.io/name: operator
+        app.kubernetes.io/name: union-operator
         app.kubernetes.io/instance: release-name
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -144,7 +144,7 @@ kind: ServiceAccount
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -377,7 +377,7 @@ kind: ConfigMap
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1104,7 +1104,7 @@ kind: ClusterRole
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1401,7 +1401,7 @@ kind: ClusterRoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1473,7 +1473,7 @@ kind: Role
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1516,7 +1516,7 @@ kind: RoleBinding
 metadata:
   name: operator-system
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1835,7 +1835,7 @@ kind: Service
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
@@ -1847,7 +1847,7 @@ spec:
       protocol: TCP
       name: debug
   selector:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
 ---
 # Source: dataplane/templates/propeller/service-webhook.yaml
@@ -2403,7 +2403,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a849c598014eab30871b2cbadf4763068c5eb6cbdedf1388532920a6f4de37f"
+        configChecksum: "9b12efdde76c5a349bd11c120d10a63f89293802b0d75eb598a4683afe01c27"
         
       labels:
         app.kubernetes.io/name: operator-proxy
@@ -2531,23 +2531,23 @@ kind: Deployment
 metadata:
   name: union-operator
   labels:
-    app.kubernetes.io/name: operator
+    app.kubernetes.io/name: union-operator
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: operator
+      app.kubernetes.io/name: union-operator
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       annotations:
-        configChecksum: "a849c598014eab30871b2cbadf4763068c5eb6cbdedf1388532920a6f4de37f"
+        configChecksum: "9b12efdde76c5a349bd11c120d10a63f89293802b0d75eb598a4683afe01c27"
         
       labels:
         
-        app.kubernetes.io/name: operator
+        app.kubernetes.io/name: union-operator
         app.kubernetes.io/instance: release-name
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
In BYOC we use `app.kubernetes.io/name: union-operator`. This PR fix the inconsistency.