### PR TITLE
Bump chart versions to 2026.5.2

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,8 +3,8 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.1
-appVersion: 2026.5.1
+version: 2026.5.2
+appVersion: 2026.5.2
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane-crds
 description: Deploys the Union dataplane CRDs.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.1
-appVersion: 2026.5.1
+version: 2026.5.2
+appVersion: 2026.5.2
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: prometheus-operator-crds

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.1
-appVersion: 2026.5.1
+version: 2026.5.2
+appVersion: 2026.5.2
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.1
-appVersion: 2026.5.1
+version: 2026.5.2
+appVersion: 2026.5.2
 kubeVersion: '>= 1.28.0'

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -255,7 +255,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -266,10 +266,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -279,10 +279,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -291,10 +291,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -303,10 +303,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -315,10 +315,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -327,10 +327,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -339,10 +339,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -351,10 +351,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -363,10 +363,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -375,10 +375,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -388,10 +388,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -646,7 +646,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -712,10 +712,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -809,10 +809,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -899,10 +899,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1089,10 +1089,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1201,10 +1201,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1286,10 +1286,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1376,10 +1376,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1459,10 +1459,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1543,10 +1543,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1738,7 +1738,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6943,7 +6943,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6997,7 +6997,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7157,7 +7157,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7184,10 +7184,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7212,10 +7212,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7251,10 +7251,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7290,10 +7290,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7325,10 +7325,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7360,10 +7360,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7395,10 +7395,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7434,10 +7434,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7469,10 +7469,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7504,10 +7504,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8051,7 +8051,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8062,7 +8062,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9f9d83e26774ee3adccad2a3d7b298a787d56ea53bc0aeff3608f32ca0d56cf"
+        configChecksum: "a7eb2969df625de68d1582ef35634d8e50257eae5d33389905b8f31c7644c9d"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8071,7 +8071,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.1
+        helm.sh/chart: controlplane-2026.5.2
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8163,10 +8163,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8206,7 +8206,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.1"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8233,10 +8233,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8274,7 +8274,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8348,10 +8348,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8389,7 +8389,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8405,7 +8405,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8479,10 +8479,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8520,7 +8520,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8591,10 +8591,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8632,7 +8632,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8648,7 +8648,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8719,10 +8719,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8760,7 +8760,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8834,10 +8834,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8875,7 +8875,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8890,7 +8890,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8907,7 +8907,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8981,10 +8981,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -9023,7 +9023,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -9039,7 +9039,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -9110,10 +9110,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9151,7 +9151,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9167,7 +9167,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9239,10 +9239,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9280,7 +9280,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9387,10 +9387,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -255,7 +255,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -266,10 +266,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -279,10 +279,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -291,10 +291,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -303,10 +303,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -315,10 +315,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -327,10 +327,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -339,10 +339,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -351,10 +351,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -363,10 +363,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -375,10 +375,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -388,10 +388,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -646,7 +646,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -712,10 +712,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -809,10 +809,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -899,10 +899,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1089,10 +1089,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1201,10 +1201,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1286,10 +1286,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1376,10 +1376,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1459,10 +1459,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1543,10 +1543,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1738,7 +1738,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6943,7 +6943,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6997,7 +6997,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7157,7 +7157,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7184,10 +7184,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7212,10 +7212,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7251,10 +7251,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7290,10 +7290,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7325,10 +7325,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7360,10 +7360,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7395,10 +7395,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7434,10 +7434,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7469,10 +7469,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7504,10 +7504,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8051,7 +8051,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8062,7 +8062,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9f9d83e26774ee3adccad2a3d7b298a787d56ea53bc0aeff3608f32ca0d56cf"
+        configChecksum: "a7eb2969df625de68d1582ef35634d8e50257eae5d33389905b8f31c7644c9d"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8072,7 +8072,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.1
+        helm.sh/chart: controlplane-2026.5.2
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8164,10 +8164,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8208,7 +8208,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.1"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8235,10 +8235,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8277,7 +8277,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8351,10 +8351,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8393,7 +8393,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8409,7 +8409,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8483,10 +8483,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8525,7 +8525,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8596,10 +8596,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8638,7 +8638,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8654,7 +8654,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8725,10 +8725,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8767,7 +8767,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8841,10 +8841,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8883,7 +8883,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8898,7 +8898,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8915,7 +8915,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8989,10 +8989,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -9032,7 +9032,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -9048,7 +9048,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -9119,10 +9119,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9161,7 +9161,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9177,7 +9177,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9249,10 +9249,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9291,7 +9291,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9392,10 +9392,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -255,7 +255,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -268,10 +268,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -281,10 +281,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -293,10 +293,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -305,10 +305,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -317,10 +317,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -329,10 +329,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -341,10 +341,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -353,10 +353,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -365,10 +365,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -377,10 +377,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -390,10 +390,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -656,7 +656,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -727,10 +727,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -824,10 +824,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -914,10 +914,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1104,10 +1104,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1216,10 +1216,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1301,10 +1301,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1391,10 +1391,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1474,10 +1474,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1558,10 +1558,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1753,7 +1753,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6961,7 +6961,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7015,7 +7015,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7175,7 +7175,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7202,10 +7202,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7230,10 +7230,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7269,10 +7269,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7308,10 +7308,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7343,10 +7343,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7378,10 +7378,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7413,10 +7413,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7452,10 +7452,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7487,10 +7487,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7522,10 +7522,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8069,7 +8069,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8080,7 +8080,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cb43a075b229720280f27e72b5f147c51d10b8ee9bc0d32d7f9deeffaba5a4c"
+        configChecksum: "4ee6e6a267b9c27b6dfb2c48804a674053de2b12964c0674972774ca765b598"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8089,7 +8089,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.1
+        helm.sh/chart: controlplane-2026.5.2
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8181,10 +8181,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8224,7 +8224,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.1"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8251,10 +8251,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8292,7 +8292,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8366,10 +8366,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8407,7 +8407,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8423,7 +8423,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8497,10 +8497,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8538,7 +8538,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8609,10 +8609,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8650,7 +8650,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8666,7 +8666,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8737,10 +8737,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8778,7 +8778,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8852,10 +8852,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8893,7 +8893,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8908,7 +8908,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8925,7 +8925,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8999,10 +8999,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -9041,7 +9041,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -9057,7 +9057,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -9128,10 +9128,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9169,7 +9169,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9185,7 +9185,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9257,10 +9257,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9298,7 +9298,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9405,10 +9405,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -253,7 +253,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -264,10 +264,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -277,10 +277,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -289,10 +289,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -301,10 +301,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -313,10 +313,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -325,10 +325,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -337,10 +337,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -349,10 +349,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -361,10 +361,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -373,10 +373,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -386,10 +386,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -647,7 +647,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -713,10 +713,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -814,10 +814,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -904,10 +904,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1094,10 +1094,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1206,10 +1206,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1291,10 +1291,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1381,10 +1381,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1464,10 +1464,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1548,10 +1548,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1743,7 +1743,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6948,7 +6948,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7002,7 +7002,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7162,7 +7162,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7189,10 +7189,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7217,10 +7217,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7256,10 +7256,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7295,10 +7295,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7330,10 +7330,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7365,10 +7365,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7400,10 +7400,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7439,10 +7439,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7474,10 +7474,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7509,10 +7509,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8056,7 +8056,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8067,7 +8067,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "588c9b5b46ff917a57b2003ebe97c6a8f836428f40db5cd054dbe99762074f2"
+        configChecksum: "938536d375ec65246c12bba3a8c407ccffd719d24f7a26bbca4ba8f52231090"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8076,7 +8076,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.1
+        helm.sh/chart: controlplane-2026.5.2
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8168,10 +8168,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8211,7 +8211,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.1"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8238,10 +8238,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8279,7 +8279,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8353,10 +8353,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8394,7 +8394,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8410,7 +8410,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8484,10 +8484,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8525,7 +8525,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8596,10 +8596,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8637,7 +8637,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8653,7 +8653,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8724,10 +8724,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8765,7 +8765,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8839,10 +8839,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8880,7 +8880,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8895,7 +8895,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8912,7 +8912,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8986,10 +8986,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -9028,7 +9028,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -9044,7 +9044,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -9115,10 +9115,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9156,7 +9156,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9172,7 +9172,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9244,10 +9244,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9285,7 +9285,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9392,10 +9392,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -55,10 +55,10 @@ kind: PodDisruptionBudget
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: "33%"
@@ -270,10 +270,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
@@ -285,7 +285,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -296,10 +296,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -309,10 +309,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -321,10 +321,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -333,10 +333,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -345,10 +345,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -357,10 +357,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -369,10 +369,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -381,10 +381,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -393,10 +393,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -405,10 +405,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -418,10 +418,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -673,10 +673,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -722,7 +722,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -788,10 +788,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -897,10 +897,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -987,10 +987,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1177,10 +1177,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1289,10 +1289,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1374,10 +1374,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1464,10 +1464,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1547,10 +1547,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1631,10 +1631,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1826,7 +1826,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -7028,10 +7028,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -7047,7 +7047,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7098,10 +7098,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7121,7 +7121,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7277,10 +7277,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7303,7 +7303,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7330,10 +7330,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7358,10 +7358,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7397,10 +7397,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7436,10 +7436,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7471,10 +7471,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7506,10 +7506,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7541,10 +7541,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7580,10 +7580,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7615,10 +7615,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7650,10 +7650,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8194,10 +8194,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8212,7 +8212,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e5ed7b4fc5f2263c3d994290933ea69f0ffca703cb74ae6ab8f3227f7db78a27
+        checksum/config: 02a65f57e1c4697937fe0377832f790177f548e8ce980aa8f0b5205aa3cbc5b2
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8238,7 +8238,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -8313,7 +8313,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8324,7 +8324,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9f9d83e26774ee3adccad2a3d7b298a787d56ea53bc0aeff3608f32ca0d56cf"
+        configChecksum: "a7eb2969df625de68d1582ef35634d8e50257eae5d33389905b8f31c7644c9d"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8333,7 +8333,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.1
+        helm.sh/chart: controlplane-2026.5.2
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8425,10 +8425,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8468,7 +8468,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.1"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8495,10 +8495,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8536,7 +8536,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8610,10 +8610,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8651,7 +8651,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8667,7 +8667,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8741,10 +8741,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8782,7 +8782,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8853,10 +8853,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8894,7 +8894,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8910,7 +8910,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8981,10 +8981,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9022,7 +9022,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -9096,10 +9096,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9137,7 +9137,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -9152,7 +9152,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -9169,7 +9169,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -9243,10 +9243,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -9285,7 +9285,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -9301,7 +9301,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -9372,10 +9372,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9413,7 +9413,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9429,7 +9429,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9501,10 +9501,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9542,7 +9542,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.1
+          image: registry.unionai.cloud/controlplane/services:2026.5.2
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9643,10 +9643,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -9669,10 +9669,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.1
+    helm.sh/chart: controlplane-2026.5.2
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9757,7 +9757,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9857,7 +9857,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9965,7 +9965,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10033,7 +10033,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10100,7 +10100,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10210,7 +10210,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10526,10 +10526,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10576,10 +10576,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9787,7 +9787,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9885,7 +9885,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9991,7 +9991,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10059,7 +10059,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10124,7 +10124,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10232,7 +10232,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10548,10 +10548,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10598,10 +10598,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -10288,7 +10288,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10386,7 +10386,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10492,7 +10492,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10560,7 +10560,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10625,7 +10625,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10733,7 +10733,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -11136,10 +11136,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -11186,10 +11186,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9756,7 +9756,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9854,7 +9854,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9960,7 +9960,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10028,7 +10028,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10093,7 +10093,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10201,7 +10201,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10637,10 +10637,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10687,10 +10687,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -10215,7 +10215,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10313,7 +10313,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10419,7 +10419,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10487,7 +10487,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10552,7 +10552,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10660,7 +10660,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -11006,10 +11006,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -11056,10 +11056,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9824,7 +9824,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9923,7 +9923,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10030,7 +10030,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10098,7 +10098,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10164,7 +10164,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10273,7 +10273,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10589,10 +10589,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10639,10 +10639,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9824,7 +9824,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9923,7 +9923,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10030,7 +10030,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10098,7 +10098,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10164,7 +10164,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10273,7 +10273,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10589,10 +10589,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10639,10 +10639,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -9702,7 +9702,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -9953,7 +9953,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10051,7 +10051,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10159,7 +10159,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10227,7 +10227,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10292,7 +10292,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10400,7 +10400,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10703,10 +10703,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10753,10 +10753,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9773,7 +9773,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9871,7 +9871,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9977,7 +9977,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10045,7 +10045,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10110,7 +10110,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10218,7 +10218,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10534,10 +10534,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10584,10 +10584,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -10098,7 +10098,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10196,7 +10196,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10302,7 +10302,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10370,7 +10370,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10435,7 +10435,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10543,7 +10543,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10889,10 +10889,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10939,10 +10939,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9772,7 +9772,7 @@ spec:
             name: leaseworker
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9860,7 +9860,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9959,7 +9959,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10061,7 +10061,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10167,7 +10167,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10606,10 +10606,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10656,10 +10656,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9771,7 +9771,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9869,7 +9869,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9975,7 +9975,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10043,7 +10043,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10108,7 +10108,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10216,7 +10216,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10532,10 +10532,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10582,10 +10582,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9795,7 +9795,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9893,7 +9893,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9999,7 +9999,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10067,7 +10067,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10132,7 +10132,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10240,7 +10240,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10556,10 +10556,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10606,10 +10606,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -11880,7 +11880,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -11978,7 +11978,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -12084,7 +12084,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -12152,7 +12152,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -12217,7 +12217,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -12325,7 +12325,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -17095,10 +17095,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -17145,10 +17145,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -9222,7 +9222,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9918,7 +9918,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10016,7 +10016,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10122,7 +10122,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10190,7 +10190,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10255,7 +10255,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10363,7 +10363,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10679,10 +10679,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10729,10 +10729,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9816,7 +9816,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9928,7 +9928,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10048,7 +10048,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10122,7 +10122,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10195,7 +10195,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10317,7 +10317,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.1"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10647,10 +10647,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.1
+    helm.sh/chart: dataplane-2026.5.2
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.1"
+    app.kubernetes.io/version: "2026.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10697,10 +10697,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.1
+      helm.sh/chart: dataplane-2026.5.2
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.1"
+      app.kubernetes.io/version: "2026.5.2"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:


### PR DESCRIPTION
## Summary
- Bump `version` and `appVersion` to 2026.5.2 across controlplane, dataplane, dataplane-crds, and sandbox charts
- Tracks the 2026.5.2 image release published from buildkite/publish-images-release/builds/48
- Regenerated test snapshots reflect the new version label

## Test plan
- [x] `make gen_version_bump` ran cleanly
- [x] `make generate-expected` regenerated snapshots
- [ ] CI `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)