### PR TITLE
Add selfhosted authorizer defaults and dashboard fixes

### DIFF
--- a/charts/controlplane/dashboards/union-controlplane-overview.json
+++ b/charts/controlplane/dashboards/union-controlplane-overview.json
@@ -2299,12 +2299,12 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:update_status:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+              "expr": "cluster:svc:update_status:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
               "legendFormat": "UpdateStatus p95",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:heartbeat:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+              "expr": "cluster:svc:heartbeat:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
               "legendFormat": "Heartbeat p95",
               "refId": "B"
             }
@@ -2581,17 +2581,17 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "rate(flyte:cacheservice:cache:cache_hit{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(flyte:cacheservice:cache:cache_hit_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Hits",
               "refId": "A"
             },
             {
-              "expr": "rate(flyte:cacheservice:cache:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(flyte:cacheservice:cache:not_found_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Misses",
               "refId": "B"
             },
             {
-              "expr": "rate(flyte:cacheservice:cache:get_failure{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(flyte:cacheservice:cache:get_failure_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Get failures",
               "refId": "C"
             }
@@ -2628,17 +2628,17 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "rate(flyte:cacheservice:cache:reservation_contention{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(flyte:cacheservice:cache:reservation_contention_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Contention",
               "refId": "A"
             },
             {
-              "expr": "rate(flyte:cacheservice:cache:get_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(flyte:cacheservice:cache:get_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Reservation acquired",
               "refId": "B"
             },
             {
-              "expr": "rate(flyte:cacheservice:cache:release_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(flyte:cacheservice:cache:release_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Reservation released",
               "refId": "C"
             }
@@ -2689,12 +2689,12 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Allowed",
               "refId": "A"
             },
             {
-              "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
+              "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
               "legendFormat": "Denied",
               "refId": "B"
             }
@@ -2731,17 +2731,17 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.5\"}",
+              "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.9\"}",
+              "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
               "legendFormat": "p90",
               "refId": "B"
             },
             {
-              "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.99\"}",
+              "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
               "legendFormat": "p99",
               "refId": "C"
             }
@@ -2778,7 +2778,7 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+              "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
               "legendFormat": "Deny %",
               "refId": "A"
             }
@@ -2807,10 +2807,14 @@
                 {
                   "type": "value",
                   "options": {
-                    "noop": { "text": "Noop", "index": 0 },
-                    "userclouds": { "text": "UserClouds", "index": 1 },
-                    "external": { "text": "External", "index": 2 },
-                    "authorizer": { "text": "Authorizer", "index": 3 }
+                    "Noop": { "text": "Noop", "index": 0 },
+                    "noop": { "text": "Noop", "index": 1 },
+                    "UserClouds": { "text": "UserClouds", "index": 2 },
+                    "userclouds": { "text": "UserClouds", "index": 3 },
+                    "External": { "text": "External", "index": 4 },
+                    "external": { "text": "External", "index": 5 },
+                    "Authorizer": { "text": "Authorizer", "index": 6 },
+                    "authorizer": { "text": "Authorizer", "index": 7 }
                   }
                 }
               ]
