### PR TITLE
Fix dashboard authz metric names: drop :connect: prefix

### DIFF
--- a/charts/controlplane/dashboards/union-controlplane-overview.json
+++ b/charts/controlplane/dashboards/union-controlplane-overview.json
@@ -2700,7 +2700,7 @@
           },
           "targets": [
             {
-              "expr": "authorizer:authorizer:cloudauthorizer:connect:authz_type_info{namespace=\"$namespace\"} == 1",
+              "expr": "authorizer:authorizer:cloudauthorizer:authz_type_info{namespace=\"$namespace\"} == 1",
               "legendFormat": "{{type}}",
               "refId": "A"
             }
@@ -2778,12 +2778,12 @@
           },
           "targets": [
             {
-              "expr": "sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]))",
+              "expr": "sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]))",
               "legendFormat": "allowed ({{identity_type}})",
               "refId": "A"
             },
             {
-              "expr": "sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+              "expr": "sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
               "legendFormat": "denied ({{identity_type}})",
               "refId": "B"
             }
@@ -2845,7 +2845,7 @@
           },
           "targets": [
             {
-              "expr": "(sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])) or vector(0)) / clamp_min((sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])) + sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))), 1e-10)",
+              "expr": "(sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval])) or vector(0)) / clamp_min((sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])) + sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))), 1e-10)",
               "legendFormat": "{{identity_type}}",
               "refId": "A"
             }
@@ -3034,12 +3034,12 @@
           },
           "targets": [
             {
-              "expr": "sum by (action, identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]))",
+              "expr": "sum by (action, identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]))",
               "legendFormat": "{{action}} {{identity_type}} (allowed)",
               "refId": "A"
             },
             {
-              "expr": "sum by (action, identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+              "expr": "sum by (action, identity_type) (rate(authorizer:authorizer:cloudauthorizer:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
               "legendFormat": "{{action}} {{identity_type}} (denied)",
               "refId": "B"
             }


### PR DESCRIPTION
## Summary
Fix metric name mismatch in authorizer dashboard panels. The `authz_allowed`/`authz_denied` counters are registered at the service layer, not the sharedService/connect layer, so they don't have the `:connect:` prefix.

**Before:** `authorizer:authorizer:cloudauthorizer:connect:authz_denied` (no data)
**After:** `authorizer:authorizer:cloudauthorizer:authz_denied` (matches actual metrics)

## Test Plan
- [x] Verified actual metric names via `curl localhost:10254/metrics` on identity-testing authorizer pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)