### PR TITLE
Make CRDs conditional but maintain knative operator

### DIFF
--- a/charts/dataplane/templates/serving/knative-operator-crds.yaml
+++ b/charts/dataplane/templates/serving/knative-operator-crds.yaml
@@ -1,4 +1,4 @@
-{{- if index .Values "knative-operator" "enabled" }}
+{{- if index .Values "knative-operator" "installCRDs" }}
 # Knative Operator CRDs — managed by Helm so they exist before KnativeServing CR is applied.
 # The remaining Knative Serving CRDs (certificates, routes, etc.) are installed by the
 # knative-operator itself and must NOT be managed here to avoid SSA conflicts.

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1854,6 +1854,7 @@ knative-operator:
   namespaceOverride: '{{ .Release.Namespace }}'
   # Skip namespace creation — the parent chart creates the release namespace via --create-namespace
   skipNamespaceCreation: true
+  installCRDs: true
 
 imageBuilder:
   enabled: true


### PR DESCRIPTION
There are cloud environments that already ship with the knative `eventings` and `servings` CRDs, but we still need the knative-operator for serving to work.

This change makes CRDs conditional on a particular flag