### PR TITLE
dataplane: disable 2nd mutating webhook config when managedConfig is set

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1548,7 +1548,7 @@ union-pod-webhook
 {{- $_ := set $webhook "serviceName" (include "flytepropellerwebhook.serviceName" .) }}
 {{- $_ := set $webhook "secretName" (include "flytepropellerwebhook.secretName" .) }}
 {{- $_ := set $webhook "localCert" true }}
-{{- if .Values.low_privilege }}
+{{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
 {{- if include "singleNamespace" . }}

--- a/charts/dataplane/templates/propeller/configmap.yaml
+++ b/charts/dataplane/templates/propeller/configmap.yaml
@@ -21,7 +21,7 @@ data:
 {{- if include "singleNamespace" $ }}
 {{- $_ := set (index $core "propeller") "limit-namespace" .Release.Namespace }}
 {{- end }}
-{{- if .Values.low_privilege }}
+{{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- if not (hasKey $core "webhook") }}
 {{- $_ := set $core "webhook" (dict "disableCreateMutatingWebhookConfig" true) }}
 {{- else }}

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -1031,6 +1031,7 @@ data:
     
     webhook:
       certDir: /etc/webhook/certs
+      disableCreateMutatingWebhookConfig: true
       embeddedSecretManagerConfig:
         imagePullSecrets:
           enabled: true
@@ -9938,7 +9939,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "94e894bde82ff0212c0a9d8d5e6041febec3ca2730a8bcb902faa3ce061c6fc"
+        configChecksum: "59b1ef29e2ed9038bde29b9ffc3ed91cdbc637b24bf4e1c369f12d1754eee41"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -10398,7 +10399,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "94e894bde82ff0212c0a9d8d5e6041febec3ca2730a8bcb902faa3ce061c6fc"
+        configChecksum: "59b1ef29e2ed9038bde29b9ffc3ed91cdbc637b24bf4e1c369f12d1754eee41"
         
     spec:
       securityContext:


### PR DESCRIPTION
## Summary

The dataplane chart sets `disableCreateMutatingWebhookConfig: true` (in both the `union-pod-webhook` helper and the propeller configmap) only when `low_privilege` is set. But when `flytepropellerwebhook.enabled` + `flytepropellerwebhook.managedConfig` are set, the webhook deployment manages its own `MutatingWebhookConfiguration` — so propeller should not also try to create one, or we end up with a second/conflicting config.

This gates the `disableCreateMutatingWebhookConfig: true` setting on either condition:

```
{{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
```

Applied in both places that previously checked `low_privilege` alone:
- `charts/dataplane/templates/_helpers.tpl` (union-pod-webhook helper)
- `charts/dataplane/templates/propeller/configmap.yaml`

## Test plan

- [x] `make generate-expected` — `tests/generated/dataplane.clusterresourcesync.yaml` picks up `disableCreateMutatingWebhookConfig: true` in the propeller webhook config + corresponding `configChecksum` updates
- [x] `make test` passes
- [x] Validate on a selfhosted dataplane with `flytepropellerwebhook.enabled=true` + `managedConfig=true` that only one `MutatingWebhookConfiguration` is reconciled

🤖 Generated with [Claude Code](https://claude.com/claude-code)