### PR TITLE
controlplane: only render PDBs when replicaCount > 1

### DIFF
--- a/charts/controlplane/templates/console/pdb.yaml
+++ b/charts/controlplane/templates/console/pdb.yaml
@@ -1,6 +1,8 @@
 {{- $autoscaling := include "console.autoscaling" . | fromYaml }}
 {{- $replicaCount := .Values.console.replicaCount | int }}
-{{- if or (ge $replicaCount 1) (and $autoscaling.enabled (ge $autoscaling.maxReplicas 1)) }}
+{{- /* Render PDB only when there are at least 2 replicas — see
+       comment in controlplane/templates/pdb.yaml. */ -}}
+{{- if or (gt $replicaCount 1) (and $autoscaling.enabled (gt (int $autoscaling.maxReplicas) 1)) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/controlplane/templates/flyte-core-pdb.yaml
+++ b/charts/controlplane/templates/flyte-core-pdb.yaml
@@ -1,3 +1,9 @@
+{{- /* PDBs for flyte-core services. Render only when the service is
+       configured with >= 2 replicas: a `minAvailable: 1` PDB on a
+       single-replica deployment evaluates to ALLOWED DISRUPTIONS = 0,
+       blocking every voluntary eviction (node drain, autoscaler
+       consolidation). Mirrors the gating in dataplane/imagebuilder/pdb.yaml. */ -}}
+{{- if gt ((index .Values "flyte" "flyteadmin" "replicaCount") | default 1 | int) 1 }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -9,6 +15,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: flyteadmin
+{{- end }}
+{{- if gt ((index .Values "flyte" "datacatalog" "replicaCount") | default 1 | int) 1 }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -20,6 +28,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: datacatalog
+{{- end }}
+{{- if gt ((index .Values "flyte" "cacheservice" "replicaCount") | default 1 | int) 1 }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -31,3 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cacheservice
+{{- end }}

--- a/charts/controlplane/templates/pdb.yaml
+++ b/charts/controlplane/templates/pdb.yaml
@@ -4,7 +4,12 @@
 ---
 {{- $autoscaling := (include "unionai.autoscaling" $service | fromYaml) }}
 {{- $replicaCount := include "unionai.replicaCount" $service | trim | int}}
-{{- if and (not $service.config.disabled) (or (ge $replicaCount 1) (and $autoscaling.enabled (ge $autoscaling.maxReplicas 1))) }}
+{{- /* Render PDB only when there are at least 2 replicas. A PDB with
+       minAvailable: 33% on a single-replica deployment evaluates to ALLOWED
+       DISRUPTIONS = 0, which blocks every voluntary eviction (node drain,
+       autoscaler-triggered consolidation) on the cluster. Mirrors the gate
+       pattern already used by dataplane/templates/imagebuilder/pdb.yaml. */ -}}
+{{- if and (not $service.config.disabled) (or (gt $replicaCount 1) (and $autoscaling.enabled (gt (int $autoscaling.maxReplicas) 1))) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -31,169 +31,6 @@ spec:
       app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: webhook-server
 ---
-# Source: controlplane/templates/console/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: unionconsole
-  labels:
-    helm.sh/chart: controlplane-2026.5.2
-    app.kubernetes.io/name: unionconsole
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: unionconsole
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: flyteadmin
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: flyteadmin
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: datacatalog
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: datacatalog
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cacheservice
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cacheservice
----
-# Source: controlplane/templates/pdb.yaml
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: authorizer
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: authorizer
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cluster
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cluster
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dataproxy
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: dataproxy
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: executions
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: executions
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: identity
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: identity
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: organizations
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: organizations
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: queue
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: queue
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: run-scheduler
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: run-scheduler
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: usage
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: usage
-      app.kubernetes.io/instance: release-name
----
 # Source: controlplane/charts/flyte/templates/admin/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -11926,6 +11763,21 @@ webhooks:
 # Source: controlplane/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
 # PDB is not supported for DaemonSets.
 # https://github.com/kubernetes/kubernetes/issues/108124
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
 ---
 # Source: controlplane/templates/secret.yaml
 ---

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -31,169 +31,6 @@ spec:
       app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: webhook-server
 ---
-# Source: controlplane/templates/console/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: unionconsole
-  labels:
-    helm.sh/chart: controlplane-2026.5.2
-    app.kubernetes.io/name: unionconsole
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: unionconsole
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: flyteadmin
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: flyteadmin
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: datacatalog
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: datacatalog
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cacheservice
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cacheservice
----
-# Source: controlplane/templates/pdb.yaml
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: authorizer
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: authorizer
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cluster
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cluster
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dataproxy
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: dataproxy
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: executions
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: executions
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: identity
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: identity
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: organizations
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: organizations
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: queue
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: queue
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: run-scheduler
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: run-scheduler
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: usage
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: usage
-      app.kubernetes.io/instance: release-name
----
 # Source: controlplane/charts/flyte/templates/admin/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -11917,6 +11754,21 @@ webhooks:
 # Source: controlplane/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
 # PDB is not supported for DaemonSets.
 # https://github.com/kubernetes/kubernetes/issues/108124
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
 ---
 # Source: controlplane/templates/secret.yaml
 ---

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -31,169 +31,6 @@ spec:
       app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: webhook-server
 ---
-# Source: controlplane/templates/console/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: unionconsole
-  labels:
-    helm.sh/chart: controlplane-2026.5.2
-    app.kubernetes.io/name: unionconsole
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: unionconsole
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: flyteadmin
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: flyteadmin
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: datacatalog
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: datacatalog
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cacheservice
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cacheservice
----
-# Source: controlplane/templates/pdb.yaml
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: authorizer
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: authorizer
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cluster
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cluster
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dataproxy
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: dataproxy
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: executions
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: executions
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: identity
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: identity
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: organizations
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: organizations
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: queue
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: queue
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: run-scheduler
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: run-scheduler
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: usage
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: usage
-      app.kubernetes.io/instance: release-name
----
 # Source: controlplane/charts/flyte/templates/admin/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -11930,6 +11767,21 @@ webhooks:
 # Source: controlplane/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
 # PDB is not supported for DaemonSets.
 # https://github.com/kubernetes/kubernetes/issues/108124
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
 ---
 # Source: controlplane/templates/secret.yaml
 ---

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -31,169 +31,6 @@ spec:
       app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: webhook-server
 ---
-# Source: controlplane/templates/console/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: unionconsole
-  labels:
-    helm.sh/chart: controlplane-2026.5.2
-    app.kubernetes.io/name: unionconsole
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: unionconsole
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: flyteadmin
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: flyteadmin
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: datacatalog
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: datacatalog
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cacheservice
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cacheservice
----
-# Source: controlplane/templates/pdb.yaml
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: authorizer
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: authorizer
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cluster
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cluster
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dataproxy
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: dataproxy
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: executions
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: executions
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: identity
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: identity
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: organizations
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: organizations
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: queue
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: queue
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: run-scheduler
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: run-scheduler
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: usage
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: usage
-      app.kubernetes.io/instance: release-name
----
 # Source: controlplane/charts/flyte/templates/admin/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -11917,6 +11754,21 @@ webhooks:
 # Source: controlplane/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
 # PDB is not supported for DaemonSets.
 # https://github.com/kubernetes/kubernetes/issues/108124
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
 ---
 # Source: controlplane/templates/secret.yaml
 ---

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -49,169 +49,6 @@ spec:
       app.kubernetes.io/name: union-authz
       app.kubernetes.io/instance: release-name
 ---
-# Source: controlplane/templates/console/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: unionconsole
-  labels:
-    helm.sh/chart: controlplane-2026.5.2
-    app.kubernetes.io/name: unionconsole
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: unionconsole
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: flyteadmin
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: flyteadmin
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: datacatalog
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: datacatalog
----
-# Source: controlplane/templates/flyte-core-pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cacheservice
-  namespace: union
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cacheservice
----
-# Source: controlplane/templates/pdb.yaml
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: authorizer
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: authorizer
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cluster
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cluster
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: dataproxy
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: dataproxy
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: executions
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: executions
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: identity
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: identity
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: organizations
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: organizations
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: queue
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: queue
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: run-scheduler
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: run-scheduler
-      app.kubernetes.io/instance: release-name
----
-# Source: controlplane/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: usage
-spec:
-  minAvailable: "33%"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: usage
-      app.kubernetes.io/instance: release-name
----
 # Source: controlplane/charts/flyte/templates/admin/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -12194,6 +12031,21 @@ webhooks:
 # Source: controlplane/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
 # PDB is not supported for DaemonSets.
 # https://github.com/kubernetes/kubernetes/issues/108124
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
 ---
 # Source: controlplane/templates/secret.yaml
 ---


### PR DESCRIPTION
## Summary

Three PDB templates emit `PodDisruptionBudget`s unconditionally for deployments that default to a single replica:

- `charts/controlplane/templates/pdb.yaml` (per-service loop: authorizer, cluster, dataproxy, executions, organizations, queue, run-scheduler, usage)
- `charts/controlplane/templates/console/pdb.yaml` (unionconsole)
- `charts/controlplane/templates/flyte-core-pdb.yaml` (flyteadmin, datacatalog, cacheservice)

With `minAvailable: 1` (or `"33%"` which rounds up to 1) on a single-replica deployment, the PDB exposes **`ALLOWED DISRUPTIONS = 0`** — every voluntary eviction (node drain during GKE/EKS rolling upgrade, cluster-autoscaler consolidation, manual `kubectl drain`) is blocked indefinitely until someone manually deletes the pod or scales up replicas.

This was caught when a GKE rolling node upgrade on a selfhosted env sat for >1 hour waiting on these PDBs before we noticed. The 13 affected single-replica services across the CP chart all block drains in the default config.

## Change

Gate each PDB on `gt replicaCount 1` (and `gt maxReplicas 1` when autoscaling is enabled). Matches the pattern already used by `dataplane/templates/imagebuilder/pdb.yaml`.

- Users who actually run HA replicas keep their PDB (still ≥1 available during disruption).
- Users running default single-replica get a chart that doesn't stall infra operations.

## Test plan

- [x] `make generate-expected` re-renders 5 controlplane snapshots; diff is **only** removed `PodDisruptionBudget` resources (no other resource type changes)
- [x] `make test` (kubeconform) passes
- [x] Validated against the gating already used by `dataplane/imagebuilder/pdb.yaml` — same idiom
- [ ] Reviewer should confirm the `gt` vs `ge` semantic is correct for their topology (this PR adopts the "skip PDB unless ≥2 replicas" stance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)