### PR TITLE
Data plane ingress

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,9 +10,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@v4.3.0
         with:
-          version: v3.17.0
+          version: v3.18.0
       - name: Run linter
         run: make lint
   validate:
@@ -23,9 +23,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@v4.3.0
         with:
-          version: v3.17.0
+          version: v3.18.0
       - name: Run tests
         run: make helm-test
   kubeconform:

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 68.2.2
+  version: 72.9.1
   alias: prometheus
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -948,3 +948,11 @@ The URI to connect to buildkit
 tcp://{{ include "imagebuilder.buildkit.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.imageBuilder.buildkit.service.port }}
 {{- end -}}
 {{- end -}}
+
+{{- define "ingress.serving.host" -}}
+{{- if .Values.ingress.serving.hostOverride }}
+{{- .Values.ingress.serving.hostOverride | quote }}
+{{- else }}
+{{- printf "*.apps.%s" .Values.host | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/dataplane/templates/common/ingress.yaml
+++ b/charts/dataplane/templates/common/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "unionai-dataplane.fullname" . }}
+  name: {{ include "unionai-dataplane.fullname" . }}-serving
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "unionai-dataplane.name" . }}

--- a/charts/dataplane/templates/common/ingress.yaml
+++ b/charts/dataplane/templates/common/ingress.yaml
@@ -7,18 +7,18 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "unionai-dataplane.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.serving.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.class | quote }}
-  {{- with .Values.ingress.tls }}
+  ingressClassName: {{ .Values.ingress.serving.class | quote }}
+  {{- with .Values.ingress.serving.tls }}
   tls:
     {{ toYaml . | nindent 4 }}
   {{- end }}
   rules:
-  - host: "*.apps.{{ .Values.host }}"
+  - host: {{ include "ingress.serving.host" . }}
     http:
       paths:
       - path: /

