### PR TITLE
Revert "Revert "Default to Shadow mode when reporting usage from operator""

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,8 +3,8 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.4.6
-appVersion: 2026.4.6
+version: 2026.4.7
+appVersion: 2026.4.7
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane-crds
 description: Deploys the Union dataplane CRDs.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.4.4
-appVersion: 2026.4.1
+version: 2026.4.5
+appVersion: 2026.4.5
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: prometheus-operator-crds

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.4.6
-appVersion: 2026.4.6
+version: 2026.4.7
+appVersion: 2026.4.7
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -521,9 +521,9 @@ config:
     collectUsages:
       # -- Enable usage collection in the operator service.
       enabled: true
-    # -- Billing model: None, Legacy, or ResourceUsage.
+    # -- Billing model: None, Legacy, Shadow, or ResourceUsage.
     billing:
-      model: "Legacy"
+      model: "Shadow"
     # -- Heartbeat check configuration.
     dependenciesHeartbeat:
       # -- Define the propeller health check endpoint.

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.4.4
-appVersion: 2026.3.6
+version: 2026.4.5
+appVersion: 2026.4.5
 kubeVersion: '>= 1.28.0'

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -226,7 +226,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/console/serviceaccount.yaml
@@ -235,10 +235,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -248,10 +248,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -260,10 +260,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -272,10 +272,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -284,10 +284,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -296,10 +296,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -308,10 +308,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -320,10 +320,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -333,10 +333,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -595,7 +595,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -666,10 +666,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -730,10 +730,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -805,10 +805,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -868,10 +868,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -954,10 +954,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1023,10 +1023,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1092,10 +1092,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5815,7 +5815,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -5888,7 +5888,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6022,7 +6022,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6049,10 +6049,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6077,10 +6077,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6116,10 +6116,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6155,10 +6155,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6190,10 +6190,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6225,10 +6225,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6260,10 +6260,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6295,10 +6295,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6823,7 +6823,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -6834,7 +6834,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "de3ef8a50756203ade985224212d015678e27b399650b8f40091473fb20f268"
+        configChecksum: "197f4097faabcce1c83bbd79953460800854d6b92837333f3dd60c6c1bfa14a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -6843,7 +6843,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.6
+        helm.sh/chart: controlplane-2026.4.7
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -6935,10 +6935,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6976,7 +6976,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.6"
+        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.7"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7000,10 +7000,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7039,7 +7039,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7113,10 +7113,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7152,7 +7152,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7168,7 +7168,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7242,10 +7242,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7281,7 +7281,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7352,10 +7352,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7391,7 +7391,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7407,7 +7407,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7478,10 +7478,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7518,7 +7518,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -7534,7 +7534,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -7605,10 +7605,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7644,7 +7644,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7660,7 +7660,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7732,10 +7732,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7771,7 +7771,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -7878,10 +7878,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -226,7 +226,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/console/serviceaccount.yaml
@@ -235,10 +235,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -248,10 +248,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -260,10 +260,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -272,10 +272,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -284,10 +284,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -296,10 +296,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -308,10 +308,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -320,10 +320,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -333,10 +333,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -595,7 +595,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -666,10 +666,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -730,10 +730,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -805,10 +805,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -868,10 +868,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -954,10 +954,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1023,10 +1023,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1092,10 +1092,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5815,7 +5815,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -5888,7 +5888,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6022,7 +6022,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6049,10 +6049,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6077,10 +6077,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6116,10 +6116,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6155,10 +6155,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6190,10 +6190,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6225,10 +6225,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6260,10 +6260,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6295,10 +6295,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6823,7 +6823,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -6834,7 +6834,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "de3ef8a50756203ade985224212d015678e27b399650b8f40091473fb20f268"
+        configChecksum: "197f4097faabcce1c83bbd79953460800854d6b92837333f3dd60c6c1bfa14a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -6844,7 +6844,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.6
+        helm.sh/chart: controlplane-2026.4.7
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -6936,10 +6936,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6978,7 +6978,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.6"
+        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.7"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7002,10 +7002,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7042,7 +7042,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7116,10 +7116,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7156,7 +7156,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7172,7 +7172,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7246,10 +7246,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7286,7 +7286,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7357,10 +7357,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7397,7 +7397,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7413,7 +7413,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7484,10 +7484,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7525,7 +7525,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -7541,7 +7541,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -7612,10 +7612,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7652,7 +7652,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7668,7 +7668,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7740,10 +7740,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7780,7 +7780,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -7881,10 +7881,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -224,7 +224,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/console/serviceaccount.yaml
@@ -233,10 +233,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -246,10 +246,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -258,10 +258,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -270,10 +270,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -282,10 +282,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -294,10 +294,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -306,10 +306,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -318,10 +318,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -331,10 +331,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -596,7 +596,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -667,10 +667,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -735,10 +735,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -810,10 +810,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -873,10 +873,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -959,10 +959,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1028,10 +1028,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1097,10 +1097,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5820,7 +5820,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -5893,7 +5893,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6027,7 +6027,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6054,10 +6054,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6082,10 +6082,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6121,10 +6121,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6160,10 +6160,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6195,10 +6195,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6230,10 +6230,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6265,10 +6265,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6300,10 +6300,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6828,7 +6828,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -6839,7 +6839,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4d7f0f53604d15cd65eb3db1ba902baa354c56816734fb6d356aeed2685c30a"
+        configChecksum: "2417c396d3583bf5ae2dc5221fe6fe53fb4ee6a37bb02bc0b6b875e2ec2aaa7"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -6848,7 +6848,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.6
+        helm.sh/chart: controlplane-2026.4.7
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -6940,10 +6940,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6981,7 +6981,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.6"
+        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.7"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7005,10 +7005,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7044,7 +7044,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7118,10 +7118,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7157,7 +7157,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7173,7 +7173,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7247,10 +7247,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7286,7 +7286,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7357,10 +7357,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7396,7 +7396,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7412,7 +7412,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7483,10 +7483,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7523,7 +7523,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -7539,7 +7539,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -7610,10 +7610,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7649,7 +7649,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7665,7 +7665,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7737,10 +7737,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7776,7 +7776,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -7883,10 +7883,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -226,7 +226,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/console/serviceaccount.yaml
@@ -235,10 +235,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -248,10 +248,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -260,10 +260,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -272,10 +272,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -284,10 +284,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -296,10 +296,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -308,10 +308,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -320,10 +320,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -333,10 +333,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -595,7 +595,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -666,10 +666,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -730,10 +730,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -805,10 +805,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -868,10 +868,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -954,10 +954,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1023,10 +1023,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1092,10 +1092,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5815,7 +5815,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -5888,7 +5888,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6022,7 +6022,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6049,10 +6049,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6077,10 +6077,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6116,10 +6116,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6155,10 +6155,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6190,10 +6190,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6225,10 +6225,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6260,10 +6260,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6295,10 +6295,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6823,7 +6823,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -6834,7 +6834,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "de3ef8a50756203ade985224212d015678e27b399650b8f40091473fb20f268"
+        configChecksum: "197f4097faabcce1c83bbd79953460800854d6b92837333f3dd60c6c1bfa14a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -6843,7 +6843,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.6
+        helm.sh/chart: controlplane-2026.4.7
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -6935,10 +6935,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6976,7 +6976,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.6"
+        image: "643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/unionconsole:2026.4.7"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7000,10 +7000,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7039,7 +7039,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7113,10 +7113,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7152,7 +7152,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7168,7 +7168,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7242,10 +7242,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7281,7 +7281,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7352,10 +7352,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7391,7 +7391,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7407,7 +7407,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7478,10 +7478,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7518,7 +7518,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -7534,7 +7534,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -7605,10 +7605,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7644,7 +7644,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7660,7 +7660,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7732,10 +7732,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7771,7 +7771,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.6
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -7872,10 +7872,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.6
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -3166,7 +3166,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9310,7 +9310,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9f173d6f4412c91858e16604240da14386ec2ff7f861d554d9b98d78ed9cc94"
+        configChecksum: "1b59c3a9b98c82b9efa61b11a7d19a48678684bea7190029705b79d22befedc"
         prometheus.io/scrape: "true"
       labels:
         