@@ -3366,17 +3370,17 @@
           "type": "timeseries",
           "targets": [
             {
-              "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.5\"}",
+              "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.9\"}",
+              "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
               "legendFormat": "p90",
               "refId": "B"
             },
             {
-              "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.99\"}",
+              "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
               "legendFormat": "p99",
               "refId": "C"
             }

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -412,19 +412,8 @@ services:
       #
       # Supported types:
       #   - "Noop"       — no enforcement (default)
-      #   - "UserClouds" — Union Cloud's authorization backend
+      #   - "UserClouds" — Union RBAC (just set type, defaults are pre-configured)
       #   - "External"   — customer-provided gRPC authorization server (selfhosted)
-      #
-      # --- Union Cloud (UserClouds) ---
-      # For Union Cloud deployments, set type to "UserClouds":
-      #   authorizer:
-      #     type: "UserClouds"
-      #     userCloudsClient:
-      #       tenantUrl: 'http://{{ .Release.Name }}-union-authz.{{ .Release.Namespace }}.svc.cluster.local:8080'
-      #       tenantID: '623771e7-ddd6-4575-bedb-7c970ec75b87'
-      #       clientID: '{{ .Values.union.authz.clientID }}'
-      #       clientSecretName: 'union/client_secret'
-      #       enableLogging: true
       #
       # --- External Authorization (selfhosted) ---
       # For selfhosted deployments with a customer-provided authz server:
@@ -467,6 +456,31 @@ services:
           forwardHeaders:
             - authorization
             - flyte-authorization
+        # --- UserClouds client defaults (pre-configured) ---
+        # These defaults are used when type is set to "UserClouds" (Union RBAC).
+        # They are ignored when type is "Noop" or "External".
+        # To enable Union RBAC, just change type to "UserClouds" — no other
+        # configuration is needed. Override individual fields only if your
+        # deployment uses non-standard naming or secrets.
+        userCloudsClient:
+          tenantUrl: 'http://{{ .Release.Name }}-union-authz.{{ .Release.Namespace }}.svc.cluster.local:8080'
+          tenantID: '623771e7-ddd6-4575-bedb-7c970ec75b87'
+          clientID: '{{ .Values.union.authz.clientID }}'
+          clientSecretName: 'union/client_secret'
+          enableLogging: true
+        internalCommunicationConfig:
+          enabled: false
+        bootstrap:
+          organization: ""
+          domains:
+            - development
+            - staging
+            - production
+          projects: []
+          serviceAccounts: []
+          adminUsers: []
+          retryInterval: 5s
+          maxRetries: 30
       sharedService:
         connectPort: 8081
         metrics:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -682,12 +682,31 @@ data:
         grpcConfig:
           host: dns:///authorizer.union.svc.cluster.local:80
           insecure: true
+      bootstrap:
+        adminUsers: []
+        domains:
+        - development
+        - staging
+        - production
+        maxRetries: 30
+        organization: ""
+        projects: []
+        retryInterval: 5s
+        serviceAccounts: []
       externalClient:
         forwardHeaders:
         - authorization
         - flyte-authorization
+      internalCommunicationConfig:
+        enabled: false
       type: Noop
       useExternalIdentity: 'false'
+      userCloudsClient:
+        clientID: 'union-authz-client'
+        clientSecretName: union/client_secret
+        enableLogging: true
+        tenantID: 623771e7-ddd6-4575-bedb-7c970ec75b87
+        tenantUrl: http://release-name-union-authz.union.svc.cluster.local:8080
     cache:
       identity:
         enabled: false
@@ -3576,12 +3595,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:update_status:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:update_status:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "UpdateStatus p95",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:heartbeat:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:heartbeat:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "Heartbeat p95",
                   "refId": "B"
                 }
@@ -3858,17 +3877,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:cache_hit{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:cache_hit_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Hits",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:not_found_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Misses",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_failure{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_failure_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Get failures",
                   "refId": "C"
                 }
@@ -3905,17 +3924,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:reservation_contention{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:reservation_contention_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Contention",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation acquired",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation released",
                   "refId": "C"
                 }
@@ -3966,12 +3985,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Allowed",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Denied",
                   "refId": "B"
                 }
@@ -4008,17 +4027,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }
@@ -4055,7 +4074,7 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
                   "legendFormat": "Deny %",
                   "refId": "A"
                 }
@@ -4084,10 +4103,14 @@ data:
                     {
                       "type": "value",
                       "options": {
-                        "noop": { "text": "Noop", "index": 0 },
-                        "userclouds": { "text": "UserClouds", "index": 1 },
-                        "external": { "text": "External", "index": 2 },
-                        "authorizer": { "text": "Authorizer", "index": 3 }
+                        "Noop": { "text": "Noop", "index": 0 },
+                        "noop": { "text": "Noop", "index": 1 },
+                        "UserClouds": { "text": "UserClouds", "index": 2 },
+                        "userclouds": { "text": "UserClouds", "index": 3 },
+                        "External": { "text": "External", "index": 4 },
+                        "external": { "text": "External", "index": 5 },
+                        "Authorizer": { "text": "Authorizer", "index": 6 },
+                        "authorizer": { "text": "Authorizer", "index": 7 }
                       }
                     }
                   ]
@@ -4643,17 +4666,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -682,12 +682,31 @@ data:
         grpcConfig:
           host: dns:///authorizer.union.svc.cluster.local:80
           insecure: true
+      bootstrap:
+        adminUsers: []
+        domains:
+        - development
+        - staging
+        - production
+        maxRetries: 30
+        organization: ""
+        projects: []
+        retryInterval: 5s
+        serviceAccounts: []
       externalClient:
         forwardHeaders:
         - authorization
         - flyte-authorization
+      internalCommunicationConfig:
+        enabled: false
       type: Noop
       useExternalIdentity: 'false'
