### PR TITLE
Add organizations service bootstrap for selfhosted deployments

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -763,6 +763,13 @@ services:
           - migrate
           - --config
           - "/etc/config/*.yaml"
+      - name: bootstrap
+        args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
+          - --config
+          - "/etc/config/*.yaml"
     args:
       - cloudorganizations
       - serve
@@ -773,6 +780,11 @@ services:
         connectPort: 8081
         metrics:
           scope: "organizations:"
+      organizations:
+        bootStrapConfig:
+          organizations:
+            - '{{ .Values.global.UNION_ORG }}'
+          tenantType: "SELF_MANAGED"
       db:
         debug: '{{ .Values.global.DB_DEBUG }}'
         dbname: '{{ .Values.global.DB_NAME }}'

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -1223,6 +1223,11 @@ data:
         type: json
       level: 6
       show-source: true
+    organizations:
+      bootStrapConfig:
+        organizations:
+        - ''
+        tenantType: SELF_MANAGED
     otel:
       type: noop
     sharedService:
@@ -8592,6 +8597,22 @@ spec:
           args:
           - cloudorganizations
           - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+        - name: organizations-bootstrap
+          image: registry.unionai.cloud/controlplane/services:2026.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
           - --config
           - /etc/config/*.yaml
           volumeMounts:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -1223,6 +1223,11 @@ data:
         type: json
       level: 6
       show-source: true
+    organizations:
+      bootStrapConfig:
+        organizations:
+        - ''
+        tenantType: SELF_MANAGED
     otel:
       type: noop
     sharedService:
@@ -8599,6 +8604,22 @@ spec:
           args:
           - cloudorganizations
           - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+        - name: organizations-bootstrap
+          image: registry.unionai.cloud/controlplane/services:2026.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
           - --config
           - /etc/config/*.yaml
           volumeMounts:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -1238,6 +1238,11 @@ data:
         type: json
       level: 6
       show-source: true
+    organizations:
+      bootStrapConfig:
+        organizations:
+        - ''
+        tenantType: SELF_MANAGED
     otel:
       type: noop
     sharedService:
@@ -8610,6 +8615,22 @@ spec:
           args:
           - cloudorganizations
           - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+        - name: organizations-bootstrap
+          image: registry.unionai.cloud/controlplane/services:2026.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
           - --config
           - /etc/config/*.yaml
           volumeMounts:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -1228,6 +1228,11 @@ data:
         type: json
       level: 6
       show-source: true
+    organizations:
+      bootStrapConfig:
+        organizations:
+        - ''
+        tenantType: SELF_MANAGED
     otel:
       type: noop
     sharedService:
@@ -8597,6 +8602,22 @@ spec:
           args:
           - cloudorganizations
           - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+        - name: organizations-bootstrap
+          image: registry.unionai.cloud/controlplane/services:2026.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
           - --config
           - /etc/config/*.yaml
           volumeMounts:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -1311,6 +1311,11 @@ data:
         type: json
       level: 6
       show-source: true
+    organizations:
+      bootStrapConfig:
+        organizations:
+        - 'test-org'
+        tenantType: SELF_MANAGED
     otel:
       type: noop
     sharedService:
@@ -8854,6 +8859,22 @@ spec:
           args:
           - cloudorganizations
           - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+        - name: organizations-bootstrap
+          image: registry.unionai.cloud/controlplane/services:2026.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
           - --config
           - /etc/config/*.yaml
           volumeMounts:


### PR DESCRIPTION
## Summary
- Adds bootstrap init container to organizations service that runs `bootstrap-tenant organizations` after DB migration
- Adds `bootStrapConfig` to organizations configMap using `global.UNION_ORG`

## Problem
The organizations service requires a seeded `orgs` table for the identity service prefetcher to list users. Without this bootstrap, `OrgService/List` returns 0 orgs and the identity service reports "Prefetched 0 users/apps" — users don't appear in the UI.

Unlike the authorizer (which has automatic `RunBootstrap` in `GrpcRegistrationHook`), the organizations service requires the CLI command `cloudorganizations bootstrap-tenant organizations` to be explicitly invoked.

## Test plan
- [x] `make generate-expected && make test` passes
- [x] Deploy to monty-selfhosted and verify orgs table is populated
- [ ] Verify users appear in the UI after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)