### PR TITLE
Set insecureSkipVerify for intra-cluster TLS connections

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -355,11 +355,15 @@ configMap:
         - '{{ .Values.global.UNION_ORG }}'
   union:
     connection:
-      # gRPC requires TLS for HTTP/2 with NGINX. Cannot mix HTTP/1.1 and HTTP/2
-      # on the same listener without TLS.
+      # Internal service-to-service communication goes through the controlplane
+      # nginx ingress to trigger the authentication flow (auth subrequest to /me).
+      # gRPC requires TLS for HTTP/2 with NGINX, so insecure must be false.
+      # However, the TLS certificate on the ingress is typically issued for the
+      # external domain only — the internal FQDN (controlplane-nginx-controller.
+      # <namespace>.svc.cluster.local) won't match. Since traffic is already
+      # within the cluster network, skip TLS certificate verification.
       insecure: false
-      # Set to true if using self-signed certificates (e.g. cert-manager self-signed issuer).
-      insecureSkipVerify: false
+      insecureSkipVerify: true
 
       # Overridden by terraform from authn module trusted_identity_claims output.
       # Okta: externalIdentityClaim = internal client_id (sub == client_id)

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -769,7 +769,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -858,7 +858,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -935,7 +935,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1044,7 +1044,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1130,7 +1130,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1213,7 +1213,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1296,7 +1296,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1374,7 +1374,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -769,7 +769,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -858,7 +858,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -935,7 +935,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1044,7 +1044,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1130,7 +1130,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1213,7 +1213,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1296,7 +1296,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1374,7 +1374,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -784,7 +784,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -873,7 +873,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -950,7 +950,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1059,7 +1059,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1145,7 +1145,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1228,7 +1228,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1311,7 +1311,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1389,7 +1389,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -774,7 +774,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -863,7 +863,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -940,7 +940,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1049,7 +1049,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1135,7 +1135,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1218,7 +1218,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1301,7 +1301,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1379,7 +1379,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -845,7 +845,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -934,7 +934,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1011,7 +1011,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1120,7 +1120,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1206,7 +1206,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1289,7 +1289,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1372,7 +1372,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""
@@ -1450,7 +1450,7 @@ data:
         type: ClientSecret
       connection:
         insecure: false
-        insecureSkipVerify: false
+        insecureSkipVerify: true
         trustedIdentityClaims:
           enabled: true
           externalIdentityClaim: ""


### PR DESCRIPTION
## Summary

Set `insecureSkipVerify: true` for internal service-to-service connections that go through the controlplane nginx ingress.

Internal CP→CP traffic uses nginx to trigger the auth subrequest flow. gRPC requires TLS (HTTP/2), but the TLS cert is issued for the external domain — the internal FQDN (`controlplane-nginx-controller.<ns>.svc.cluster.local`) won't match. Since this traffic is already within the cluster network, certificate verification can be safely skipped.

## Test Plan
- [ ] Deploy to identity-testing, verify SDK `flyte run` succeeds
- [ ] Verify intra-cluster gRPC (cluster → executions) no longer fails with x509 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)