+      userCloudsClient:
+        clientID: 'union-authz-client'
+        clientSecretName: union/client_secret
+        enableLogging: true
+        tenantID: 623771e7-ddd6-4575-bedb-7c970ec75b87
+        tenantUrl: http://release-name-union-authz.union.svc.cluster.local:8080
     cache:
       identity:
         enabled: false
@@ -3576,12 +3595,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:update_status:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:update_status:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "UpdateStatus p95",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:heartbeat:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:heartbeat:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "Heartbeat p95",
                   "refId": "B"
                 }
@@ -3858,17 +3877,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:cache_hit{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:cache_hit_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Hits",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:not_found_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Misses",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_failure{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_failure_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Get failures",
                   "refId": "C"
                 }
@@ -3905,17 +3924,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:reservation_contention{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:reservation_contention_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Contention",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation acquired",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation released",
                   "refId": "C"
                 }
@@ -3966,12 +3985,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Allowed",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Denied",
                   "refId": "B"
                 }
@@ -4008,17 +4027,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }
@@ -4055,7 +4074,7 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
                   "legendFormat": "Deny %",
                   "refId": "A"
                 }
@@ -4084,10 +4103,14 @@ data:
                     {
                       "type": "value",
                       "options": {
-                        "noop": { "text": "Noop", "index": 0 },
-                        "userclouds": { "text": "UserClouds", "index": 1 },
-                        "external": { "text": "External", "index": 2 },
-                        "authorizer": { "text": "Authorizer", "index": 3 }
+                        "Noop": { "text": "Noop", "index": 0 },
+                        "noop": { "text": "Noop", "index": 1 },
+                        "UserClouds": { "text": "UserClouds", "index": 2 },
+                        "userclouds": { "text": "UserClouds", "index": 3 },
+                        "External": { "text": "External", "index": 4 },
+                        "external": { "text": "External", "index": 5 },
+                        "Authorizer": { "text": "Authorizer", "index": 6 },
+                        "authorizer": { "text": "Authorizer", "index": 7 }
                       }
                     }
                   ]
@@ -4643,17 +4666,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -683,6 +683,17 @@ data:
         grpcConfig:
           host: dns:///authorizer.union.svc.cluster.local:80
           insecure: true
+      bootstrap:
+        adminUsers: []
+        domains:
+        - development
+        - staging
+        - production
+        maxRetries: 30
+        organization: ""
+        projects: []
+        retryInterval: 5s
+        serviceAccounts: []
       externalClient:
         failOpen: false
         forwardHeaders:
@@ -691,8 +702,16 @@ data:
         grpcConfig:
           host: dns:///my-authz-server.default.svc.cluster.local:50051
           insecure: true
+      internalCommunicationConfig:
+        enabled: false
       type: External
       useExternalIdentity: 'true'
+      userCloudsClient:
+        clientID: 'union-authz-client'
+        clientSecretName: union/client_secret
+        enableLogging: true
+        tenantID: 623771e7-ddd6-4575-bedb-7c970ec75b87
+        tenantUrl: http://release-name-union-authz.union.svc.cluster.local:8080
     cache:
       identity:
         enabled: false
@@ -3581,12 +3600,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:update_status:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:update_status:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "UpdateStatus p95",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:heartbeat:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:heartbeat:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "Heartbeat p95",
                   "refId": "B"
                 }
@@ -3863,17 +3882,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:cache_hit{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:cache_hit_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Hits",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:not_found_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Misses",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_failure{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_failure_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Get failures",
                   "refId": "C"
                 }
@@ -3910,17 +3929,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:reservation_contention{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:reservation_contention_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Contention",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation acquired",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation released",
                   "refId": "C"
                 }
@@ -3971,12 +3990,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Allowed",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Denied",
                   "refId": "B"
                 }
@@ -4013,17 +4032,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }
@@ -4060,7 +4079,7 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
                   "legendFormat": "Deny %",
                   "refId": "A"
                 }
@@ -4089,10 +4108,14 @@ data:
                     {
                       "type": "value",
                       "options": {
-                        "noop": { "text": "Noop", "index": 0 },
-                        "userclouds": { "text": "UserClouds", "index": 1 },
-                        "external": { "text": "External", "index": 2 },
-                        "authorizer": { "text": "Authorizer", "index": 3 }
+                        "Noop": { "text": "Noop", "index": 0 },
+                        "noop": { "text": "Noop", "index": 1 },
+                        "UserClouds": { "text": "UserClouds", "index": 2 },
+                        "userclouds": { "text": "UserClouds", "index": 3 },
+                        "External": { "text": "External", "index": 4 },
+                        "external": { "text": "External", "index": 5 },
+                        "Authorizer": { "text": "Authorizer", "index": 6 },
+                        "authorizer": { "text": "Authorizer", "index": 7 }
                       }
                     }
                   ]
