### PR TITLE
Fix/cleanup stale/immutable resources

### DIFF
--- a/charts/dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+++ b/charts/dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,7 +25,7 @@ metadata:
   name: flyte-webhook-cleanup-{{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -44,7 +44,7 @@ metadata:
   name: flyte-webhook-cleanup-{{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+++ b/charts/dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -85,5 +85,6 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 {{- end }}
 {{- end }}

--- a/charts/dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+++ b/charts/dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.flytepropellerwebhook.enabled }}
+{{- if .Values.flytepropellerwebhook.legacyWebhookCleanup.enabled }}
+{{/*
+Pre-upgrade hook that deletes stale flyte-pod-webhook resources left behind from
+old chart versions. These cannot be updated in-place by Kubernetes or Helm:
+  1. MutatingWebhookConfiguration/flyte-pod-webhook — cluster-scoped orphan causing
+     "service not found" errors on pod creation.
+  2. Deployment/flytepropeller-webhook — selector label changed (immutable field).
+  3. Secret/flyte-pod-webhook — marked immutable:true; blocks TLS cert renewal.
+*/}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-{{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-{{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      {{- with .Values.flytepropellerwebhook.legacyWebhookCleanup.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: cleanup
+          image: "{{ .Values.flytepropellerwebhook.legacyWebhookCleanup.image.repository }}:{{ .Values.flytepropellerwebhook.legacyWebhookCleanup.image.tag }}"
+          imagePullPolicy: {{ .Values.flytepropellerwebhook.legacyWebhookCleanup.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS={{ .Release.Namespace }}
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+{{- end }}
+{{- end }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1062,6 +1062,18 @@ flytepropeller:
 flytepropellerwebhook:
   # -- enable or disable secrets webhook
   enabled: true
+  # -- Cleanup job to remove the legacy flyte-pod-webhook MutatingWebhookConfiguration
+  # left behind when upgrading from versions that used the old webhook name.
+  legacyWebhookCleanup:
+    # -- Enable the pre-upgrade hook that deletes the stale flyte-pod-webhook resource. 
+    # THIS IS MOSTLY NEEDED FOR UPGRADES FROM PRE 2026.24.7 VERSIONS.  IT DOESN'T ACT ON NEW INSTALLS.
+    enabled: true
+    image:
+      repository: alpine/k8s
+      tag: "1.32.3"
+      pullPolicy: IfNotPresent
+    # -- ImagePullSecrets for the cleanup job (use if kubectl image is in a private registry)
+    imagePullSecrets: []
   # -- Replicas
   replicaCount: 1
   # -- Sets priorityClassName for webhook pod

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9877,7 +9877,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9769,7 +9769,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9779,7 +9779,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9799,7 +9799,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9888,6 +9888,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9761,6 +9761,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9810,6 +9859,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9895,7 +9895,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9787,7 +9787,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9797,7 +9797,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9817,7 +9817,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9906,6 +9906,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9779,6 +9779,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9828,6 +9877,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -10356,7 +10356,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -10366,7 +10366,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -10386,7 +10386,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10475,6 +10475,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -10348,6 +10348,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -10397,6 +10446,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -10464,7 +10464,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9882,7 +9882,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9892,7 +9892,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9912,7 +9912,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10001,6 +10001,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9874,6 +9874,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9923,6 +9972,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9990,7 +9990,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -10251,7 +10251,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -10261,7 +10261,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -10281,7 +10281,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10370,6 +10370,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -10243,6 +10243,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -10292,6 +10341,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -10359,7 +10359,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9815,7 +9815,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9825,7 +9825,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9845,7 +9845,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9934,6 +9934,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9807,6 +9807,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9856,6 +9905,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9923,7 +9923,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9815,7 +9815,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9825,7 +9825,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9845,7 +9845,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9934,6 +9934,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9807,6 +9807,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9856,6 +9905,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9923,7 +9923,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9881,7 +9881,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9773,7 +9773,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9783,7 +9783,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9803,7 +9803,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9892,6 +9892,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9765,6 +9765,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9814,6 +9863,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -10128,7 +10128,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -10138,7 +10138,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -10158,7 +10158,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10247,6 +10247,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -10120,6 +10120,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -10169,6 +10218,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -10236,7 +10236,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9962,7 +9962,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9846,6 +9846,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9895,6 +9944,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9854,7 +9854,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9864,7 +9864,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9884,7 +9884,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9973,6 +9973,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9766,6 +9766,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9815,6 +9864,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9882,7 +9882,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9774,7 +9774,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9784,7 +9784,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9804,7 +9804,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9893,6 +9893,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9784,6 +9784,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9833,6 +9882,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9792,7 +9792,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9802,7 +9802,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9822,7 +9822,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9911,6 +9911,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9900,7 +9900,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -16027,7 +16027,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/charts/monitoring/charts/grafana/templates/tests/test-configmap.yaml
@@ -16091,7 +16091,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -16140,7 +16140,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16453,6 +16453,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -16019,6 +16019,17 @@ metadata:
     app.kubernetes.io/component: prometheus-operator-webhook
 automountServiceAccountToken: true
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
 # Source: dataplane/charts/monitoring/charts/grafana/templates/tests/test-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -16073,6 +16084,26 @@ rules:
       - update
       - patch
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
 # Source: dataplane/charts/monitoring/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16100,6 +16131,24 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: monitoring-admission
+    namespace: union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
     namespace: union
 ---
 # Source: dataplane/charts/monitoring/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
@@ -16375,6 +16424,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -16442,7 +16442,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -9918,7 +9918,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9928,7 +9928,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9948,7 +9948,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10037,6 +10037,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -10026,7 +10026,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -9910,6 +9910,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9959,6 +10008,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9864,7 +9864,7 @@ metadata:
   namespace: union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
@@ -9874,7 +9874,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -9894,7 +9894,7 @@ metadata:
   name: flyte-webhook-cleanup-union
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9983,6 +9983,7 @@ spec:
               kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
+              kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9972,7 +9972,7 @@ spec:
       serviceAccountName: flyte-webhook-cleanup
       containers:
         - name: cleanup
-          image: "bitnami/kubectl:latest"
+          image: "alpine/k8s:1.32.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9856,6 +9856,55 @@ template:
       - name: default
         image: docker.io/rwgrim/docker-noop
 ---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flyte-webhook-cleanup-union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flyte-webhook-cleanup-union
+subjects:
+  - kind: ServiceAccount
+    name: flyte-webhook-cleanup
+    namespace: union
+---
 # Source: dataplane/charts/fluentbit/templates/tests/test-connection.yaml
 apiVersion: v1
 kind: Pod
@@ -9905,6 +9954,35 @@ spec:
             union-operator-serving \
             --ignore-not-found=true \
             -n union
+---
+# Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flyte-webhook-cleanup
+  namespace: union
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: flyte-webhook-cleanup
+      containers:
+        - name: cleanup
+          image: "bitnami/kubectl:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              NS=union
+              kubectl delete mutatingwebhookconfiguration flyte-pod-webhook --ignore-not-found
+              kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
+              kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
 ---
 # Source: dataplane/templates/serving/knative-serving.yaml
 apiVersion: operator.knative.dev/v1beta1


### PR DESCRIPTION
This change aims to address the following issues during upgrades from pre `2026.4.7` versions

1. Immutable Deployment Selector Change                                                      

  The chart renamed the `flytepropeller-webhook` deployment's selector label from flyte-pod-webhook to
   union-pod-webhook. Kubernetes does not allow changing spec.selector on an existing Deployment — the deployment must be deleted and recreated. ArgoCD's ServerSideApply sync strategy cannot handle this; a --replace sync is required for this specific resource.

  Affected resource: Deployment/union-pod-webhook
  Error: spec.selector: Invalid value: field is immutable

  2. Immutable Secret

  The `flyte-pod-webhook` Secret is marked as `immutable: true.` The new chart version regenerates
  this secret with new TLS certs, but Kubernetes rejects updates to immutable secrets. The
  secret must be deleted before syncing.

  Affected resource: Secret/union-pod-webhook
  Error: data: Forbidden: field is immutable when immutable is set

  3. MutatingWebhookConfiguration Name Change

  The chart renamed the MutatingWebhookConfiguration from union-pod-webhook to
  union-pod-webhook-mistral. This leaves the old webhook config orphaned with a stale CA
  bundle, causing TLS verification failures when pods are created in flyte-default.

  Affected resource: MutatingWebhookConfiguration/union-pod-webhook
  Error: tls: failed to verify certificate: x509: certificate signed by unknown authority
  Fix: Delete the old union-pod-webhook MutatingWebhookConfiguration manually.

4. Immutable selector on union-operator-prometheus
```
Deployment: Deployment.apps "union-operator-prometheus" is     
  invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"prometheus",     
  "app.kubernetes.io/instance":"ml-orchestrator-dp", "app.kubernetes.io/name":"ml-orchestrator-dp-dataplane"},                          
  MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

### What this change does

It introduces a pre-upgrade hook that will delete these 4 resources before upgrading the release:

1. flytepropeller-webhook deployment
2. flyte-pod-webhook secret
3. flyte-pod-webhook MutatingWebhookConfiguration
4. `union-operator-prometheus` deployment

Cleans temporary SA and ClusterRoles on hook success or fail.

It only acts on upgrades, not installs.

Once our customer base is migrated we can retire this component.