### PR TITLE
Fix SSA conflict on admissionregistration

### DIFF
--- a/charts/dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -61,7 +61,10 @@ webhooks:
         port: {{ .Values.flytepropellerwebhook.service.port }}
     failurePolicy: {{ .Values.flytepropellerwebhook.webhook.failurePolicy }}
     matchPolicy: Equivalent
-    namespaceSelector: {}
+    {{- with .Values.flytepropellerwebhook.webhook.webhooks.secrets.namespaceSelector }}
+    namespaceSelector:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     objectSelector:
       {{- with .Values.flytepropellerwebhook.webhook.webhooks.secrets.objectSelector }}
       {{- tpl (toYaml .) $ | nindent 6 }}
@@ -96,7 +99,10 @@ webhooks:
         port: {{ .Values.flytepropellerwebhook.service.port }}
     failurePolicy: {{ .Values.flytepropellerwebhook.webhook.failurePolicy }}
     matchPolicy: Equivalent
-    namespaceSelector: {}
+    {{- with .Values.flytepropellerwebhook.webhook.webhooks.managedImage.namespaceSelector }}
+    namespaceSelector:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     objectSelector:
       {{- with .Values.flytepropellerwebhook.webhook.webhooks.managedImage.objectSelector }}
       {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1267,6 +1267,9 @@ flytepropellerwebhook:
         name: union-pod-webhook.flyte.org
         # -- Path for the webhook
         path: /mutate--v1-pod/secrets
+        # -- Namespace selector for the webhook. If empty, the field is omitted and external controllers
+        # -- (e.g. admissionsenforcer) can manage it without SSA field ownership conflicts.
+        namespaceSelector: {}
         # -- Object selector for the webhook
         objectSelector:
           matchLabels:
@@ -1279,6 +1282,9 @@ flytepropellerwebhook:
         name: managed-image-webhook.union.ai
         # -- Path for the webhook
         path: /mutate--v1-pod/managed-image
+        # -- Namespace selector for the webhook. If empty, the field is omitted and external controllers
+        # -- (e.g. admissionsenforcer) can manage it without SSA field ownership conflicts.
+        namespaceSelector: {}
         # -- Object selector for the webhook (matchExpressions)
         objectSelector:
           matchLabels:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -10331,7 +10331,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -10353,7 +10353,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -10854,7 +10854,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -10442,7 +10442,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -10781,7 +10781,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -10394,7 +10394,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -10394,7 +10394,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -10521,7 +10521,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -10339,7 +10339,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -10664,7 +10664,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -10411,7 +10411,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -10337,7 +10337,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -10361,7 +10361,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -12487,7 +12487,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -10484,7 +10484,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -10452,7 +10452,6 @@ webhooks:
         port: 443
     failurePolicy: Fail
     matchPolicy: Equivalent
-    namespaceSelector: {}
     objectSelector:
       matchLabels:
         inject-flyte-secrets: "true"


### PR DESCRIPTION
Upgrading to `2026.5.2` fails with a conflict on the webhook `admissionregistration` due to trying to patch the namespaceSelector to be empty when the webhookconfiguration already has an existing config. 

For example on Azure it has this config

```
 Namespace Selector:                                                                                               │
│     Match Expressions:                                                                                              │
│       Key:       kubernetes.azure.com/managedby                                                                     │
│       Operator:  NotIn                                                                                              │
│       Values:                                                                                                       │
│         aks                                                                                                         │
│       Key:       control-plane                                                                                      │
│       Operator:  NotIn                                                                                              │
│       Values: 
```

whereas the upgrade tries to empty it, triggering a conflict.

This change removes the empty selector from the template and makes it configurable via values.

Upgraded to latest release without issues and without `--force-conflicts`