@@ -4648,17 +4671,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -31,6 +31,24 @@ spec:
       app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: webhook-server
 ---
+# Source: controlplane/templates/authz/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-union-authz
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: union-authz
+      app.kubernetes.io/instance: release-name
+---
 # Source: controlplane/templates/console/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -216,6 +234,18 @@ metadata:
   labels:
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: webhook-server
+---
+# Source: controlplane/templates/authz/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-union-authz
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
 apiVersion: v1
@@ -586,6 +616,52 @@ data:
   BASE_URL: /console
   CONFIG_DIR: /etc/flyte/config
 ---
+# Source: controlplane/templates/authz/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-union-authz-config
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    database:
+      host: ""
+      port: 5432
+      name: "userclouds"
+      user: ""
+      password: "file:///etc/db/pass.txt"
+      sslMode: "require"
+      mode: "normal"
+
+    auth:
+      issuer: "http://release-name-union-authz.union.svc.cluster.local:8080"
+      signingKey: "kube://secrets/userclouds-signing-key?key=signing_key"
+      apps:
+        - credentials:
+          - clientId: 'union-authz-client'
+            clientSecret: kube://secrets/?key=client_secret
+          id: union-controlplane
+          name: union-controlplane
+
+    cache:
+      enabled: true
+      type: "memory"
+      ttl: "60m"
+      memory:
+        maxEntries: 100000
+        shards: 128
+        depShards: 128
+
+    services:
+      checkAttributeEndpoint: "http://localhost:8080"
+      idpEndpoint: "http://localhost:8080"
+      authzEndpoint: "http://localhost:8080"
+---
 # Source: controlplane/templates/cacheservice/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -682,12 +758,31 @@ data:
         grpcConfig:
           host: dns:///authorizer.union.svc.cluster.local:80
           insecure: true
+      bootstrap:
+        adminUsers: []
+        domains:
+        - development
+        - staging
+        - production
+        maxRetries: 30
+        organization: ""
+        projects: []
+        retryInterval: 5s
+        serviceAccounts: []
       externalClient:
         forwardHeaders:
         - authorization
         - flyte-authorization
-      type: Noop
+      internalCommunicationConfig:
+        enabled: false
+      type: UserClouds
       useExternalIdentity: 'false'
+      userCloudsClient:
+        clientID: 'union-authz-client'
+        clientSecretName: union/client_secret
+        enableLogging: true
+        tenantID: 623771e7-ddd6-4575-bedb-7c970ec75b87
+        tenantUrl: http://release-name-union-authz.union.svc.cluster.local:8080
     cache:
       identity:
         enabled: false
@@ -712,12 +807,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -787,12 +882,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -850,12 +945,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -934,12 +1029,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -1005,12 +1100,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -1074,12 +1169,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -1138,12 +1233,12 @@ data:
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-internal-client-id'
         clientSecretLocation: /etc/secrets/union/client_secret
         enable: true
         scopes:
         - all
-        tokenUrl: ''
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       internalConnectionConfig:
         enabled: true
@@ -3576,12 +3671,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:update_status:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:update_status:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "UpdateStatus p95",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.95, sum by (le) (rate(cluster:svc:heartbeat:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "expr": "cluster:svc:heartbeat:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
                   "legendFormat": "Heartbeat p95",
                   "refId": "B"
                 }
@@ -3858,17 +3953,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:cache_hit{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:cache_hit_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Hits",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:not_found_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Misses",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_failure{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_failure_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Get failures",
                   "refId": "C"
                 }
@@ -3905,17 +4000,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(flyte:cacheservice:cache:reservation_contention{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:reservation_contention_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Contention",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation acquired",
                   "refId": "B"
                 },
                 {
-                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Reservation released",
                   "refId": "C"
                 }
@@ -3966,12 +4061,12 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Allowed",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
                   "legendFormat": "Denied",
                   "refId": "B"
                 }
@@ -4008,17 +4103,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "authorizer:authorize_duration{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }
@@ -4055,7 +4150,7 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]) / (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]) + rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
                   "legendFormat": "Deny %",
                   "refId": "A"
                 }
