### PR TITLE
Add selfhosted ingress identity forwarding and organizations service

### DIFF
--- a/charts/controlplane/values.aws.selfhosted-intracluster.yaml
+++ b/charts/controlplane/values.aws.selfhosted-intracluster.yaml
@@ -478,10 +478,22 @@ ingress:
         - "{{ .Values.global.CONTROLPLANE_INTRA_CLUSTER_HOST }}"
       secretName: "{{ .Values.global.TLS_SECRET_NAME }}"
 
+  # --- Ingress Annotations (shared across all ingress objects) ---
+  annotations:
+    # Allow the nginx controller's internal DNS to match ingress rules so that
+    # intra-cluster traffic (DP → CP via nginx service DNS) is routed through
+    # the same auth subrequest as external traffic. Without this, the :authority
+    # header won't match the ingress host and auth is bypassed.
+    nginx.ingress.kubernetes.io/server-alias: "{{ .Values.global.CONTROLPLANE_INTRA_CLUSTER_HOST }}"
+
   # --- Protected Ingress Auth Annotations ---
   # These configure nginx to validate requests via flyteadmin's /me endpoint
   # and redirect unauthenticated users to /login for the OIDC flow.
   # Active when OIDC authentication is enabled (server.security.useAuth: true).
+  #
+  # All protected endpoints use "https://$host/me" so the auth subrequest goes
+  # through nginx itself. This ensures verifyClaims runs on the access token,
+  # which resolves identitytype for all callers (browser, CLI, service-to-service).
   protectedIngressAnnotations:
     nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login?redirect_url=$escaped_request_uri"

--- a/charts/controlplane/values.gcp.selfhosted-intracluster.yaml
+++ b/charts/controlplane/values.gcp.selfhosted-intracluster.yaml
@@ -508,7 +508,14 @@ ingress:
         - "{{ .Values.global.CONTROLPLANE_INTRA_CLUSTER_HOST }}"
       secretName: "{{ .Values.global.TLS_SECRET_NAME }}"
 
-  # Protected ingress auth annotations are now defined in the base values.yaml.
+  # --- Ingress Annotations (shared across all ingress objects) ---
+  annotations:
+    # Allow the nginx controller's internal DNS to match ingress rules so that
+    # intra-cluster traffic (DP → CP via nginx service DNS) is routed through
+    # the same auth subrequest as external traffic.
+    nginx.ingress.kubernetes.io/server-alias: "{{ .Values.global.CONTROLPLANE_INTRA_CLUSTER_HOST }}"
+
+  # Protected ingress auth annotations are defined in the base values.yaml.
   # Override here only if you need to customize auth behavior for this deployment mode.
 
 # ----------------------------------------------------------------------------

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -253,6 +253,31 @@ ingress:
     nginx.ingress.kubernetes.io/auth-url: "http://flyteadmin.{{ template \"flyte.namespace\" . }}.svc.cluster.local/me"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
     nginx.ingress.kubernetes.io/auth-cache-key: "$http_authorization$http_flyte_authorization$http_cookie"
+    # For gRPC backends (backend-protocol: GRPC), nginx uses grpc_pass instead
+    # of proxy_pass. The auth-response-headers annotation only sets proxy headers,
+    # not gRPC headers. This configuration-snippet bridges identity headers from
+    # the auth subrequest response into the upstream gRPC request so backend
+    # services receive the caller's identity.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 
 envoyGateway:
   # GatewayClass name for Envoy Gateway. Used when INGRESS_PROVIDER is "envoy" or "both".
@@ -541,6 +566,38 @@ services:
         secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80 # http://ingress-nginx-internal.ingress-nginx.svc.cluster.local
         clusterSelector:
           type: local
