### PR TITLE
Configurable app-serving auth and extra manifests

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -32,6 +32,17 @@ migrated to the "dataplane" service and will use these.
 {{- end }}
 
 {{/*
+Renders a complete tree, even values that contains template.
+*/}}
+{{- define "unionai-dataplane.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{ else }}
+    {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Output the cluster name
 */}}
 {{- define "getClusterName" -}}

--- a/charts/dataplane/templates/common/extra-manifests.yaml
+++ b/charts/dataplane/templates/common/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ include "unionai-dataplane.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/dataplane/templates/serving/knative-serving.yaml
+++ b/charts/dataplane/templates/serving/knative-serving.yaml
@@ -151,7 +151,7 @@ spec:
     - container: controller
       envVars:
       - name: KOURIER_UNION_AUTHZ_ENABLED
-        value: "true"
+        value: {{ .Values.serving.auth.enabled | quote }}
     {{- with index .Values.serving.resources "net-kourier-controller" }}
     resources:
     {{- range $container, $resources := . }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1040,6 +1040,12 @@ serving:
           cpu: 500m
           memory: 500Mi
 
+  # -- Union authentication and authorization configuration.
+  auth:
+    # -- Enable Union authentication and authorization envoy plugin.
+    # -- Disabling is common if not leveraging Union Cloud SSO.
+    enabled: true
+
 # Enable the knative operator.  Required for app serving.
 knative-operator:
   enabled: false
@@ -1155,3 +1161,6 @@ imageBuilder:
 
     # -- Additional volume mounts to add to the buildkit container
     additionalVolumeMounts: []
+
+## -- Extra Kubernetes objects to deploy with the helm chart
+extraObjects: []


### PR DESCRIPTION
* Make app-serving Union authn and authz enablement configurable
* Add support for adding arbitrary manifests via `extraObjects` pattern.
  E.g. supports ability to add alb ingress classes but can be extended
  to anything including Union future CRDs.
