### PR TITLE
Release 2026.4.8

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,8 +3,8 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.4.7
-appVersion: 2026.4.7
+version: 2026.4.8
+appVersion: 2026.4.8
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.4.7
-appVersion: 2026.4.7
+version: 2026.4.8
+appVersion: 2026.4.8
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -243,7 +243,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -254,10 +254,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -267,10 +267,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -279,10 +279,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -291,10 +291,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -303,10 +303,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -315,10 +315,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -327,10 +327,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -339,10 +339,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -351,10 +351,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -364,10 +364,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -622,7 +622,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -688,10 +688,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -785,10 +785,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -874,10 +874,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -951,10 +951,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1062,10 +1062,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1146,10 +1146,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1229,10 +1229,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1312,10 +1312,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -6164,7 +6164,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6218,7 +6218,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6378,7 +6378,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6405,10 +6405,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6433,10 +6433,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6472,10 +6472,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6511,10 +6511,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6546,10 +6546,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6581,10 +6581,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6620,10 +6620,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6655,10 +6655,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6690,10 +6690,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7231,7 +7231,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7242,7 +7242,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9cc1443a3602745c7c15fc1c3ab5f2742d34a170e66340f04e4ced50fda172a"
+        configChecksum: "ad21815847261cda3d9de91278b1be00b6fa81828b137a083e802c6f733b0e1"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7251,7 +7251,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.7
+        helm.sh/chart: controlplane-2026.4.8
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7343,10 +7343,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7386,7 +7386,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.8"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7413,10 +7413,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7454,7 +7454,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7528,10 +7528,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7569,7 +7569,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7585,7 +7585,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7659,10 +7659,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7700,7 +7700,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7771,10 +7771,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7812,7 +7812,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7828,7 +7828,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7899,10 +7899,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7940,7 +7940,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -7956,7 +7956,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8030,10 +8030,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8072,7 +8072,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8088,7 +8088,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8159,10 +8159,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8200,7 +8200,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8216,7 +8216,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8288,10 +8288,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8329,7 +8329,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -8436,10 +8436,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -243,7 +243,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -254,10 +254,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -267,10 +267,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -279,10 +279,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -291,10 +291,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -303,10 +303,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -315,10 +315,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -327,10 +327,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -339,10 +339,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -351,10 +351,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -364,10 +364,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -622,7 +622,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -688,10 +688,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -785,10 +785,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -874,10 +874,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -951,10 +951,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1062,10 +1062,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1146,10 +1146,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1229,10 +1229,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1312,10 +1312,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -6164,7 +6164,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6218,7 +6218,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6378,7 +6378,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6405,10 +6405,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6433,10 +6433,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6472,10 +6472,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6511,10 +6511,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6546,10 +6546,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6581,10 +6581,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6620,10 +6620,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6655,10 +6655,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6690,10 +6690,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7231,7 +7231,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7242,7 +7242,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9cc1443a3602745c7c15fc1c3ab5f2742d34a170e66340f04e4ced50fda172a"
+        configChecksum: "ad21815847261cda3d9de91278b1be00b6fa81828b137a083e802c6f733b0e1"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7252,7 +7252,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.7
+        helm.sh/chart: controlplane-2026.4.8
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7344,10 +7344,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7388,7 +7388,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.8"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7415,10 +7415,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7457,7 +7457,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7531,10 +7531,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7573,7 +7573,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7589,7 +7589,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7663,10 +7663,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7705,7 +7705,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7776,10 +7776,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7818,7 +7818,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7834,7 +7834,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7905,10 +7905,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7947,7 +7947,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -7963,7 +7963,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8037,10 +8037,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8080,7 +8080,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8096,7 +8096,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8167,10 +8167,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8209,7 +8209,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8225,7 +8225,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8297,10 +8297,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8339,7 +8339,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -8440,10 +8440,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -243,7 +243,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -256,10 +256,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -269,10 +269,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -281,10 +281,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -293,10 +293,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -305,10 +305,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -317,10 +317,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -329,10 +329,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -341,10 +341,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -353,10 +353,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -366,10 +366,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -632,7 +632,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -703,10 +703,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -800,10 +800,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -889,10 +889,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -966,10 +966,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1077,10 +1077,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1161,10 +1161,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1244,10 +1244,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1327,10 +1327,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -6182,7 +6182,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6236,7 +6236,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6396,7 +6396,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6423,10 +6423,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6451,10 +6451,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6490,10 +6490,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6529,10 +6529,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6564,10 +6564,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6599,10 +6599,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6638,10 +6638,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6673,10 +6673,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6708,10 +6708,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7249,7 +7249,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7260,7 +7260,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "197f4097faabcce1c83bbd79953460800854d6b92837333f3dd60c6c1bfa14a"
+        configChecksum: "a90023924ca434ed5a3c4a4b90164aae63e98d889ff1c4997a98f44338d8abd"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7269,7 +7269,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.7
+        helm.sh/chart: controlplane-2026.4.8
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7361,10 +7361,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7404,7 +7404,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.8"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7431,10 +7431,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7472,7 +7472,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7546,10 +7546,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7587,7 +7587,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7603,7 +7603,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7677,10 +7677,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7718,7 +7718,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7789,10 +7789,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7830,7 +7830,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7846,7 +7846,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7917,10 +7917,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7958,7 +7958,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -7974,7 +7974,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8048,10 +8048,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8090,7 +8090,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8106,7 +8106,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8177,10 +8177,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8218,7 +8218,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8234,7 +8234,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8306,10 +8306,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8347,7 +8347,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -8454,10 +8454,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -241,7 +241,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -252,10 +252,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -265,10 +265,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -277,10 +277,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -289,10 +289,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -301,10 +301,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -313,10 +313,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -325,10 +325,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -337,10 +337,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -349,10 +349,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -362,10 +362,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -623,7 +623,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -689,10 +689,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -790,10 +790,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -879,10 +879,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -956,10 +956,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1067,10 +1067,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1151,10 +1151,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1234,10 +1234,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1317,10 +1317,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -6169,7 +6169,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6223,7 +6223,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6383,7 +6383,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6410,10 +6410,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6438,10 +6438,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6477,10 +6477,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6516,10 +6516,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6551,10 +6551,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6586,10 +6586,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6625,10 +6625,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6660,10 +6660,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6695,10 +6695,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7236,7 +7236,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7247,7 +7247,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "75e457c226bf09461d9def0e9a1adcda9fa3aeca040274f300d371da47d2a82"
+        configChecksum: "2f6b15006e37e8dbd25d0de5beb495005870f59853e75f3776f52208052e73b"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7256,7 +7256,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.7
+        helm.sh/chart: controlplane-2026.4.8
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7348,10 +7348,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7391,7 +7391,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.8"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7418,10 +7418,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7459,7 +7459,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7533,10 +7533,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7574,7 +7574,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7590,7 +7590,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7664,10 +7664,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7705,7 +7705,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7776,10 +7776,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7817,7 +7817,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7833,7 +7833,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7904,10 +7904,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7945,7 +7945,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -7961,7 +7961,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8035,10 +8035,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8077,7 +8077,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8093,7 +8093,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8164,10 +8164,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8205,7 +8205,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8221,7 +8221,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8293,10 +8293,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8334,7 +8334,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -8441,10 +8441,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -55,10 +55,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -258,10 +258,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
@@ -273,7 +273,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -284,10 +284,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -297,10 +297,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -309,10 +309,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -321,10 +321,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -333,10 +333,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -345,10 +345,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -357,10 +357,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -369,10 +369,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -381,10 +381,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -394,10 +394,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -649,10 +649,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -698,7 +698,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -764,10 +764,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -861,10 +861,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -950,10 +950,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1027,10 +1027,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1138,10 +1138,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1222,10 +1222,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1305,10 +1305,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1388,10 +1388,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -6237,10 +6237,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -6256,7 +6256,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6307,10 +6307,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6330,7 +6330,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6486,10 +6486,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6512,7 +6512,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6539,10 +6539,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6567,10 +6567,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6606,10 +6606,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6645,10 +6645,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6680,10 +6680,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6715,10 +6715,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6754,10 +6754,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6789,10 +6789,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6824,10 +6824,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7362,10 +7362,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7380,7 +7380,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8bda5502d8cb82e6d35a0d7495c605eba4ea4137a8294c0149d7b60dafb1d458
+        checksum/config: 114003f8c75cced775e3d2b32988b5f5c989b37ebf61a5bed20bd14b259361f5
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7406,7 +7406,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -7481,7 +7481,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7492,7 +7492,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9cc1443a3602745c7c15fc1c3ab5f2742d34a170e66340f04e4ced50fda172a"
+        configChecksum: "ad21815847261cda3d9de91278b1be00b6fa81828b137a083e802c6f733b0e1"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7501,7 +7501,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.7
+        helm.sh/chart: controlplane-2026.4.8
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7593,10 +7593,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7636,7 +7636,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.8"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7663,10 +7663,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7704,7 +7704,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7778,10 +7778,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7819,7 +7819,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7835,7 +7835,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7909,10 +7909,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7950,7 +7950,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8021,10 +8021,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8062,7 +8062,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8078,7 +8078,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8149,10 +8149,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8190,7 +8190,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8206,7 +8206,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8280,10 +8280,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8322,7 +8322,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8338,7 +8338,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8409,10 +8409,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8450,7 +8450,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8466,7 +8466,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8538,10 +8538,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8579,7 +8579,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.4.7
+          image: registry.unionai.cloud/controlplane/services:2026.4.8
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -8680,10 +8680,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -8706,10 +8706,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.8
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9229,7 +9229,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9337,7 +9337,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9405,7 +9405,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9472,7 +9472,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9582,7 +9582,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9900,10 +9900,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9950,10 +9950,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9253,7 +9253,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9359,7 +9359,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9427,7 +9427,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9492,7 +9492,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9600,7 +9600,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9918,10 +9918,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9968,10 +9968,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -9735,7 +9735,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9841,7 +9841,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9909,7 +9909,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9974,7 +9974,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10082,7 +10082,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10487,10 +10487,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10537,10 +10537,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9228,7 +9228,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9334,7 +9334,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9402,7 +9402,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9467,7 +9467,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9575,7 +9575,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10013,10 +10013,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10063,10 +10063,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -9687,7 +9687,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9793,7 +9793,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9861,7 +9861,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9926,7 +9926,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10034,7 +10034,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10382,10 +10382,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10432,10 +10432,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9278,7 +9278,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9385,7 +9385,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9453,7 +9453,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9519,7 +9519,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9628,7 +9628,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9946,10 +9946,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9996,10 +9996,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9278,7 +9278,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9385,7 +9385,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9453,7 +9453,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9519,7 +9519,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9628,7 +9628,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9946,10 +9946,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9996,10 +9996,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9239,7 +9239,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9345,7 +9345,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9413,7 +9413,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9478,7 +9478,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9586,7 +9586,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9904,10 +9904,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9954,10 +9954,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -9564,7 +9564,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9670,7 +9670,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9738,7 +9738,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9803,7 +9803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9911,7 +9911,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10259,10 +10259,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10309,10 +10309,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9237,7 +9237,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9336,7 +9336,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9438,7 +9438,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9544,7 +9544,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9985,10 +9985,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10035,10 +10035,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9240,7 +9240,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9346,7 +9346,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9414,7 +9414,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9479,7 +9479,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9587,7 +9587,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9905,10 +9905,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9955,10 +9955,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9258,7 +9258,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9364,7 +9364,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9432,7 +9432,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9497,7 +9497,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9605,7 +9605,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9923,10 +9923,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -9973,10 +9973,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -11346,7 +11346,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -11452,7 +11452,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -11520,7 +11520,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -11585,7 +11585,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -11693,7 +11693,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -16465,10 +16465,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -16515,10 +16515,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -8691,7 +8691,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9384,7 +9384,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9490,7 +9490,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9558,7 +9558,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9623,7 +9623,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9731,7 +9731,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10049,10 +10049,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10099,10 +10099,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9274,7 +9274,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9394,7 +9394,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9468,7 +9468,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9541,7 +9541,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9663,7 +9663,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.7"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.4.8"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -9995,10 +9995,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.4.7
+    helm.sh/chart: dataplane-2026.4.8
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10045,10 +10045,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.4.7
+      helm.sh/chart: dataplane-2026.4.8
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.4.7"
+      app.kubernetes.io/version: "2026.4.8"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:


### PR DESCRIPTION
## Release 2026.4.8 — Notable Changes
                                                                                                                                 
### Chart Changes (`helm-charts`, since `*-2026.4.7`)
                                                                                                                                                              
- **[#342](https://github.com/unionai/helm-charts/pull/342)** — fluentbit: support `additionalFilters` and `extraParsers` values
- **[#341](https://github.com/unionai/helm-charts/pull/341)** — dataplane: include fluentbit `additionalOutputs` in template

### Controlplane Image Change (`unionai/cloud`)

- **[#15423](https://github.com/unionai/cloud/pull/15423)** — Upgrade codemirror plugin in `clientsv2/` (Union Console)
                                                                                                                                                              