@@ -4084,10 +4179,14 @@ data:
                     {
                       "type": "value",
                       "options": {
-                        "noop": { "text": "Noop", "index": 0 },
-                        "userclouds": { "text": "UserClouds", "index": 1 },
-                        "external": { "text": "External", "index": 2 },
-                        "authorizer": { "text": "Authorizer", "index": 3 }
+                        "Noop": { "text": "Noop", "index": 0 },
+                        "noop": { "text": "Noop", "index": 1 },
+                        "UserClouds": { "text": "UserClouds", "index": 2 },
+                        "userclouds": { "text": "UserClouds", "index": 3 },
+                        "External": { "text": "External", "index": 4 },
+                        "external": { "text": "External", "index": 5 },
+                        "Authorizer": { "text": "Authorizer", "index": 6 },
+                        "authorizer": { "text": "Authorizer", "index": 7 }
                       }
                     }
                   ]
@@ -4643,17 +4742,17 @@ data:
               "type": "timeseries",
               "targets": [
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
                   "legendFormat": "p50",
                   "refId": "A"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
                   "legendFormat": "p90",
                   "refId": "B"
                 },
                 {
-                  "expr": "usage:messages:processing_time{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
                   "legendFormat": "p99",
                   "refId": "C"
                 }
@@ -5806,6 +5905,22 @@ rules:
   - create
   - patch
 ---
+# Source: controlplane/templates/authz/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-union-authz-secrets-manager
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+---
 # Source: controlplane/templates/flyte-core-app.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -5878,6 +5993,26 @@ subjects:
 - kind: ServiceAccount
   name: 'envoy-gateway'
   namespace: 'union'
+---
+# Source: controlplane/templates/authz/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-union-authz-secrets-manager
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-name-union-authz-secrets-manager
+subjects:
+  - kind: ServiceAccount
+    name: release-name-union-authz
+    namespace: union
 ---
 # Source: controlplane/templates/flyte-core-app.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6011,6 +6146,28 @@ spec:
   selector:
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: webhook-server
+---
+# Source: controlplane/templates/authz/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-union-authz
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
 apiVersion: v1
@@ -6813,6 +6970,120 @@ spec:
                   app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 1
+---
+# Source: controlplane/templates/authz/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-union-authz
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: union-authz
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        checksum/config: 8bda5502d8cb82e6d35a0d7495c605eba4ea4137a8294c0149d7b60dafb1d458
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: union-authz
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-union-authz
+      terminationGracePeriodSeconds: 45
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: userclouds-lite
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          command:
+            - userclouds-lite
+          args:
+            - serve
+            - all
+            - --config=/etc/userclouds/config.yaml
+            - --addr=:8080
+            - --static=/usr/share/userclouds/static
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/userclouds
+              readOnly: true
+            - name: db-pass
+              mountPath: /etc/db
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: release-name-union-authz-config
+        - name: db-pass
+          secret:
+            secretName: 
+        - name: tmp
+          emptyDir: {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: union-authz
+            topologyKey: kubernetes.io/hostname
 ---
 # Source: controlplane/templates/cacheservice/deployment.yaml
 apiVersion: apps/v1
@@ -7865,6 +8136,32 @@ spec:
           averageUtilization: 70
           type: Utilization
       type: Resource
+---
+# Source: controlplane/templates/authz/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: release-name-union-authz
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: union-authz
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: release-name-union-authz
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
 ---
 # Source: controlplane/templates/console/hpa.yaml
 apiVersion: autoscaling/v2

--- a/tests/values/controlplane.userclouds.yaml
+++ b/tests/values/controlplane.userclouds.yaml
@@ -63,5 +63,8 @@ flyte:
         endpoint: dns:///fake-host.domain
         insecure: false
 
-global:
-  AUTHZ_TYPE: "union"
+services:
+  authorizer:
+    configMap:
+      authorizer:
+        type: "UserClouds"


### PR DESCRIPTION
## Overview

Adds authorizer configuration defaults for selfhosted deployments and fixes dashboard panel issues.

- **defaultIdentityToSubject**: Config for non-Okta IdPs (FAB-189) that don't include `identitytype` claim natively. When enabled, subjects without identitytype are treated as users.
- **UserClouds client defaults**: Pre-configured connection settings in the controlplane values so terraform doesn't need deep-merge overrides.
- **Dashboard fixes**: Authorizer Mode panel value mappings for case sensitivity, metric name mismatches.

## Migration Notes

No migration required. Additive defaults only — existing deployments are not affected.

## Test Plan

- [x] `helm template` renders correctly
- [x] Verified on identity-testing environment

ref FAB-189
ref FAB-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - **Add selfhosted authorizer defaults and dashboard fixes** :point\_left:
    - \#349
      - \#350
        - \#351
          - \#352
            - \#353
              - \#354