@@ -9447,7 +9447,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9f173d6f4412c91858e16604240da14386ec2ff7f861d554d9b98d78ed9cc94"
+        configChecksum: "1b59c3a9b98c82b9efa61b11a7d19a48678684bea7190029705b79d22befedc"
         prometheus.io/scrape: "true"
       labels:
         

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9229,7 +9229,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9337,7 +9337,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9405,7 +9405,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9472,7 +9472,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9582,7 +9582,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9821,10 +9821,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9871,10 +9871,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -3180,7 +3180,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9334,7 +9334,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a4359544543680d66ed71cdcd8fea9460540ea8b9d6a7d8de7cb28b48e4c200"
+        configChecksum: "4cb605165bcbafa41070d90c8a61b0fb2102174accce94041dd87fa7e20de68"
         
       labels:
         
@@ -9469,7 +9469,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a4359544543680d66ed71cdcd8fea9460540ea8b9d6a7d8de7cb28b48e4c200"
+        configChecksum: "4cb605165bcbafa41070d90c8a61b0fb2102174accce94041dd87fa7e20de68"
         
       labels:
         

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9253,7 +9253,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9359,7 +9359,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9427,7 +9427,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9492,7 +9492,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9600,7 +9600,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9839,10 +9839,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9889,10 +9889,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3340,7 +3340,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9816,7 +9816,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e3f97d434a07515ae9564430aa1a80b3a89374b92a7241fe2c2fdb64266e1ce"
+        configChecksum: "4a4c2425b13312e08ab6037aafa8f457c262ed50d0b65985635ee22c971ed81"
         
       labels:
         