+  organizations:
+    fullnameOverride: "organizations"
+    sharedService:
+      connectPort: 8081
+    initContainers:
+      - name: migrate
+        args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - "/etc/config/*.yaml"
+    args:
+      - cloudorganizations
+      - serve
+      - --config
+      - /etc/config/*.yaml
+    configMap:
+      sharedService:
+        connectPort: 8081
+        metrics:
+          scope: "organizations:"
+      db:
+        dbname: '{{ .Values.global.DB_NAME }}'
+        host: '{{ .Values.global.DB_HOST }}'
+        username: '{{ .Values.global.DB_USER }}'
+        passwordPath: /etc/db/pass.txt
+        port: 5432
+        connectionPool:
+          maxIdleConnections: 20
+          maxOpenConnections: 20
+          maxConnectionLifetime: 1m
+
   executions:
     fullnameOverride: "executions"
     initContainers:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -138,6 +138,18 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: organizations
+spec:
+  minAvailable: "33%"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
   name: queue
 spec:
   minAvailable: "33%"
@@ -286,6 +298,18 @@ metadata:
   labels:
     helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
@@ -965,6 +989,76 @@ data:
         urlPattern: _SERVICE_.union.svc.cluster.local:80
     workspace:
       enable: false
+---
+# Source: controlplane/templates/configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'organizations:'
+      selfServeConfig:
+        legacyHosts:
+        - ''
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - all
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
 ---
 # Source: controlplane/templates/configmap.yaml
 ---
@@ -6245,6 +6339,45 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: organizations
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
@@ -7499,6 +7632,135 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: organizations
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: organizations
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: organizations
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: organizations
+      initContainers:
+        - name: organizations-migrate
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: organizations
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudorganizations
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: organizations
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: queue
   labels:
     helm.sh/chart: controlplane-2026.4.7
@@ -8033,6 +8295,32 @@ spec:
           averageUtilization: 80
 ---
 # Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: organizations
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: organizations
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -8174,6 +8462,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   rules:
@@ -8697,6 +9005,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   rules:
@@ -9431,6 +9759,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   rules:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -138,6 +138,18 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: organizations
+spec:
+  minAvailable: "33%"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
   name: queue
 spec:
   minAvailable: "33%"
@@ -286,6 +298,18 @@ metadata:
   labels:
     helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
@@ -965,6 +989,76 @@ data:
         urlPattern: _SERVICE_.union.svc.cluster.local:80
     workspace:
       enable: false
+---
+# Source: controlplane/templates/configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'organizations:'
+      selfServeConfig:
+        legacyHosts:
+        - ''
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - all
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
 ---
 # Source: controlplane/templates/configmap.yaml
 ---
@@ -6245,6 +6339,45 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: organizations
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
@@ -7505,6 +7638,136 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: organizations
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: organizations
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: organizations
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: organizations
+      initContainers:
+        - name: organizations-migrate
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: organizations
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudorganizations
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: organizations
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: queue
   labels:
     helm.sh/chart: controlplane-2026.4.7
@@ -8036,6 +8299,32 @@ spec:
           averageUtilization: 80
 ---
 # Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: organizations
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: organizations
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -8182,6 +8471,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: "controlplane"
@@ -8706,6 +9015,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:
@@ -9445,6 +9774,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -132,6 +132,18 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: executions
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: organizations
+spec:
+  minAvailable: "33%"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
       app.kubernetes.io/instance: release-name
 ---
 # Source: controlplane/templates/pdb.yaml
@@ -231,7 +243,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -244,10 +256,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -257,10 +269,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -269,10 +281,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -281,10 +293,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -293,10 +305,22 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -305,10 +329,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -317,10 +341,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -329,10 +353,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -342,10 +366,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -605,7 +629,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -676,10 +700,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -769,10 +793,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -854,10 +878,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -927,10 +951,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -989,6 +1013,8 @@ data:
       llm:
         enabled: false
       task:
+        clusterCacheConfig:
+          ttl: 10m
         enabled: true
         enrichIdentities: false
     logger:
@@ -1030,12 +1056,92 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: ''
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'organizations:'
+      security:
+        singleTenantOrgID: ''
+      selfServeConfig:
+        legacyHosts:
+        - ''
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - all
+        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1111,10 +1217,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1190,10 +1296,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5876,7 +5982,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -5930,7 +6036,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6090,7 +6196,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6117,10 +6223,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6145,10 +6251,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6184,10 +6290,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6223,10 +6329,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6258,10 +6364,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6290,13 +6396,52 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: organizations
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6328,10 +6473,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6363,10 +6508,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6905,7 +7050,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -6916,7 +7061,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9c88958e2c6c93925c335fa455ed035dc6c32e92bead61445ca6463e40c19cc"
+        configChecksum: "197f4097faabcce1c83bbd79953460800854d6b92837333f3dd60c6c1bfa14a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -6925,7 +7070,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.5
+        helm.sh/chart: controlplane-2026.4.7
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7017,10 +7162,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7060,7 +7205,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7087,10 +7232,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7128,7 +7273,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7202,10 +7347,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7243,7 +7388,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7259,7 +7404,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7333,10 +7478,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7374,7 +7519,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7445,10 +7590,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7486,7 +7631,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7502,7 +7647,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7571,12 +7716,143 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: organizations
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: organizations
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: organizations
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: organizations
+      initContainers:
+        - name: organizations-migrate
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: organizations
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudorganizations
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: organizations
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7615,7 +7891,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -7631,7 +7907,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -7702,10 +7978,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7743,7 +8019,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7759,7 +8035,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7831,10 +8107,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7872,7 +8148,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -7979,10 +8255,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -8111,6 +8387,32 @@ spec:
           averageUtilization: 80
 ---
 # Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: organizations
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: organizations
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -8193,6 +8495,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -8253,6 +8556,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -8273,6 +8577,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: "controlplane"
@@ -8306,6 +8630,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -8360,6 +8685,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -8777,6 +9103,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -8797,6 +9124,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:
@@ -9516,6 +9863,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -9536,6 +9884,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:
@@ -9872,6 +10240,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -10078,6 +10447,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -10163,6 +10533,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;
@@ -10212,6 +10583,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
     nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: ''
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_timeout 604800;
       client_body_timeout 604800;

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -231,7 +231,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -244,10 +244,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -257,10 +257,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -269,10 +269,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -281,10 +281,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -293,10 +293,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -305,10 +305,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -317,10 +317,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -329,10 +329,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -342,10 +342,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -605,7 +605,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -676,10 +676,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -769,10 +769,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -854,10 +854,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -927,10 +927,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -989,8 +989,6 @@ data:
       llm:
         enabled: false
       task:
-        clusterCacheConfig:
-          ttl: 10m
         enabled: true
         enrichIdentities: false
     logger:
@@ -1034,10 +1032,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1113,10 +1111,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1192,10 +1190,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5878,7 +5876,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -5932,7 +5930,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6092,7 +6090,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6119,10 +6117,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6147,10 +6145,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6186,10 +6184,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6225,10 +6223,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6260,10 +6258,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6295,10 +6293,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6330,10 +6328,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6365,10 +6363,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6907,7 +6905,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -6918,7 +6916,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "197f4097faabcce1c83bbd79953460800854d6b92837333f3dd60c6c1bfa14a"
+        configChecksum: "9c88958e2c6c93925c335fa455ed035dc6c32e92bead61445ca6463e40c19cc"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -6927,7 +6925,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.4.7
+        helm.sh/chart: controlplane-2026.4.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -7019,10 +7017,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -7062,7 +7060,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.7"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.4.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -7089,10 +7087,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7130,7 +7128,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -7204,10 +7202,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7245,7 +7243,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -7261,7 +7259,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -7335,10 +7333,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7376,7 +7374,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -7447,10 +7445,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7488,7 +7486,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7504,7 +7502,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7575,10 +7573,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7617,7 +7615,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -7633,7 +7631,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -7704,10 +7702,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7745,7 +7743,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -7761,7 +7759,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -7833,10 +7831,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -7874,7 +7872,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -7981,10 +7979,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -138,6 +138,18 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: organizations
+spec:
+  minAvailable: "33%"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
   name: queue
 spec:
   minAvailable: "33%"
@@ -284,6 +296,18 @@ metadata:
   labels:
     helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
@@ -970,6 +994,76 @@ data:
         urlPattern: _SERVICE_.union.svc.cluster.local:80
     workspace:
       enable: false
+---
+# Source: controlplane/templates/configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'true'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'organizations:'
+      selfServeConfig:
+        legacyHosts:
+        - ''
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - all
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
 ---
 # Source: controlplane/templates/configmap.yaml
 ---
@@ -6250,6 +6344,45 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: organizations
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
@@ -7504,6 +7637,135 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: organizations
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: organizations
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: organizations
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: organizations
+      initContainers:
+        - name: organizations-migrate
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: organizations
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudorganizations
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: organizations
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: queue
   labels:
     helm.sh/chart: controlplane-2026.4.7
@@ -8038,6 +8300,32 @@ spec:
           averageUtilization: 80
 ---
 # Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: organizations
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: organizations
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -8184,6 +8472,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: "controlplane"
@@ -8708,6 +9016,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:
@@ -9447,6 +9775,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -241,10 +241,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
@@ -622,10 +622,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5911,10 +5911,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -6000,10 +6000,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6153,10 +6153,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6977,10 +6977,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6995,7 +6995,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 143023ded44f2db18ddf79507adcbb11c31eb4da967c39179d54bd01bdb07f5c
+        checksum/config: 8bda5502d8cb82e6d35a0d7495c605eba4ea4137a8294c0149d7b60dafb1d458
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7019,7 +7019,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -8143,10 +8143,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -241,10 +241,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
@@ -622,10 +622,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -5911,10 +5911,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -6000,10 +6000,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6153,10 +6153,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6977,10 +6977,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6995,7 +6995,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8bda5502d8cb82e6d35a0d7495c605eba4ea4137a8294c0149d7b60dafb1d458
+        checksum/config: 143023ded44f2db18ddf79507adcbb11c31eb4da967c39179d54bd01bdb07f5c
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7019,7 +7019,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -8143,10 +8143,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.7
+    helm.sh/chart: controlplane-2026.4.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/version: "2026.4.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -156,6 +156,18 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: organizations
+spec:
+  minAvailable: "33%"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
   name: queue
 spec:
   minAvailable: "33%"
@@ -241,10 +253,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
@@ -316,6 +328,18 @@ metadata:
   labels:
     helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
@@ -622,10 +646,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1041,6 +1065,76 @@ data:
         urlPattern: _SERVICE_.union.svc.cluster.local:80
     workspace:
       enable: false
+---
+# Source: controlplane/templates/configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'organizations:'
+      selfServeConfig:
+        legacyHosts:
+        - ''
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - all
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
 ---
 # Source: controlplane/templates/configmap.yaml
 ---
@@ -5911,10 +6005,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -6000,10 +6094,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6153,10 +6247,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -6373,6 +6467,45 @@ spec:
       targetPort: debug
   selector:
     app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: organizations
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
 ---
 # Source: controlplane/templates/service.yaml
@@ -6977,10 +7110,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -6995,7 +7128,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 143023ded44f2db18ddf79507adcbb11c31eb4da967c39179d54bd01bdb07f5c
+        checksum/config: 8bda5502d8cb82e6d35a0d7495c605eba4ea4137a8294c0149d7b60dafb1d458
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7019,7 +7152,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.5
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -7747,6 +7880,135 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.4.7
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.4.7"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: organizations
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: organizations
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: organizations
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: organizations
+      initContainers:
+        - name: organizations-migrate
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: organizations
+          image: 643379628101.dkr.ecr.us-east-1.amazonaws.com/union-cp/services:2026.4.7
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudorganizations
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: organizations
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: queue
   labels:
     helm.sh/chart: controlplane-2026.4.7
@@ -8143,10 +8405,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.4.5
+    helm.sh/chart: controlplane-2026.4.7
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.4.5"
+    app.kubernetes.io/version: "2026.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -8284,6 +8546,32 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: executions
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: organizations
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: organizations
   minReplicas: 1
   maxReplicas: 1
   metrics:
@@ -8447,6 +8735,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: "controlplane"
@@ -8971,6 +9279,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:
@@ -9710,6 +10038,26 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $user_id $upstream_http_x_user_subject;
+      proxy_set_header X-User-Subject $user_id;
+      grpc_set_header X-User-Subject $user_id;
+    
+      auth_request_set $user_identitytype $upstream_http_x_user_claim_identitytype;
+      proxy_set_header X-User-Claim-Identitytype $user_identitytype;
+      grpc_set_header X-User-Claim-Identitytype $user_identitytype;
+    
+      auth_request_set $user_handle $upstream_http_x_user_claim_userhandle;
+      proxy_set_header X-User-Claim-userhandle $user_handle;
+      grpc_set_header X-User-Claim-userhandle $user_handle;
+    
+      auth_request_set $groups $upstream_http_x_user_claim_groups;
+      proxy_set_header X-User-Claim-groups $groups;
+      grpc_set_header X-User-Claim-groups $groups;
+    
+      more_set_headers "x-request-id: $request_id";
+      proxy_set_header x-request-id $request_id;
+      grpc_set_header x-request-id $request_id;
 spec:
   ingressClassName: "controlplane"
   tls:


### PR DESCRIPTION
## Summary

- **server-alias annotation**: Allows DP→CP intra-cluster traffic through nginx ingress by matching the internal service DNS name
- **gRPC configuration-snippet**: Forwards identity headers (X-User-Subject, X-User-Claim-Identitytype) from auth subrequest to gRPC backends. Required for BYOC since Oct 2024, now ported to selfhosted chart.
- **Organizations service**: New controlplane service for settings/org APIs. Required by CreateRun since #15107.
- **Fix organizations connectPort** in configmap

Stacked on #349 → #348 → main

## Migration Notes

**New behavior:** Intra-cluster DP→CP gRPC traffic now goes through nginx auth subrequests (via server-alias). This ensures consistent identity resolution for all callers. Previously, intra-cluster traffic could bypass auth if the `:authority` header didn't match the ingress host.

**Action required:** None for new deployments. Existing deployments will get the server-alias annotation on next helm upgrade.

## Risk Assessment

**Medium** — Changes ingress behavior. Test: DP→CP traffic, browser login.

## Test Plan

- [ ] Verify DP→CP gRPC traffic still works through ingress
- [ ] Verify browser login flow unchanged
- [ ] Verify organizations service endpoints respond
- [ ] `helm template` produces expected manifests

ref FAB-178, FAB-195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - **Add selfhosted ingress identity forwarding and organizations service** :point\_left:
    - \#351
      - \#352
        - \#353
          - \#354
