### PR TITLE
dataplane: include fluentbit additionalOutputs in template

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1017,6 +1017,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .Values.fluentbit.additionalOutputs }}
+{{ . }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This allows users to configure additional fluentbit outputs from the `values.yaml` files