### PR TITLE
ingress-nginx, extraObjects, add override service secrets in controlplane

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -11,3 +11,8 @@ dependencies:
     alias: flyte
     repository: https://helm.flyte.org
     version: v1.16.0-b2
+  # Optionally use ingress-nginx for Ingresss controller.
+  - name: ingress-nginx
+    repository: https://kubernetes.github.io/ingress-nginx
+    version: 4.12.3
+    condition: ingress-nginx.enabled

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -219,6 +219,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- default .Release.Namespace .Values.forceNamespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "unionai.secretName" -}}
+{{- if .config.secretNameOverride }}
+{{- .config.secretNameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if and (hasKey .Values.global "service") (hasKey .Values.global.service "secretName") }}
+{{- .Values.global.service.secretName }}
+{{- else }}
+{{- include "unionai.fullname" . | trim -}}
+{{- end }}
+{{- end }}
 
 {{/*
 Selector labels
@@ -344,4 +353,13 @@ IfNotPresent
 {{- include "unionai.deepMerge" (dict "dest" $global "source" $svc) }}
 {{- end }}
 
-
+{{/*
+Renders a complete tree, even values that contains template.
+*/}}
+{{- define "unionai.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{ else }}
+    {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end -}}

--- a/charts/controlplane/templates/deployment.yaml
+++ b/charts/controlplane/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       volumes:
       - name: secrets
         secret:
-          secretName: {{ include "unionai.fullname" $service }}
+          secretName: {{ include "unionai.secretName" $service }}
       - name: config
         configMap:
           name: {{ include "unionai.fullname" $service }}

--- a/charts/controlplane/templates/extra-manifests.yaml
+++ b/charts/controlplane/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ include "unionai.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -732,3 +732,10 @@ objectstore:
 ingress:
   hostnames:
     -  #placeholder for the actual dns hostname of the control plane
+
+# Disable by default, but can be explicityl enabled if needed.
+ingress-nginx:
+  enabled: false
+
+# This section is for additional objects that can be added to the Helm chart.
+extraObjects: []

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -34,3 +34,8 @@ dependencies:
   version: 4.1.0
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
   condition: dcgm-exporter.enabled
+# Temporarily inclusion of ingress-nginx chart to enable an ingress method
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.12.3
+  condition: ingress-nginx.enabled

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1167,5 +1167,9 @@ imageBuilder:
     # -- Additional volume mounts to add to the buildkit container
     additionalVolumeMounts: []
 
+# Disable by default, but can be explicityl enabled if needed.
+ingress-nginx:
+  enabled: false
+
 ## -- Extra Kubernetes objects to deploy with the helm chart
 extraObjects: []

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -24,6 +24,7 @@ function generate {
     helm repo add fluent https://fluent.github.io/helm-charts
     helm repo add opencost https://opencost.github.io/opencost-helm-chart
     helm repo add nvidia https://nvidia.github.io/dcgm-exporter/helm-charts
+    helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
     helm dependency build ${CHARTS_DIR}/${CHART}
     helm dep update ${CHARTS_DIR}/${CHART}
     helm template ${CHARTS_DIR}/${CHART} \


### PR DESCRIPTION
* Adds ingrss-nginx controller to `controlplane` and `dataplane`,
  default to disabled.
  * Adding to both to allow users to run dataplane or controlplane in
    isolation.
* Add `extraObjects` in controlplane to allow users to deploy extra
  Kubernetes manifests.
* Add support for overriding secrets in controlplane
