### PR TITLE
Disable workspaces in selfhosted

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -231,6 +231,8 @@ services:
       annotations:
         eks.amazonaws.com/role-arn: executions-role # Placeholder for the actual role ARN
     configMap:
+      workspace:
+        enable: false
       sharedService:
         metrics:
           scope: "executions:"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -911,6 +911,8 @@ data:
       internalConnectionConfig:
         enabled: true
         urlPattern: '{{ service }}.union.svc.cluster.local:80'
+    workspace:
+      enable: false
 ---
 # Source: controlplane/templates/configmap.yaml
 ---


### PR DESCRIPTION
Workspaces rely on notification queues and currently we dont have  an offering for queues for onprem and hence we will need to disable this feature

Added config to disable it.