### PR TITLE
Add flyteidl2.cluster.ClusterService ingress route for SDK v2

### DIFF
--- a/charts/controlplane/templates/common/_ingress-protected.yaml
+++ b/charts/controlplane/templates/common/_ingress-protected.yaml
@@ -393,6 +393,20 @@
       name: cluster
       port:
         name: connect
+- path: /flyteidl2.cluster.ClusterService/*
+  pathType: ImplementationSpecific
+  backend:
+    service:
+      name: cluster
+      port:
+        name: connect
+- path: /flyteidl2.cluster.ClusterService
+  pathType: ImplementationSpecific
+  backend:
+    service:
+      name: cluster
+      port:
+        name: connect
 - path: /cloudidl.cluster.ClusterNodepoolService/*
   pathType: ImplementationSpecific
   backend:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -9377,6 +9377,20 @@ spec:
                 name: cluster
                 port:
                   name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
           - path: /cloudidl.cluster.ClusterNodepoolService/*
             pathType: ImplementationSpecific
             backend:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -9367,6 +9367,20 @@ spec:
                 name: cluster
                 port:
                   name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
           - path: /cloudidl.cluster.ClusterNodepoolService/*
             pathType: ImplementationSpecific
             backend:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -9381,6 +9381,20 @@ spec:
                 name: cluster
                 port:
                   name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
           - path: /cloudidl.cluster.ClusterNodepoolService/*
             pathType: ImplementationSpecific
             backend:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -9368,6 +9368,20 @@ spec:
                 name: cluster
                 port:
                   name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
           - path: /cloudidl.cluster.ClusterNodepoolService/*
             pathType: ImplementationSpecific
             backend:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -9633,6 +9633,20 @@ spec:
                 name: cluster
                 port:
                   name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
           - path: /cloudidl.cluster.ClusterNodepoolService/*
             pathType: ImplementationSpecific
             backend:


### PR DESCRIPTION
## Summary
- Adds `/flyteidl2.cluster.ClusterService` and `/flyteidl2.cluster.ClusterService/*` routes to the protected gRPC ingress, targeting the `cluster` service on the `connect` port
- Without this, the flyte-sdk v2 `SelectCluster` call falls through to the console catch-all and gets `text/html` instead of `application/proto`
- Route already exists in BYOC (dogfood `helm-protected-grpc` ingress) but was missing from the selfhosted controlplane chart

## Test plan
- [ ] Verify `flyte run` works on identity-testing after deploy