### PR TITLE
Fix ingress class inclusion and remove default ingress class annotation

### DIFF
--- a/charts/controlplane/templates/common/_dataproxy-ingress.yaml
+++ b/charts/controlplane/templates/common/_dataproxy-ingress.yaml
@@ -20,6 +20,9 @@ metadata:
   {{- end}}
   {{- end}}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:

--- a/charts/controlplane/templates/common/_ingress-protected.yaml
+++ b/charts/controlplane/templates/common/_ingress-protected.yaml
@@ -1111,6 +1111,9 @@ spec:
   {{- include "protectedDefaultBackend" . | nindent 2 -}}
   {{- end}}
   {{- end}}
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if  .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:
@@ -1149,6 +1152,9 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end}}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:
@@ -1189,6 +1195,9 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end}}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:

--- a/charts/controlplane/templates/common/_ingress-unprotected.yaml
+++ b/charts/controlplane/templates/common/_ingress-unprotected.yaml
@@ -201,6 +201,9 @@ metadata:
   annotations: {{ tpl (toYaml .) $ | nindent 4}}
   {{- end }}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:
@@ -237,6 +240,9 @@ metadata:
   {{- toYaml . | nindent 4}}
   {{- end }}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:
@@ -271,6 +277,9 @@ metadata:
   {{- toYaml . | nindent 4}}
   {{- end }}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:

--- a/charts/controlplane/templates/common/_usage-ingress.yaml
+++ b/charts/controlplane/templates/common/_usage-ingress.yaml
@@ -76,6 +76,9 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
   {{- end }}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:
@@ -118,6 +121,9 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
   {{- end }}
 spec:
+  {{- with .Values.flyte.common.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.flyte.common.ingress.tls.enabled }}
   tls:
   - hosts:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -409,7 +409,6 @@ flyte:
       albSSLRedirect: false
       separateGrpcIngress: true
       annotations:
-        kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/app-root: /console
         # Set RPS (requests per second) to 100, Burst is automatically computed to be 5x that number. If we decide to
         # bump rps, we should consider setting Burst separately through `limit-burst-multiplier`

--- a/charts/dataplane/templates/common/ingress.yaml
+++ b/charts/dataplane/templates/common/ingress.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.serving.class | quote }}
+  {{- with .Values.ingress.serving.class }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- with .Values.ingress.serving.tls }}
   tls:
     {{ toYaml . | nindent 4 }}
@@ -42,7 +44,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.dataproxy.class | quote }}
+  {{- with .Values.ingress.dataproxy.class }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- with .Values.ingress.dataproxy.tls }}
   tls:
     {{ toYaml . | nindent 4 }}

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -4088,7 +4088,6 @@ metadata:
   name: controlplane-console-protected
   namespace: union
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -2624,7 +2624,6 @@ metadata:
   name: controlplane-dataproxy
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -2680,7 +2679,6 @@ metadata:
   name: controlplane-usage-grpc
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -2737,7 +2735,6 @@ metadata:
   name: controlplane-usage
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -2794,7 +2791,6 @@ metadata:
   name: controlplane-protected
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3180,7 +3176,6 @@ metadata:
   name: controlplane-protected-grpc
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3607,7 +3602,6 @@ metadata:
   name: controlplane-protected-grpc-streaming
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3791,7 +3785,6 @@ metadata:
   name: controlplane
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3991,7 +3984,6 @@ metadata:
   name: controlplane-grpc
   namespace: union
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -4048,7 +4040,6 @@ metadata:
   name: controlplane-grpc-streaming
   namespace: union
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -2624,7 +2624,6 @@ metadata:
   name: controlplane-dataproxy
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -2680,7 +2679,6 @@ metadata:
   name: controlplane-usage-grpc
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -2731,7 +2729,6 @@ metadata:
   name: controlplane-usage
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -2782,7 +2779,6 @@ metadata:
   name: controlplane-protected
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3168,7 +3164,6 @@ metadata:
   name: controlplane-protected-grpc
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3595,7 +3590,6 @@ metadata:
   name: controlplane-protected-grpc-streaming
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3779,7 +3773,6 @@ metadata:
   name: controlplane
   namespace: union
   annotations: 
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -3979,7 +3972,6 @@ metadata:
   name: controlplane-grpc
   namespace: union
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"
@@ -4036,7 +4028,6 @@ metadata:
   name: controlplane-grpc-streaming
   namespace: union
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -4076,7 +4076,6 @@ metadata:
   name: controlplane-console-protected
   namespace: union
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/app-root: /console
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "100"

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -2859,7 +2859,6 @@ metadata:
     app.kubernetes.io/name: dataplane
     app.kubernetes.io/instance: release-name
 spec:
-  ingressClassName: ""
   rules:
   - host: "*.apps.union.us-west-2.union.ai"
     http:
@@ -2882,7 +2881,6 @@ metadata:
     app.kubernetes.io/name: dataplane
     app.kubernetes.io/instance: release-name
 spec:
-  ingressClassName: ""
   rules:
     - host: union.us-west-2.union.ai
       http:


### PR DESCRIPTION
* Include explicit ingress class only when nonempty string
* Remove default nginx ingress class annotation
