### PR TITLE
Add NEXT_PUBLIC_UNION_ORG_OVERRIDE to console deployment (fixes FAB-282)

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -968,6 +968,8 @@ console:
   env:
     - name: UNION_ORG_OVERRIDE
       value: '{{ .Values.global.UNION_ORG }}'
+    - name: NEXT_PUBLIC_UNION_ORG_OVERRIDE
+      value: '{{ .Values.global.UNION_ORG }}'
 
   # Additional environment variables from ConfigMap
   envFrom: []

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -7398,6 +7398,8 @@ spec:
         env:
           - name: UNION_ORG_OVERRIDE
             value: ''
+          - name: NEXT_PUBLIC_UNION_ORG_OVERRIDE
+            value: ''
         resources:
           limits:
             cpu: 500m

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -7400,6 +7400,8 @@ spec:
         env:
           - name: UNION_ORG_OVERRIDE
             value: ''
+          - name: NEXT_PUBLIC_UNION_ORG_OVERRIDE
+            value: ''
         resources:
           limits:
             cpu: 500m

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -7416,6 +7416,8 @@ spec:
         env:
           - name: UNION_ORG_OVERRIDE
             value: ''
+          - name: NEXT_PUBLIC_UNION_ORG_OVERRIDE
+            value: ''
         resources:
           limits:
             cpu: 500m

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -7403,6 +7403,8 @@ spec:
         env:
           - name: UNION_ORG_OVERRIDE
             value: ''
+          - name: NEXT_PUBLIC_UNION_ORG_OVERRIDE
+            value: ''
         resources:
           limits:
             cpu: 500m

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -7648,6 +7648,8 @@ spec:
         env:
           - name: UNION_ORG_OVERRIDE
             value: ''
+          - name: NEXT_PUBLIC_UNION_ORG_OVERRIDE
+            value: ''
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
## Summary
- Adds `NEXT_PUBLIC_UNION_ORG_OVERRIDE` env var to the console deployment alongside the existing `UNION_ORG_OVERRIDE`
- The v2 console `layout.tsx` reads `NEXT_PUBLIC_UNION_ORG_OVERRIDE` to inject `org` into `window.__ENV__` for browser-side `useOrg()` hook
- Without this, `run_id.org` is empty on selfhosted single-tenant deployments, and `buf.validate` rejects `GetRunDetails` with `"run_id.org: value length must be at least 1 characters"`

## Root cause
The helm chart set `UNION_ORG_OVERRIDE` but `layout.tsx:30` reads `env('NEXT_PUBLIC_UNION_ORG_OVERRIDE')`. The SSR path (`process.env.UNION_ORG_OVERRIDE`) worked, but the browser path (`window.__ENV__.UNION_ORG_OVERRIDE`) was empty because the `NEXT_PUBLIC_` prefixed variant was never set.

## Test plan
- [ ] Verify `GetRunDetails` returns 200 on identity-testing after deploy

Fixes [FAB-282](https://linear.app/unionai/issue/FAB-282)