### PR TITLE
Add cache service for the controlplane

### DIFF
--- a/charts/controlplane/templates/cacheservice/configmap.yaml
+++ b/charts/controlplane/templates/cacheservice/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.flyte.cacheservice.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cacheservice-config
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "cacheservice.labels" . | nindent 4 }}
+data:
+{{- with .Values.flyte.db.cacheservice }}
+  db.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+{{- with .Values.flyte.configmap.logger }}
+  logger.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+{{- with .Values.flyte.configmap.cacheserviceServer }}
+  server.yaml: | {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+  storage.yaml: | {{ tpl (include "cacheservice-storage" .) $ | nindent 4 }}
+{{- end }}

--- a/charts/controlplane/templates/cacheservice/deployment.yaml
+++ b/charts/controlplane/templates/cacheservice/deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.flyte.cacheservice.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "cacheservice.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "cacheservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.flyte.cacheservice.replicaCount }}
+  selector:
+    matchLabels: {{ include "cacheservice.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        configChecksum: {{ include (print .Template.BasePath "/cacheservice/configmap.yaml") . | sha256sum | trunc 63 | quote }}
+        {{- with .Values.flyte.cacheservice.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels: {{ include "cacheservice.podLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.flyte.cacheservice.securityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flyte.cacheservice.priorityClassName }}
+      priorityClassName: {{ .Values.flyte.cacheservice.priorityClassName }}
+      {{- end }}
+      initContainers:
+      - command:
+        - cacheservice
+        - --config
+        - {{ .Values.flyte.cacheservice.configPath }}
+        - migrate
+        - run
+        image: "{{ .Values.flyte.cacheservice.image.repository }}:{{ .Values.flyte.cacheservice.image.tag }}"
+        imagePullPolicy: "{{ .Values.flyte.cacheservice.image.pullPolicy }}"
+        name: run-migrations
+        volumeMounts: {{- include "cacheservice-databaseSecret.volumeMount" . | nindent 8 }}
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+        {{- if .Values.flyte.cacheservice.podEnv }}
+        env:
+          {{- with .Values.flyte.cacheservice.podEnv }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      containers:
+      - command:
+        - cacheservice
+        - --config
+        - {{ .Values.flyte.cacheservice.configPath }}
+        - serve
+        {{- with .Values.flyte.cacheservice.extraArgs }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+        {{- if .Values.flyte.cacheservice.podEnv }}
+        env:
+          {{- with .Values.flyte.cacheservice.podEnv }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
+        image: "{{ .Values.flyte.cacheservice.image.repository }}:{{ .Values.flyte.cacheservice.image.tag }}"
+        imagePullPolicy: "{{ .Values.flyte.cacheservice.image.pullPolicy }}"
+        name: cacheservice
+        ports:
+        - containerPort: 8088
+        - containerPort: 8089
+        - containerPort: {{ index .Values.flyte.configmap.cacheserviceServer.cacheservice "profiler-port" }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources: {{- toYaml .Values.flyte.cacheservice.resources | nindent 10 }}
+        volumeMounts: {{- include "cacheservice-databaseSecret.volumeMount" . | nindent 8 }}
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+        {{- with .Values.flyte.cacheservice.additionalVolumeMounts -}}
+        {{ tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with .Values.flyte.cacheservice.additionalContainers -}}
+      {{- tpl (toYaml .) $ | nindent 6}}
+      {{- end }}
+      serviceAccountName: {{ template "cacheservice.name" . }}
+      volumes: {{- include "cacheservice-databaseSecret.volume" . | nindent 6 }}
+      - emptyDir: {}
+        name: shared-data
+      - configMap:
+          name: cacheservice-config
+        name: config-volume
+      {{- with .Values.flyte.cacheservice.additionalVolumes -}}
+      {{ tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      {{- with .Values.flyte.cacheservice.nodeSelector }}
+      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.flyte.cacheservice.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.flyte.cacheservice.tolerations }}
+      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/controlplane/templates/cacheservice/rbac.yaml
+++ b/charts/controlplane/templates/cacheservice/rbac.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.flyte.cacheservice.enabled }}
+---
+{{- if .Values.flyte.cacheservice.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cacheservice.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "cacheservice.labels" . | nindent 4 }}
+  {{- with .Values.flyte.cacheservice.serviceAccount.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+{{- with .Values.flyte.cacheservice.serviceAccount.imagePullSecrets }}
+imagePullSecrets: {{ tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/controlplane/templates/cacheservice/service.yaml
+++ b/charts/controlplane/templates/cacheservice/service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.flyte.cacheservice.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cacheservice.name" . }}
+  namespace: {{ template "flyte.namespace" . }}
+  labels: {{ include "cacheservice.labels" . | nindent 4 }}
+  {{- with .Values.flyte.cacheservice.service.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.flyte.cacheservice.service.type}}
+  type: {{ . }}
+  {{- end }}
+  ports:
+  - name: http
+    port: 88
+    protocol: TCP
+    targetPort: 8088
+  - name: grpc
+    port: 89
+    protocol: TCP
+    targetPort: 8089
+  - name: http-metrics
+    protocol: TCP
+    port: 10254
+  {{- with .Values.flyte.cacheservice.service.additionalPorts -}}
+  {{ tpl (toYaml .) $ | nindent 2 }}
+  {{- end }}
+  selector: {{ include "cacheservice.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -380,6 +380,66 @@ flyte:
     enabled: false
   cluster_resource_manager:
     enabled: false
+  cacheservice:
+    enabled: true
+    replicaCount: 1
+    image:
+      repository: "" # -- Set the repository for the private cacheservice image"
+      tag: "" # -- Set the tag for the private cacheservice datacatalog image
+      pullPolicy: "" # -- Set the pull policy for the private cacheservice  image
+    serviceAccount:
+      # -- If the service account is created by you, make this false
+      create: true
+      annotations:
+      # -- Set the role arn for the cacheservice service account which has access to the S3 bucket
+    resources:
+      limits:
+        cpu: 1
+        ephemeral-storage: 200Mi
+      requests:
+        cpu: 500m
+        ephemeral-storage: 200Mi
+        memory: 200Mi
+    configPath: /etc/cacheservice/config/*.yaml
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cacheservice
+            topologyKey: kubernetes.io/hostname
+
+    service:
+      annotations: { }
+      type: ClusterIP
+    # -- Annotations for Cacheservice pods
+    podAnnotations: { }
+    # -- Additional Cacheservice container environment variables
+    podEnv: { }
+    # -- Labels for Cacheservice pods
+    podLabels: { }
+    # -- nodeSelector for Cacheservice deployment
+    nodeSelector: { }
+    # -- tolerations for Cacheservice deployment
+    tolerations: [ ]
+    # -- Appends additional volumes to the deployment spec. May include template values.
+    additionalVolumes: [ ]
+    # -- Appends additional volume mounts to the main container's spec. May include template values.
+    additionalVolumeMounts: [ ]
+    # -- Appends additional containers to the deployment spec. May include template values.
+    additionalContainers: [ ]
+    # -- Appends extra command line arguments to the main command
+    extraArgs: { }
+    # -- Sets priorityClassName for cacheservice pod(s).
+    priorityClassName: ""
+    # -- Sets securityContext for cacheservice pod(s).
+    securityContext:
+      runAsNonRoot: true
+      fsGroup: 1001
+      runAsUser: 1001
+      fsGroupChangePolicy: "OnRootMismatch"
+      seLinuxOptions:
+        type: spc_t
   common:
     databaseSecret:
       name: db-pass
@@ -495,16 +555,6 @@ flyte:
         maxOpenConnections: 20
         connMaxLifeTime: 120s
   configmap:
-    cacheserviceServer:
-      union:
-        internalConnectionConfig:
-          enabled: true
-          urlPattern: '{{ printf "_SERVICE_.%s.svc.cluster.local:80" .Release.Namespace }}'
-      authorizer:
-        type: "Noop"
-        internalCommunicationConfig:
-          enabled: false
-
     adminServer:
       admin:
         flyteadmin:
@@ -576,6 +626,36 @@ flyte:
         internalConnectionConfig:
           enabled: true
           urlPattern: '{{ printf "_SERVICE_.%s.svc.cluster.local:80" .Release.Namespace }}'
+    cacheserviceServer:
+      union:
+        internalConnectionConfig:
+          enabled: true
+          urlPattern: '{{ printf "_SERVICE_.%s.svc.cluster.local:80" .Release.Namespace }}'
+      authorizer:
+        type: "Noop"
+        internalCommunicationConfig:
+          enabled: false
+      cacheservice:
+        storage-prefix: cached_outputs
+        metrics-scope: flyte
+        profiler-port: 10254
+        heartbeat-grace-period-multiplier: 3
+        max-reservation-heartbeat: 30s
+      cache-server:
+        grpcPort: 8089
+        httpPort: 8080
+        grpcServerReflection: true
+      otel:
+        type: otlpgrpc
+        otlpgrpc:
+          endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+        sampler:
+          parentSampler: traceid
+          traceIdRatio: 0.001
+      private:
+        app:
+          cacheProviderConfig:
+            kind: bypass
   cloudEvents:
     enable: false
   workflow_notifications:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -145,6 +145,18 @@ metadata:
     helm.sh/chart: flyte-v1.16.0-b2
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: controlplane/templates/cacheservice/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -615,6 +627,72 @@ data:
     scheduler:
       metricsScope: 'flyte:'
       profilerPort: 10254
+---
+# Source: controlplane/templates/cacheservice/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cacheservice-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+data:
+  db.yaml: | 
+    database:
+      connMaxLifeTime: 120s
+      dbname: cacheservice
+      host: 'db-instance-url'
+      maxIdleConnections: 10
+      maxOpenConnections: 20
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: 'dbUser'
+  server.yaml: | 
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache-server:
+      grpcPort: 8089
+      grpcServerReflection: true
+      httpPort: 8080
+    cacheservice:
+      heartbeat-grace-period-multiplier: 3
+      max-reservation-heartbeat: 30s
+      metrics-scope: flyte
+      profiler-port: 10254
+      storage-prefix: cached_outputs
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    private:
+      app:
+        cacheProviderConfig:
+          kind: bypass
+    union:
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '_SERVICE_.union.svc.cluster.local:80'
+  storage.yaml: | 
+    storage:
+      type: s3
+      container: "bucketName"
+      connection:
+        auth-type: iam
+        region: us-east-2
+      enable-multicontainer: false
+      limits:
+        maxDownloadMBs: 10
+      cache:
+        max_size_mbs: 1024
+        target_gc_percent: 70
 ---
 # Source: controlplane/templates/configmap.yaml
 apiVersion: v1
@@ -1148,6 +1226,35 @@ spec:
     targetPort: 8089
   selector: 
     app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/cacheservice/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 88
+    protocol: TCP
+    targetPort: 8088
+  - name: grpc
+    port: 89
+    protocol: TCP
+    targetPort: 8089
+  - name: http-metrics
+    protocol: TCP
+    port: 10254
+  selector: 
+    app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
 ---
 # Source: controlplane/templates/service.yaml
@@ -1796,6 +1903,107 @@ spec:
       - name: auth
         secret:
           secretName: flyte-secret-auth
+---
+# Source: controlplane/templates/cacheservice/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: cacheservice
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        configChecksum: "3d9830acd051375eb4f700aa7786b85350af28da1ad5d1dcea0a297da64b915"
+      labels: 
+        app.kubernetes.io/name: cacheservice
+        app.kubernetes.io/instance: release-name
+        helm.sh/chart: controlplane-2025.5.6
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext: 
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+        runAsUser: 1001
+        seLinuxOptions:
+          type: spc_t
+      initContainers:
+      - command:
+        - cacheservice
+        - --config
+        - /etc/cacheservice/config/*.yaml
+        - migrate
+        - run
+        image: ":"
+        imagePullPolicy: ""
+        name: run-migrations
+        volumeMounts:
+        - mountPath: /etc/db
+          name: db-pass
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      containers:
+      - command:
+        - cacheservice
+        - --config
+        - /etc/cacheservice/config/*.yaml
+        - serve
+        image: ":"
+        imagePullPolicy: ""
+        name: cacheservice
+        ports:
+        - containerPort: 8088
+        - containerPort: 8089
+        - containerPort: 10254
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: 1
+            ephemeral-storage: 200Mi
+          requests:
+            cpu: 500m
+            ephemeral-storage: 200Mi
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/db
+          name: db-pass
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+      serviceAccountName: cacheservice
+      volumes:
+      - name: db-pass
+        secret:
+          secretName: db-pass
+      - emptyDir: {}
+        name: shared-data
+      - configMap:
+          name: cacheservice-config
+        name: config-volume
+      affinity: 
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cacheservice
+            topologyKey: kubernetes.io/hostname
 ---
 # Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -145,6 +145,18 @@ metadata:
     helm.sh/chart: flyte-v1.16.0-b2
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: controlplane/templates/cacheservice/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -615,6 +627,72 @@ data:
     scheduler:
       metricsScope: 'flyte:'
       profilerPort: 10254
+---
+# Source: controlplane/templates/cacheservice/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cacheservice-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+data:
+  db.yaml: | 
+    database:
+      connMaxLifeTime: 120s
+      dbname: cacheservice
+      host: 'db-instance-url'
+      maxIdleConnections: 10
+      maxOpenConnections: 20
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: 'dbUser'
+  server.yaml: | 
+    authorizer:
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+    cache-server:
+      grpcPort: 8089
+      grpcServerReflection: true
+      httpPort: 8080
+    cacheservice:
+      heartbeat-grace-period-multiplier: 3
+      max-reservation-heartbeat: 30s
+      metrics-scope: flyte
+      profiler-port: 10254
+      storage-prefix: cached_outputs
+    otel:
+      otlpgrpc:
+        endpoint: http://otel-collector.monitoring.svc.cluster.local:4317
+      sampler:
+        parentSampler: traceid
+        traceIdRatio: 0.001
+      type: otlpgrpc
+    private:
+      app:
+        cacheProviderConfig:
+          kind: bypass
+    union:
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '_SERVICE_.union.svc.cluster.local:80'
+  storage.yaml: | 
+    storage:
+      type: s3
+      container: "bucketName"
+      connection:
+        auth-type: iam
+        region: us-east-2
+      enable-multicontainer: false
+      limits:
+        maxDownloadMBs: 10
+      cache:
+        max_size_mbs: 1024
+        target_gc_percent: 70
 ---
 # Source: controlplane/templates/configmap.yaml
 apiVersion: v1
@@ -1148,6 +1226,35 @@ spec:
     targetPort: 8089
   selector: 
     app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/cacheservice/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 88
+    protocol: TCP
+    targetPort: 8088
+  - name: grpc
+    port: 89
+    protocol: TCP
+    targetPort: 8089
+  - name: http-metrics
+    protocol: TCP
+    port: 10254
+  selector: 
+    app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
 ---
 # Source: controlplane/templates/service.yaml
@@ -1796,6 +1903,107 @@ spec:
       - name: auth
         secret:
           secretName: flyte-secret-auth
+---
+# Source: controlplane/templates/cacheservice/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2025.5.6
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: cacheservice
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        configChecksum: "3d9830acd051375eb4f700aa7786b85350af28da1ad5d1dcea0a297da64b915"
+      labels: 
+        app.kubernetes.io/name: cacheservice
+        app.kubernetes.io/instance: release-name
+        helm.sh/chart: controlplane-2025.5.6
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext: 
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+        runAsUser: 1001
+        seLinuxOptions:
+          type: spc_t
+      initContainers:
+      - command:
+        - cacheservice
+        - --config
+        - /etc/cacheservice/config/*.yaml
+        - migrate
+        - run
+        image: ":"
+        imagePullPolicy: ""
+        name: run-migrations
+        volumeMounts:
+        - mountPath: /etc/db
+          name: db-pass
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      containers:
+      - command:
+        - cacheservice
+        - --config
+        - /etc/cacheservice/config/*.yaml
+        - serve
+        image: ":"
+        imagePullPolicy: ""
+        name: cacheservice
+        ports:
+        - containerPort: 8088
+        - containerPort: 8089
+        - containerPort: 10254
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: 1
+            ephemeral-storage: 200Mi
+          requests:
+            cpu: 500m
+            ephemeral-storage: 200Mi
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/db
+          name: db-pass
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+      serviceAccountName: cacheservice
+      volumes:
+      - name: db-pass
+        secret:
+          secretName: db-pass
+      - emptyDir: {}
+        name: shared-data
+      - configMap:
+          name: cacheservice-config
+        name: config-volume
+      affinity: 
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cacheservice
+            topologyKey: kubernetes.io/hostname
 ---
 # Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
Registered flytesnacks lifecycle examples which demonstrate caching
https://github.com/flyteorg/flytesnacks/releases/tag/v0.3.341


Verified the cache was written 
https://selfhosted.cloud-staging.union.ai/console/projects/union-health-monitoring/domains/development/executions/a4flvt2fjblrzgcnr4h4/nodes

Verified this was all read from the cache

https://selfhosted.cloud-staging.union.ai/console/projects/union-health-monitoring/domains/development/executions/a25cmtvp79ldbqbnhbrn/nodes