### PR TITLE
Fix SSA conflict on aggregated knative-operator ClusterRoles

### DIFF
--- a/charts/knative-operator/templates/knative-operator.yaml
+++ b/charts/knative-operator/templates/knative-operator.yaml
@@ -239,7 +239,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -255,7 +258,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -271,7 +277,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -287,7 +296,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 
 ---
 # Copyright 2020 The Knative Authors

--- a/tests/generated/knative-operator.crds-disabled.yaml
+++ b/tests/generated/knative-operator.crds-disabled.yaml
@@ -175,7 +175,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -192,7 +195,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -209,7 +215,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -226,7 +235,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/knative-operator.default.yaml
+++ b/tests/generated/knative-operator.default.yaml
@@ -175,7 +175,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -192,7 +195,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -209,7 +215,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -226,7 +235,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors


### PR DESCRIPTION
## Summary

The four aggregated ClusterRoles in `charts/knative-operator/templates/knative-operator.yaml` declared `rules: []` alongside an `aggregationRule`. Under server-side apply (which Helm 4 uses by default via `--server-side=auto`), this caused Helm to claim ownership of `.rules`. The K8s `clusterrole-aggregation-controller` then forcibly transferred ownership to itself when it populated the field. Every subsequent `helm upgrade` then conflicted on `.rules` with the aggregation controller, failing the upgrade with the customer's exact error:

```
level=WARN msg="upgrade failed" name=unionai-dataplane error="conflict occurred while applying object /knative-serving-operator-aggregated-stable rbac.authorization.k8s.io/v1, Kind=ClusterRole: Apply failed with 1 conflict: conflict with \"clusterrole-aggregation-controller\": .rules"
Error: UPGRADE FAILED: conflict occurred while applying object /knative-serving-operator-aggregated-stable rbac.authorization.k8s.io/v1, Kind=ClusterRole: Apply failed with 1 conflict: conflict with "clusterrole-aggregation-controller": .rules
```

This affects all four aggregated roles: `knative-{serving,eventing}-operator-aggregated` and `-aggregated-stable`. Helm halts on the first conflict, so the customer only sees one role named in the error, but all four are broken the same way.

The fix omits `rules` from the manifest entirely. Helm no longer claims the field, the aggregation controller becomes the sole owner, and upgrades stop conflicting. Post-fix field ownership:

```
helm:                              f:aggregationRule, f:metadata
clusterrole-aggregation-controller: f:rules           (sole owner)
```

## Verification

Reproduced and fixed end-to-end on a local k3d cluster using `helm install` + `helm upgrade` (matching the customer's command).

| Step | Chart state | Command | Result |
|---|---|---|---|
| 1 | broken (`rules: []`) | `helm install` (rev 1) | succeeds |
| 2 | broken | `helm upgrade` (rev 2) | **`UPGRADE FAILED: ... conflict with "clusterrole-aggregation-controller": .rules`** |
| 3 | fixed (no `rules` field) | `helm upgrade` (rev 3, same release) | `Release ... has been upgraded. Happy Helming! STATUS: deployed` |

Step 3 is the recovery story: **stuck releases don't need to be uninstalled** — deploying the fixed chart over the failed revision recovers the release in place, with field ownership cleanly partitioned afterward.

## Snapshot updates

- `tests/generated/knative-operator.{default,crds-disabled}.yaml` — only the four expected `rules: []` → comment-block replacements
- `make test` (helm-test + kubeconform-test) passes
- `kubeconform` confirms a ClusterRole with no `.rules` is schema-valid (`rules` is `+optional` in the K8s API)

## Test plan

- [x] Reproduced the exact error against a k3d cluster with the broken chart via `helm install` + `helm upgrade`
- [x] Confirmed the fixed chart recovers the failed release in place via a follow-up `helm upgrade` (no uninstall required)
- [x] Confirmed post-fix field-manager ownership: `helm` owns `f:aggregationRule`/`f:metadata`, `clusterrole-aggregation-controller` is sole owner of `f:rules`
- [x] `make generate-expected` produces a diff scoped strictly to the four aggregated roles
- [x] `make test` passes