@@ -9951,7 +9951,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e3f97d434a07515ae9564430aa1a80b3a89374b92a7241fe2c2fdb64266e1ce"
+        configChecksum: "4a4c2425b13312e08ab6037aafa8f457c262ed50d0b65985635ee22c971ed81"
         
       labels:
         

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -9735,7 +9735,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9841,7 +9841,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9909,7 +9909,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9974,7 +9974,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10082,7 +10082,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10408,10 +10408,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10458,10 +10458,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9228,7 +9228,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9334,7 +9334,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9402,7 +9402,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9467,7 +9467,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9575,7 +9575,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9934,10 +9934,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9984,10 +9984,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -3167,7 +3167,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9309,7 +9309,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a354659ec6780321ee929320da221164a5a26a636d8d421e4b9418e542b31fd"
+        configChecksum: "75cc95f1f9fdc790165c940934bf967f9f23aeb1f2db6fa07651eb88379998b"
         
       labels:
         
@@ -9444,7 +9444,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a354659ec6780321ee929320da221164a5a26a636d8d421e4b9418e542b31fd"
+        configChecksum: "75cc95f1f9fdc790165c940934bf967f9f23aeb1f2db6fa07651eb88379998b"
         
       labels:
         

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -3292,7 +3292,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9768,7 +9768,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b7464b41c6e640059db085f351b8de1b9426fd12ccfcc95146b5f338b1a6338"
+        configChecksum: "15078554163114187e6191f07b791dcd033dd3cd7ccca6f3fc54f9540df8e05"
         
       labels:
         
@@ -9903,7 +9903,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b7464b41c6e640059db085f351b8de1b9426fd12ccfcc95146b5f338b1a6338"
+        configChecksum: "15078554163114187e6191f07b791dcd033dd3cd7ccca6f3fc54f9540df8e05"
         
       labels:
         

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -9687,7 +9687,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9793,7 +9793,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9861,7 +9861,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9926,7 +9926,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10034,7 +10034,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10303,10 +10303,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10353,10 +10353,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -3203,7 +3203,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9359,7 +9359,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7dce40cadaab9d761e4b05c6e57bfb4d664999f4293ef014176d1b8fe03e595"
+        configChecksum: "bf26331f6c4ad12975cdfe53d4d09c3d5520eee22d7abdaca1156a926344d47"
         
       labels:
         