--- a/charts/dataplane/templates/common/ingress.yaml
+++ b/charts/dataplane/templates/common/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "unionai-dataplane.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "unionai-dataplane.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.class | quote }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  - host: "*.apps.{{ .Values.host }}"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kourier-internal
+            port:
+              number: 80
+{{- end }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -765,12 +765,18 @@ operator:
 # Enable access to dataplane services.
 ingress:
   enabled: false
-  # -- Ingress class name
-  class: ""
-  # -- Annotations to apply to the ingress resource.
-  annotations: {}
-  # -- Ingress TLS configuration
-  tls: {}
+
+  # -- Serving specific ingress configuration.
+  serving:
+    # -- (Optional) Host override for serving ingress rule. Defaults to *.apps.{{ .Values.host }}.
+    hostOverride: ""
+    # -- Ingress class name
+    class: ""
+    # -- Annotations to apply to the ingress resource.
+    annotations: {}
+    # -- Ingress TLS configuration
+    tls: {}
+
 
 # -- Prometheus configuration
 prometheus:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -762,6 +762,16 @@ operator:
       cpu: "2"
       memory: "4Gi"
 
+# Enable access to dataplane services.
+ingress:
+  enabled: false
+  # -- Ingress class name
+  class: ""
+  # -- Annotations to apply to the ingress resource.
+  annotations: {}
+  # -- Ingress TLS configuration
+  tls: {}
+
 # -- Prometheus configuration
 prometheus:
   additionalPrometheusRulesMap: { }

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -69,13 +69,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
   namespace: kube-system
@@ -90,9 +90,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -113,9 +113,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 automountServiceAccountToken: true
@@ -731,13 +731,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 rules:
@@ -891,9 +891,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1001,9 +1001,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 rules:
@@ -1259,13 +1259,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 roleRef:
@@ -1286,9 +1286,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1313,9 +1313,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 roleRef:
@@ -1561,22 +1561,22 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
   - name: "http"
     protocol: TCP
     port: 8080
+    nodePort: 0
     targetPort: 8080
   
   selector:    
@@ -1594,9 +1594,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1621,9 +1621,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1649,9 +1649,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1677,9 +1677,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1705,9 +1705,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1732,9 +1732,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1762,9 +1762,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
@@ -2059,13 +2059,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   selector:
@@ -2079,13 +2079,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.28.0
+        helm.sh/chart: kube-state-metrics-5.33.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.14.0"
+        app.kubernetes.io/version: "2.15.0"
         release: release-name
     spec:
       automountServiceAccountToken: true
@@ -2098,13 +2098,14 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2149,9 +2150,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -2170,9 +2171,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app: prometheus-operator
@@ -2181,19 +2182,19 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: "quay.io/prometheus-operator/prometheus-operator:v0.79.2"
+          image: "quay.io/prometheus-operator/prometheus-operator:v0.82.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --kubelet-service=kube-system/union-operator-kubelet
             - --kubelet-endpoints=true
             - --kubelet-endpointslice=false
             - --localhost=127.0.0.1
-            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.82.2
             - --config-reloader-cpu-request=0
             - --config-reloader-cpu-limit=0
             - --config-reloader-memory-request=0
             - --config-reloader-memory-limit=0
-            - --thanos-default-base-image=quay.io/thanos/thanos:v0.37.2
+            - --thanos-default-base-image=quay.io/thanos/thanos:v0.38.0
             - --secret-field-selector=type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1
             - --web.enable-tls=true
             - --web.cert-file=/cert/cert
@@ -2858,9 +2859,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -2898,15 +2899,15 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   automountServiceAccountToken: true
-  image: "quay.io/prometheus/prometheus:v3.1.0"
-  version: v3.1.0
+  image: "quay.io/prometheus/prometheus:v3.4.1"
+  version: v3.4.1
   externalUrl: http://union-operator-prometheus.union:80
   paused: false
   replicas: 1
@@ -2955,10 +2956,13 @@ spec:
         podAffinityTerm:
           topologyKey: kubernetes.io/hostname
           labelSelector:
-            matchExpressions:
-              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
-              - {key: prometheus, operator: In, values: [union-operator-prometheus]}
+            matchExpressions:            
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            - {key: app.kubernetes.io/instance, operator: In, values: [union-operator-prometheus]}
   portName: http-web
+  enforcedKeepDroppedTargets: 0
+  minReadySeconds: 0
+  maximumStartupDurationSeconds: 0
   hostNetwork: false
 ---
 # Source: dataplane/templates/monitoring/prometheusrule.yaml
@@ -3688,16 +3692,21 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   jobLabel: app.kubernetes.io/name  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
@@ -3717,14 +3726,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-coredns
@@ -3747,14 +3761,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-controller-manager
@@ -3781,14 +3800,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
-    
+  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-etcd
@@ -3811,14 +3835,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-proxy
@@ -3841,14 +3870,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-scheduler
@@ -3874,13 +3908,18 @@ metadata:
     app: prometheus-kubelet    
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   attachMetadata:
     node: false
   jobLabel: k8s-app
@@ -3988,9 +4027,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -3998,6 +4037,11 @@ metadata:
     app.kubernetes.io/component: prometheus-operator
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   endpoints:
   - port: https
     scheme: https
@@ -4028,13 +4072,18 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-prometheus
@@ -4108,9 +4157,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4151,9 +4200,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4173,9 +4222,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4203,9 +4252,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4233,9 +4282,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4263,9 +4312,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4315,9 +4364,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4332,9 +4381,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4342,7 +4391,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -4381,9 +4430,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4398,9 +4447,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4408,7 +4457,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -54,13 +54,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
   namespace: kube-system
@@ -75,9 +75,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -98,9 +98,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 automountServiceAccountToken: true
@@ -613,13 +613,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 rules:
@@ -773,9 +773,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -883,9 +883,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 rules:
@@ -1120,13 +1120,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 roleRef:
@@ -1147,9 +1147,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1174,9 +1174,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 roleRef:
@@ -1399,22 +1399,22 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
   - name: "http"
     protocol: TCP
     port: 8080
+    nodePort: 0
     targetPort: 8080
   
   selector:    
@@ -1432,9 +1432,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1459,9 +1459,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1487,9 +1487,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1515,9 +1515,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1543,9 +1543,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1570,9 +1570,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1600,9 +1600,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
@@ -1803,13 +1803,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   selector:
@@ -1823,13 +1823,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.28.0
+        helm.sh/chart: kube-state-metrics-5.33.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.14.0"
+        app.kubernetes.io/version: "2.15.0"
         release: release-name
     spec:
       automountServiceAccountToken: true
@@ -1842,13 +1842,14 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -1893,9 +1894,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1914,9 +1915,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app: prometheus-operator
@@ -1925,19 +1926,19 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: "quay.io/prometheus-operator/prometheus-operator:v0.79.2"
+          image: "quay.io/prometheus-operator/prometheus-operator:v0.82.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --kubelet-service=kube-system/union-operator-kubelet
             - --kubelet-endpoints=true
             - --kubelet-endpointslice=false
             - --localhost=127.0.0.1
-            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.82.2
             - --config-reloader-cpu-request=0
             - --config-reloader-cpu-limit=0
             - --config-reloader-memory-request=0
             - --config-reloader-memory-limit=0
-            - --thanos-default-base-image=quay.io/thanos/thanos:v0.37.2
+            - --thanos-default-base-image=quay.io/thanos/thanos:v0.38.0
             - --secret-field-selector=type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1
             - --web.enable-tls=true
             - --web.cert-file=/cert/cert
@@ -2600,9 +2601,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -2640,15 +2641,15 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   automountServiceAccountToken: true
-  image: "quay.io/prometheus/prometheus:v3.1.0"
-  version: v3.1.0
+  image: "quay.io/prometheus/prometheus:v3.4.1"
+  version: v3.4.1
   externalUrl: http://union-operator-prometheus.union:80
   paused: false
   replicas: 1
@@ -2697,10 +2698,13 @@ spec:
         podAffinityTerm:
           topologyKey: kubernetes.io/hostname
           labelSelector:
-            matchExpressions:
-              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
-              - {key: prometheus, operator: In, values: [union-operator-prometheus]}
+            matchExpressions:            
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            - {key: app.kubernetes.io/instance, operator: In, values: [union-operator-prometheus]}
   portName: http-web
+  enforcedKeepDroppedTargets: 0
+  minReadySeconds: 0
+  maximumStartupDurationSeconds: 0
   hostNetwork: false
 ---
 # Source: dataplane/templates/monitoring/prometheusrule.yaml
@@ -3430,16 +3434,21 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   jobLabel: app.kubernetes.io/name  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
@@ -3459,14 +3468,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-coredns
@@ -3489,14 +3503,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-controller-manager
@@ -3523,14 +3542,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
-    
+  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-etcd
@@ -3553,14 +3577,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-proxy
@@ -3583,14 +3612,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-scheduler
@@ -3616,13 +3650,18 @@ metadata:
     app: prometheus-kubelet    
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   attachMetadata:
     node: false
   jobLabel: k8s-app
@@ -3730,9 +3769,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -3740,6 +3779,11 @@ metadata:
     app.kubernetes.io/component: prometheus-operator
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   endpoints:
   - port: https
     scheme: https
@@ -3770,13 +3814,18 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-prometheus
@@ -3850,9 +3899,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -3893,9 +3942,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -3915,9 +3964,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -3945,9 +3994,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -3975,9 +4024,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4005,9 +4054,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4057,9 +4106,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4074,9 +4123,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4084,7 +4133,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -4123,9 +4172,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4140,9 +4189,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4150,7 +4199,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -97,13 +97,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
   namespace: kube-system
@@ -118,9 +118,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -141,9 +141,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 automountServiceAccountToken: true
@@ -830,13 +830,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 rules:
@@ -990,9 +990,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1100,9 +1100,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 rules:
@@ -1358,13 +1358,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 roleRef:
@@ -1385,9 +1385,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1412,9 +1412,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 roleRef:
@@ -1739,22 +1739,22 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
   - name: "http"
     protocol: TCP
     port: 8080
+    nodePort: 0
     targetPort: 8080
   
   selector:    
@@ -1772,9 +1772,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1799,9 +1799,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1827,9 +1827,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1855,9 +1855,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1883,9 +1883,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1910,9 +1910,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1940,9 +1940,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
@@ -2340,13 +2340,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   selector:
@@ -2360,13 +2360,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.28.0
+        helm.sh/chart: kube-state-metrics-5.33.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.14.0"
+        app.kubernetes.io/version: "2.15.0"
         release: release-name
     spec:
       automountServiceAccountToken: true
@@ -2379,13 +2379,14 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2430,9 +2431,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -2451,9 +2452,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app: prometheus-operator
@@ -2462,19 +2463,19 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: "quay.io/prometheus-operator/prometheus-operator:v0.79.2"
+          image: "quay.io/prometheus-operator/prometheus-operator:v0.82.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --kubelet-service=kube-system/union-operator-kubelet
             - --kubelet-endpoints=true
             - --kubelet-endpointslice=false
             - --localhost=127.0.0.1
-            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.82.2
             - --config-reloader-cpu-request=0
             - --config-reloader-cpu-limit=0
             - --config-reloader-memory-request=0
             - --config-reloader-memory-limit=0
-            - --thanos-default-base-image=quay.io/thanos/thanos:v0.37.2
+            - --thanos-default-base-image=quay.io/thanos/thanos:v0.38.0
             - --secret-field-selector=type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1
             - --web.enable-tls=true
             - --web.cert-file=/cert/cert
@@ -3167,9 +3168,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -3207,15 +3208,15 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   automountServiceAccountToken: true
-  image: "quay.io/prometheus/prometheus:v3.1.0"
-  version: v3.1.0
+  image: "quay.io/prometheus/prometheus:v3.4.1"
+  version: v3.4.1
   externalUrl: http://union-operator-prometheus.union:80
   paused: false
   replicas: 1
@@ -3264,10 +3265,13 @@ spec:
         podAffinityTerm:
           topologyKey: kubernetes.io/hostname
           labelSelector:
-            matchExpressions:
-              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
-              - {key: prometheus, operator: In, values: [union-operator-prometheus]}
+            matchExpressions:            
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            - {key: app.kubernetes.io/instance, operator: In, values: [union-operator-prometheus]}
   portName: http-web
+  enforcedKeepDroppedTargets: 0
+  minReadySeconds: 0
+  maximumStartupDurationSeconds: 0
   hostNetwork: false
 ---
 # Source: dataplane/templates/monitoring/prometheusrule.yaml
@@ -4042,16 +4046,21 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   jobLabel: app.kubernetes.io/name  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
@@ -4071,14 +4080,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-coredns
@@ -4101,14 +4115,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-controller-manager
@@ -4135,14 +4154,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
-    
+  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-etcd
@@ -4165,14 +4189,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-proxy
@@ -4195,14 +4224,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-scheduler
@@ -4228,13 +4262,18 @@ metadata:
     app: prometheus-kubelet    
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   attachMetadata:
     node: false
   jobLabel: k8s-app
@@ -4342,9 +4381,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -4352,6 +4391,11 @@ metadata:
     app.kubernetes.io/component: prometheus-operator
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   endpoints:
   - port: https
     scheme: https
@@ -4382,13 +4426,18 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-prometheus
@@ -4462,9 +4511,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4505,9 +4554,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4527,9 +4576,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4557,9 +4606,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4587,9 +4636,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4617,9 +4666,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4669,9 +4718,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4686,9 +4735,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4696,7 +4745,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -4735,9 +4784,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4752,9 +4801,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4762,7 +4811,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -69,13 +69,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
   namespace: kube-system
@@ -90,9 +90,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -113,9 +113,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 automountServiceAccountToken: true
@@ -732,13 +732,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 rules:
@@ -892,9 +892,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1002,9 +1002,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 rules:
@@ -1273,13 +1273,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 roleRef:
@@ -1300,9 +1300,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1327,9 +1327,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 roleRef:
@@ -1589,22 +1589,22 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
   - name: "http"
     protocol: TCP
     port: 8080
+    nodePort: 0
     targetPort: 8080
   
   selector:    
@@ -1622,9 +1622,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1649,9 +1649,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1677,9 +1677,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1705,9 +1705,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1733,9 +1733,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1760,9 +1760,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1790,9 +1790,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
@@ -2188,13 +2188,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   selector:
@@ -2208,13 +2208,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.28.0
+        helm.sh/chart: kube-state-metrics-5.33.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.14.0"
+        app.kubernetes.io/version: "2.15.0"
         release: release-name
     spec:
       automountServiceAccountToken: true
@@ -2227,13 +2227,14 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2278,9 +2279,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -2299,9 +2300,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app: prometheus-operator
@@ -2310,19 +2311,19 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: "quay.io/prometheus-operator/prometheus-operator:v0.79.2"
+          image: "quay.io/prometheus-operator/prometheus-operator:v0.82.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --kubelet-service=kube-system/union-operator-kubelet
             - --kubelet-endpoints=true
             - --kubelet-endpointslice=false
             - --localhost=127.0.0.1
-            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.82.2
             - --config-reloader-cpu-request=0
             - --config-reloader-cpu-limit=0
             - --config-reloader-memory-request=0
             - --config-reloader-memory-limit=0
-            - --thanos-default-base-image=quay.io/thanos/thanos:v0.37.2
+            - --thanos-default-base-image=quay.io/thanos/thanos:v0.38.0
             - --secret-field-selector=type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1
             - --web.enable-tls=true
             - --web.cert-file=/cert/cert
@@ -2985,9 +2986,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -3025,15 +3026,15 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   automountServiceAccountToken: true
-  image: "quay.io/prometheus/prometheus:v3.1.0"
-  version: v3.1.0
+  image: "quay.io/prometheus/prometheus:v3.4.1"
+  version: v3.4.1
   externalUrl: http://union-operator-prometheus.union:80
   paused: false
   replicas: 1
@@ -3082,10 +3083,13 @@ spec:
         podAffinityTerm:
           topologyKey: kubernetes.io/hostname
           labelSelector:
-            matchExpressions:
-              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
-              - {key: prometheus, operator: In, values: [union-operator-prometheus]}
+            matchExpressions:            
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            - {key: app.kubernetes.io/instance, operator: In, values: [union-operator-prometheus]}
   portName: http-web
+  enforcedKeepDroppedTargets: 0
+  minReadySeconds: 0
+  maximumStartupDurationSeconds: 0
   hostNetwork: false
 ---
 # Source: dataplane/templates/monitoring/prometheusrule.yaml
@@ -3815,16 +3819,21 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   jobLabel: app.kubernetes.io/name  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
@@ -3844,14 +3853,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-coredns
@@ -3874,14 +3888,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-controller-manager
@@ -3908,14 +3927,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
-    
+  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-etcd
@@ -3938,14 +3962,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-proxy
@@ -3968,14 +3997,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-scheduler
@@ -4001,13 +4035,18 @@ metadata:
     app: prometheus-kubelet    
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   attachMetadata:
     node: false
   jobLabel: k8s-app
@@ -4115,9 +4154,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -4125,6 +4164,11 @@ metadata:
     app.kubernetes.io/component: prometheus-operator
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   endpoints:
   - port: https
     scheme: https
@@ -4155,13 +4199,18 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-prometheus
@@ -4235,9 +4284,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4278,9 +4327,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4300,9 +4349,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4330,9 +4379,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4360,9 +4409,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4390,9 +4439,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4442,9 +4491,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4459,9 +4508,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4469,7 +4518,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -4508,9 +4557,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4525,9 +4574,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4535,7 +4584,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -69,13 +69,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
   namespace: kube-system
@@ -90,9 +90,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -113,9 +113,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 automountServiceAccountToken: true
@@ -752,13 +752,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 rules:
@@ -912,9 +912,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1022,9 +1022,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 rules:
@@ -1280,13 +1280,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   name: release-name-kube-state-metrics
 roleRef:
@@ -1307,9 +1307,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1334,9 +1334,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 roleRef:
@@ -1582,22 +1582,22 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
   - name: "http"
     protocol: TCP
     port: 8080
+    nodePort: 0
     targetPort: 8080
   
   selector:    
@@ -1615,9 +1615,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1642,9 +1642,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1670,9 +1670,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1698,9 +1698,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1726,9 +1726,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
   namespace: kube-system
@@ -1753,9 +1753,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -1783,9 +1783,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
@@ -2080,13 +2080,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   selector:
@@ -2100,13 +2100,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.28.0
+        helm.sh/chart: kube-state-metrics-5.33.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.14.0"
+        app.kubernetes.io/version: "2.15.0"
         release: release-name
     spec:
       automountServiceAccountToken: true
@@ -2119,13 +2119,14 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2170,9 +2171,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -2191,9 +2192,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app: prometheus-operator
@@ -2202,19 +2203,19 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: "quay.io/prometheus-operator/prometheus-operator:v0.79.2"
+          image: "quay.io/prometheus-operator/prometheus-operator:v0.82.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --kubelet-service=kube-system/union-operator-kubelet
             - --kubelet-endpoints=true
             - --kubelet-endpointslice=false
             - --localhost=127.0.0.1
-            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.82.2
             - --config-reloader-cpu-request=0
             - --config-reloader-cpu-limit=0
             - --config-reloader-memory-request=0
             - --config-reloader-memory-limit=0
-            - --thanos-default-base-image=quay.io/thanos/thanos:v0.37.2
+            - --thanos-default-base-image=quay.io/thanos/thanos:v0.38.0
             - --secret-field-selector=type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1
             - --web.enable-tls=true
             - --web.cert-file=/cert/cert
@@ -2931,9 +2932,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -2971,15 +2972,15 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   automountServiceAccountToken: true
-  image: "quay.io/prometheus/prometheus:v3.1.0"
-  version: v3.1.0
+  image: "quay.io/prometheus/prometheus:v3.4.1"
+  version: v3.4.1
   externalUrl: http://union-operator-prometheus.union:80
   paused: false
   replicas: 1
@@ -3028,10 +3029,13 @@ spec:
         podAffinityTerm:
           topologyKey: kubernetes.io/hostname
           labelSelector:
-            matchExpressions:
-              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
-              - {key: prometheus, operator: In, values: [union-operator-prometheus]}
+            matchExpressions:            
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            - {key: app.kubernetes.io/instance, operator: In, values: [union-operator-prometheus]}
   portName: http-web
+  enforcedKeepDroppedTargets: 0
+  minReadySeconds: 0
+  maximumStartupDurationSeconds: 0
   hostNetwork: false
 ---
 # Source: dataplane/templates/monitoring/prometheusrule.yaml
@@ -3761,16 +3765,21 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: kube-system
   labels:    
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.14.0"
+    app.kubernetes.io/version: "2.15.0"
     release: release-name
 spec:
   jobLabel: app.kubernetes.io/name  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
@@ -3790,14 +3799,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-coredns
@@ -3820,14 +3834,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-controller-manager
@@ -3854,14 +3873,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
-    
+  
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-etcd
@@ -3884,14 +3908,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-proxy
@@ -3914,14 +3943,19 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   jobLabel: jobLabel
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-kube-scheduler
@@ -3947,13 +3981,18 @@ metadata:
     app: prometheus-kubelet    
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   attachMetadata:
     node: false
   jobLabel: k8s-app
@@ -4061,9 +4100,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app: prometheus-operator
@@ -4071,6 +4110,11 @@ metadata:
     app.kubernetes.io/component: prometheus-operator
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   endpoints:
   - port: https
     scheme: https
@@ -4101,13 +4145,18 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
 spec:
   
+  sampleLimit: 0
+  targetLimit: 0
+  labelLimit: 0
+  labelNameLengthLimit: 0
+  labelValueLengthLimit: 0
   selector:
     matchLabels:
       app: prometheus-prometheus
@@ -4181,9 +4230,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4224,9 +4273,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4246,9 +4295,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4276,9 +4325,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4306,9 +4355,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4336,9 +4385,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4388,9 +4437,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4405,9 +4454,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4415,7 +4464,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -4454,9 +4503,9 @@ metadata:
     
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "68.2.2"
+    app.kubernetes.io/version: "72.9.1"
     app.kubernetes.io/part-of: prometheus
-    chart: prometheus-68.2.2
+    chart: prometheus-72.9.1
     release: "release-name"
     heritage: "Helm"
     app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4471,9 +4520,9 @@ spec:
         
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "68.2.2"
+        app.kubernetes.io/version: "72.9.1"
         app.kubernetes.io/part-of: prometheus
-        chart: prometheus-68.2.2
+        chart: prometheus-72.9.1
         release: "release-name"
         heritage: "Helm"
         app.kubernetes.io/name: prometheus-prometheus-operator
@@ -4481,7 +4530,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
* Create Data plane ingress singular rule for App serving.
* Unrelated. Update kube-prometheus-stack to latest pinned version
  because there was a templating error in our previous build. This
  templating error caused `make generate-expected` to fail.
