### PR TITLE
fix(knative): use repo URL instead of file

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -23,11 +23,11 @@ dependencies:
   condition: metrics-server.enabled
   alias: metrics-server
 - name: knative-operator-crds
-  repository: file://../knative-operator-crds
+  repository: https://unionai.github.io/helm-charts
   version: 2026.4.5
   condition: knative-operator-crds.enabled
 - name: knative-operator
-  repository: file://../knative-operator
+  repository: https://unionai.github.io/helm-charts
   version: 2026.4.5
   alias: knative-operator
   condition: knative-operator.enabled


### PR DESCRIPTION
## Overview
The PR https://github.com/unionai/helm-charts/pull/335 bumped the `knative-operator-*` versions to ``, and when it was merged to main the were pushed. Now that they exist, we can update the repo URL to use the actual helm repos instead of the `file://...` directive.

### Tests
Validated the new versions exist
```
❯ helm search repo unionai/knative-operator --versions | grep "2026.4.5"
unionai/knative-operator        2026.4.5        1.16.0          Deploys Knative Operator                          
unionai/knative-operator-crds   2026.4.5        1.16.0          Knative Operator CRDs (KnativeServing, KnativeE...
```