@@ -9495,7 +9495,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7dce40cadaab9d761e4b05c6e57bfb4d664999f4293ef014176d1b8fe03e595"
+        configChecksum: "bf26331f6c4ad12975cdfe53d4d09c3d5520eee22d7abdaca1156a926344d47"
         
       labels:
         

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9278,7 +9278,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9385,7 +9385,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9453,7 +9453,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9519,7 +9519,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9628,7 +9628,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9867,10 +9867,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9917,10 +9917,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -3203,7 +3203,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9359,7 +9359,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "24634feef8600f3ccf6cb02dcb3860eb7cd4b9f1ffd973eb9eff97f5e2756b3"
+        configChecksum: "b270461ed900b2258d647b1f92a2b105f8ea7af699ab7e85f2b7c2685d7c3c0"
         
       labels:
         
@@ -9495,7 +9495,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "24634feef8600f3ccf6cb02dcb3860eb7cd4b9f1ffd973eb9eff97f5e2756b3"
+        configChecksum: "b270461ed900b2258d647b1f92a2b105f8ea7af699ab7e85f2b7c2685d7c3c0"
         
       labels:
         

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9278,7 +9278,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9385,7 +9385,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9453,7 +9453,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9519,7 +9519,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9628,7 +9628,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9867,10 +9867,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9917,10 +9917,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -3166,7 +3166,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9320,7 +9320,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1cbf9bb44767576a0ce2cfe30facbef94a1d54963db0d92bea7b5e1c1df350d"
+        configChecksum: "f76ed732cc918762bb81694f9a363bae383e4affd0ffabf6148cda45ff950ee"
         
       labels:
         
@@ -9455,7 +9455,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1cbf9bb44767576a0ce2cfe30facbef94a1d54963db0d92bea7b5e1c1df350d"
+        configChecksum: "f76ed732cc918762bb81694f9a363bae383e4affd0ffabf6148cda45ff950ee"
         
       labels:
         

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9239,7 +9239,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9345,7 +9345,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9413,7 +9413,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9478,7 +9478,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9586,7 +9586,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9825,10 +9825,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9875,10 +9875,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3289,7 +3289,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9645,7 +9645,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1cbf9bb44767576a0ce2cfe30facbef94a1d54963db0d92bea7b5e1c1df350d"
+        configChecksum: "f76ed732cc918762bb81694f9a363bae383e4affd0ffabf6148cda45ff950ee"
         
       labels:
         
@@ -9780,7 +9780,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1cbf9bb44767576a0ce2cfe30facbef94a1d54963db0d92bea7b5e1c1df350d"
+        configChecksum: "f76ed732cc918762bb81694f9a363bae383e4affd0ffabf6148cda45ff950ee"
         
       labels:
         

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -9564,7 +9564,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9670,7 +9670,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9738,7 +9738,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9803,7 +9803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9911,7 +9911,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10180,10 +10180,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10230,10 +10230,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -3170,7 +3170,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9314,7 +9314,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bb0a9121a9efbaa78a6516acc004f1c9cbc14775f49cb50de140ec933213962"
+        configChecksum: "59d80f60083c64b440e5d87ea3ed06590e2076b924f941bf2bc054d7d195b7f"
         
       labels:
         
@@ -9418,7 +9418,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bb0a9121a9efbaa78a6516acc004f1c9cbc14775f49cb50de140ec933213962"
+        configChecksum: "59d80f60083c64b440e5d87ea3ed06590e2076b924f941bf2bc054d7d195b7f"
         
       labels:
         

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9237,7 +9237,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9336,7 +9336,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9438,7 +9438,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9544,7 +9544,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9906,10 +9906,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9956,10 +9956,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -3173,7 +3173,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9321,7 +9321,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c6d4293594a69380b3811417ec589d33d98a6e913ebfe236e370a497af7de76"
+        configChecksum: "762fa67e0a8a1ad90ef507b4cc3d857e052f0b66b5fba757e26a1f4756a4928"
         
       labels:
         
@@ -9456,7 +9456,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c6d4293594a69380b3811417ec589d33d98a6e913ebfe236e370a497af7de76"
+        configChecksum: "762fa67e0a8a1ad90ef507b4cc3d857e052f0b66b5fba757e26a1f4756a4928"
         
       labels:
         

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9240,7 +9240,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9346,7 +9346,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9414,7 +9414,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9479,7 +9479,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9587,7 +9587,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9826,10 +9826,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9876,10 +9876,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -3185,7 +3185,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9339,7 +9339,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5f2a1d1f489bd8eec047919bba6d5046eaa4349289ae15c3410882a224a4037"
+        configChecksum: "838119f4c9c0fd4a26a02a1697875269bdb5b4ca3fff3aaa8b0a3f125a6bd28"
         
       labels:
         
