### PR TITLE
knative configmaps: remove conflicting label and bumping subchart

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -23,8 +23,8 @@ dependencies:
   condition: metrics-server.enabled
   alias: metrics-server
 - name: knative-operator
-  repository: https://unionai.github.io/helm-charts
-  version: 2026.4.5
+  repository: file://../knative-operator
+  version: 2026.4.6
   alias: knative-operator
   condition: knative-operator.enabled
 - name: fluent-bit

--- a/charts/knative-operator/Chart.yaml
+++ b/charts/knative-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: knative-operator
 description: Deploys Knative Operator
 type: application
-version: 2026.4.5
+version: 2026.4.6
 appVersion: 1.16.0
 kubeVersion: ">= 1.28.0-0"

--- a/charts/knative-operator/templates/knative-operator.yaml
+++ b/charts/knative-operator/templates/knative-operator.yaml
@@ -1300,7 +1300,6 @@ metadata:
   namespace: {{ include "knative-operator.namespace" . }}
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 
 ---
@@ -1325,7 +1324,6 @@ metadata:
   namespace: {{ include "knative-operator.namespace" . }}
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 
 ---

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -203,7 +203,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -228,7 +227,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7161,7 +7159,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7178,7 +7179,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7195,7 +7199,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7212,7 +7219,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -203,7 +203,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -228,7 +227,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7193,7 +7191,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7210,7 +7211,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7227,7 +7231,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7244,7 +7251,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -327,7 +327,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -352,7 +351,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7360,7 +7358,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7377,7 +7378,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7394,7 +7398,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7411,7 +7418,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -204,7 +204,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -229,7 +228,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7162,7 +7160,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7179,7 +7180,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7196,7 +7200,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7213,7 +7220,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -327,7 +327,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -352,7 +351,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7287,7 +7285,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7304,7 +7305,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7321,7 +7325,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7338,7 +7345,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -204,7 +204,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -229,7 +228,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7229,7 +7227,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7246,7 +7247,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7263,7 +7267,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7280,7 +7287,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -204,7 +204,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -229,7 +228,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7229,7 +7227,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7246,7 +7247,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7263,7 +7267,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7280,7 +7287,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -236,7 +236,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -261,7 +260,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7320,7 +7318,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7337,7 +7338,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7354,7 +7358,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7371,7 +7378,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -191,7 +191,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -216,7 +215,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7179,7 +7177,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7196,7 +7197,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7213,7 +7217,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7230,7 +7237,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -314,7 +314,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -339,7 +338,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7302,7 +7300,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7319,7 +7320,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7336,7 +7340,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7353,7 +7360,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -191,7 +191,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -216,7 +215,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7184,7 +7182,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7201,7 +7202,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7218,7 +7222,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7235,7 +7242,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -204,7 +204,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -229,7 +228,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7177,7 +7175,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7194,7 +7195,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7211,7 +7215,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7228,7 +7235,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -203,7 +203,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -228,7 +227,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7201,7 +7199,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7218,7 +7219,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7235,7 +7239,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7252,7 +7259,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -297,7 +297,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -322,7 +321,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/monitoring/charts/grafana/templates/configmap-dashboard-provider.yaml
@@ -8000,7 +7998,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8017,7 +8018,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8034,7 +8038,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8051,7 +8058,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -198,7 +198,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -223,7 +222,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7196,7 +7194,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7213,7 +7214,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7230,7 +7234,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7247,7 +7254,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -203,7 +203,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
@@ -228,7 +227,6 @@ metadata:
   namespace: "union"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: dataplane/charts/prometheus/templates/cm.yaml
@@ -7216,7 +7214,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7233,7 +7234,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7250,7 +7254,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7267,7 +7274,10 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors

--- a/tests/generated/knative-operator.crds-disabled.yaml
+++ b/tests/generated/knative-operator.crds-disabled.yaml
@@ -118,7 +118,6 @@ metadata:
   namespace: "knative-operator"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: knative-operator/templates/knative-operator.yaml
@@ -143,7 +142,6 @@ metadata:
   namespace: "knative-operator"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: knative-operator/templates/knative-operator.yaml

--- a/tests/generated/knative-operator.default.yaml
+++ b/tests/generated/knative-operator.default.yaml
@@ -118,7 +118,6 @@ metadata:
   namespace: "knative-operator"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: knative-operator/templates/knative-operator.yaml
@@ -143,7 +142,6 @@ metadata:
   namespace: "knative-operator"
   labels:
     app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/name: knative-operator
 data: {}
 ---
 # Source: knative-operator/templates/knative-operator.yaml


### PR DESCRIPTION
https://github.com/unionai/helm-charts/pull/371 introduced a fix for the conflict on knative aggregated cluster roles but we didn't bump the subchart version hence the change is still not deployed.

This change bumps the subchart, referencing the local path to avoid breaking (a follow up PR needs to revert to the upstream, then-upgraded version)

Also this change removes a conflicting field that the knative operator is meant to mutate but it keeps failing on upgrades as it's Helm-managed.

Tested by upgrading a cluster from the branch with no conflicts and no workarounds needed