@@ -9474,7 +9474,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5f2a1d1f489bd8eec047919bba6d5046eaa4349289ae15c3410882a224a4037"
+        configChecksum: "838119f4c9c0fd4a26a02a1697875269bdb5b4ca3fff3aaa8b0a3f125a6bd28"
         
       labels:
         

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9258,7 +9258,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9364,7 +9364,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9432,7 +9432,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9497,7 +9497,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9605,7 +9605,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9844,10 +9844,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9894,10 +9894,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -3987,7 +3987,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -11427,7 +11427,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "51e140ef07908a5d02c6821f38e9947b5630807e493b9b60fa5cb810beb541c"
+        configChecksum: "0ca563348cef6608aded7a7babc3b90eca84494275788a21cfac84c61dfd1de"
         
       labels:
         
@@ -11562,7 +11562,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "51e140ef07908a5d02c6821f38e9947b5630807e493b9b60fa5cb810beb541c"
+        configChecksum: "0ca563348cef6608aded7a7babc3b90eca84494275788a21cfac84c61dfd1de"
         
       labels:
         

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -11346,7 +11346,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -11452,7 +11452,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -11520,7 +11520,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -11585,7 +11585,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -11693,7 +11693,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -16386,10 +16386,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -16436,10 +16436,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -8691,7 +8691,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9384,7 +9384,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9490,7 +9490,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9558,7 +9558,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9623,7 +9623,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9731,7 +9731,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9970,10 +9970,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10020,10 +10020,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -3183,7 +3183,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9465,7 +9465,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1cbf9bb44767576a0ce2cfe30facbef94a1d54963db0d92bea7b5e1c1df350d"
+        configChecksum: "f76ed732cc918762bb81694f9a363bae383e4affd0ffabf6148cda45ff950ee"
         
       labels:
         
@@ -9600,7 +9600,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1cbf9bb44767576a0ce2cfe30facbef94a1d54963db0d92bea7b5e1c1df350d"
+        configChecksum: "f76ed732cc918762bb81694f9a363bae383e4affd0ffabf6148cda45ff950ee"
         
       labels:
         

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9274,7 +9274,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9394,7 +9394,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9468,7 +9468,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9541,7 +9541,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9663,7 +9663,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.6"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9916,10 +9916,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.6
+    helm.sh/chart: dataplane-2026.4.7
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.6"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9966,10 +9966,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.6
+      helm.sh/chart: dataplane-2026.4.7
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.6"
+      app.kubernetes.io/version: "2026.4.7"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3195,7 +3195,7 @@ data:
       collectUsages:
         enabled: false
       billing:
-        model: Legacy
+        model: Shadow
       dependenciesHeartbeat:
         executor:
           endpoint: 'http://union-operator-executor:10254'
@@ -9369,7 +9369,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0770e2f78b475354622f69d9572955275f4b84354e7ad382a3b6c94736a36d5"
+        configChecksum: "9639e74a895b45c9e878425df7d7443f3bdbd35512d98eb6c2c55a29fa54015"
         
       labels:
         
@@ -9518,7 +9518,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0770e2f78b475354622f69d9572955275f4b84354e7ad382a3b6c94736a36d5"
+        configChecksum: "9639e74a895b45c9e878425df7d7443f3bdbd35512d98eb6c2c55a29fa54015"
         
       labels:
         


### PR DESCRIPTION
Reverts unionai/helm-charts#338

Fixes forward with the 2026.4.7 Cloud image release 

Following https://www.notion.so/Self-hosted-managed-Helm-Chart-Release-Workflow-1c28cc06513d80abbe86d30290a5f008#9bd1dc20eb494463873fbae978dfc8b6

I published a new cloud image [here](https://buildkite.com/unionai/publish-images-release/builds/40), I ran make gen_version_bump and `For sandbox and dataplane-crds charts, update the appVersion to match the chart version since they do not rely on any specific app version.`