### PR TITLE
Revert imageBuilder authenticationType auto-detect

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1493,25 +1493,6 @@ Otherwise, build it from imagebuilder.defaultRegistry plus the provider-specific
 {{- end -}}
 
 {{/*
-Returns the image builder authentication type.
-If imageBuilder.authenticationType is explicitly set (non-empty, not "noop"), use it.
-Otherwise, auto-detect from the cloud provider.
-*/}}
-{{- define "imagebuilder.authenticationType" -}}
-{{- if and .Values.imageBuilder.authenticationType (ne .Values.imageBuilder.authenticationType "noop") -}}
-  {{- .Values.imageBuilder.authenticationType -}}
-{{- else if eq (tpl .Values.storage.provider .) "aws" -}}
-  {{- "aws" -}}
-{{- else if or (eq (tpl .Values.storage.provider .) "gcp") (eq (tpl .Values.storage.provider .) "gcs") (eq (.Values.provider | default "") "gcp") -}}
-  {{- "google" -}}
-{{- else if or (eq (tpl .Values.storage.provider .) "azure") (eq (.Values.provider | default "") "azure") -}}
-  {{- "azure" -}}
-{{- else -}}
-  {{- .Values.imageBuilder.authenticationType | default "noop" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Returns "true" when namespaces.enabled is false, indicating single-namespace mode.
 In this mode, templates auto-inject namespace-scoping config (limitNamespace, limit-namespace,
 namespace_mapping) so users only need to set namespaces.enabled: false.

--- a/charts/dataplane/templates/imagebuilder/build-image-configmap.yaml
+++ b/charts/dataplane/templates/imagebuilder/build-image-configmap.yaml
@@ -13,5 +13,5 @@ data:
   buildkit-uri: ""
 {{- end }}
   default-repository: {{ include "imagebuilder.defaultRepository" . | quote }}
-  authentication-type: {{ include "imagebuilder.authenticationType" . | quote }}
+  authentication-type: {{ .Values.imageBuilder.authenticationType | quote }}
 {{- end }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -120,5 +120,5 @@ data:
   image-builder.buildkit-uri: ""
 {{- end }}
   image-builder.default-repository: {{ include "imagebuilder.defaultRepository" . | quote }}
-  image-builder.authentication-type: {{ include "imagebuilder.authenticationType" . | quote }}
+  image-builder.authentication-type: {{ .Values.imageBuilder.authenticationType | quote }}
 {{- end }}

--- a/charts/dataplane/values.aws.eks-automode.yaml
+++ b/charts/dataplane/values.aws.eks-automode.yaml
@@ -107,6 +107,15 @@ storage:
   enableMultiContainer: true
 
 # ----------------------------------------------------------------------------
+# Image Builder Authentication (OPTIONAL)
+# ----------------------------------------------------------------------------
+# By default, the image builder uses authenticationType: "noop". Uncomment and
+# set "aws" if you want the builder to authenticate to ECR via the AWS provider
+# credential chain (IRSA / EC2 instance profile).
+# imageBuilder:
+#   authenticationType: aws
+
+# ----------------------------------------------------------------------------
 # SECTION 4: IAM Roles (REQUIRED for AWS)
 # ----------------------------------------------------------------------------
 # Configure IRSA (IAM Roles for Service Accounts) for secure AWS access.

--- a/charts/dataplane/values.aws.selfhosted-intracluster.yaml
+++ b/charts/dataplane/values.aws.selfhosted-intracluster.yaml
@@ -594,6 +594,10 @@ dcgm-exporter:
 # so rootless buildkit fails with "no space left on device" (ENOSPC from the
 # kernel when user namespace creation is denied). Use privileged mode instead.
 imageBuilder:
+  # Image builder defaults to authenticationType: "noop". Uncomment to
+  # authenticate to ECR via the AWS provider credential chain
+  # (IRSA / EC2 instance profile).
+  # authenticationType: aws
   buildkit:
     rootless: false
 

--- a/charts/dataplane/values.aws.yaml
+++ b/charts/dataplane/values.aws.yaml
@@ -106,6 +106,15 @@ storage:
   enableMultiContainer: true
 
 # ----------------------------------------------------------------------------
+# Image Builder Authentication (OPTIONAL)
+# ----------------------------------------------------------------------------
+# By default, the image builder uses authenticationType: "noop". Uncomment and
+# set "aws" if you want the builder to authenticate to ECR via the AWS provider
+# credential chain (IRSA / EC2 instance profile).
+# imageBuilder:
+#   authenticationType: aws
+
+# ----------------------------------------------------------------------------
 # SECTION 4: IAM Roles (REQUIRED for AWS)
 # ----------------------------------------------------------------------------
 # Configure IRSA (IAM Roles for Service Accounts) for secure AWS access.

--- a/charts/dataplane/values.azure.yaml
+++ b/charts/dataplane/values.azure.yaml
@@ -125,6 +125,15 @@ storage:
         # key: ""
 
 # ----------------------------------------------------------------------------
+# Image Builder Authentication (OPTIONAL)
+# ----------------------------------------------------------------------------
+# By default, the image builder uses authenticationType: "noop". Uncomment and
+# set "azure" if you want the builder to authenticate to ACR via the Azure
+# provider credential chain (Workload Identity / Managed Identity).
+# imageBuilder:
+#   authenticationType: azure
+
+# ----------------------------------------------------------------------------
 # SECTION 4: Workload Identity (REQUIRED for Azure)
 # ----------------------------------------------------------------------------
 # Configure Azure Workload Identity for secure Azure access.

--- a/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
+++ b/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
@@ -163,6 +163,15 @@ image:
     # tag will be set from Chart.AppVersion or can be overridden
 
 # ----------------------------------------------------------------------------
+# Image Builder Authentication (OPTIONAL)
+# ----------------------------------------------------------------------------
+# By default, the image builder uses authenticationType: "noop". Uncomment and
+# set "google" if you want the builder to authenticate to Artifact Registry / GCR
+# via the GCP provider credential chain (Workload Identity / GKE metadata).
+# imageBuilder:
+#   authenticationType: google
+
+# ----------------------------------------------------------------------------
 # SECTION 5: Workload Identity (REQUIRED for GCP)
 # ----------------------------------------------------------------------------
 # Configure Workload Identity for secure GCP access.

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -1,5 +1,12 @@
 # Work in progress: GCP specific overrides for dataplane chart
 
+# Image Builder Authentication (OPTIONAL)
+# By default, the image builder uses authenticationType: "noop". Uncomment and
+# set "google" if you want the builder to authenticate to Artifact Registry / GCR
+# via the GCP provider credential chain (Workload Identity / GKE metadata).
+# imageBuilder:
+#   authenticationType: google
+
 # DCGM Exporter
 dcgm-exporter:
   enabled: true

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -786,7 +786,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: ".dkr.ecr.us-east-1.amazonaws.com/union-dataplane"
-  authentication-type: "aws"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3686,7 +3686,7 @@ data:
         region: us-east-1
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: ".dkr.ecr.us-east-1.amazonaws.com/union-dataplane"
-  image-builder.authentication-type: "aws"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -9950,7 +9950,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1b59c3a9b98c82b9efa61b11a7d19a48678684bea7190029705b79d22befedc"
+        configChecksum: "ee9ebbcac0b3f02f8ca8f43ae02e96fa22a27fd3806ceffc42232ed221ec5a2"
         prometheus.io/scrape: "true"
       labels:
         
@@ -10087,7 +10087,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1b59c3a9b98c82b9efa61b11a7d19a48678684bea7190029705b79d22befedc"
+        configChecksum: "ee9ebbcac0b3f02f8ca8f43ae02e96fa22a27fd3806ceffc42232ed221ec5a2"
         prometheus.io/scrape: "true"
       labels:
         

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -910,7 +910,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: ".dkr.ecr.test-region.amazonaws.com/union-dataplane"
-  authentication-type: "aws"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3885,7 +3885,7 @@ data:
         region: test-region
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: ".dkr.ecr.test-region.amazonaws.com/union-dataplane"
-  image-builder.authentication-type: "aws"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -10479,7 +10479,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4c2425b13312e08ab6037aafa8f457c262ed50d0b65985635ee22c971ed81"
+        configChecksum: "a2192f701241b2d5982eb4418b9d830a33ce0691477a252dcfc96361775e389"
         
       labels:
         
@@ -10614,7 +10614,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4c2425b13312e08ab6037aafa8f457c262ed50d0b65985635ee22c971ed81"
+        configChecksum: "a2192f701241b2d5982eb4418b9d830a33ce0691477a252dcfc96361775e389"
         
       labels:
         

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -787,7 +787,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: ".dkr.ecr.us-east-2.amazonaws.com/union-dataplane"
-  authentication-type: "aws"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3687,7 +3687,7 @@ data:
         region: us-east-2
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: ".dkr.ecr.us-east-2.amazonaws.com/union-dataplane"
-  image-builder.authentication-type: "aws"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -9947,7 +9947,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "75cc95f1f9fdc790165c940934bf967f9f23aeb1f2db6fa07651eb88379998b"
+        configChecksum: "424d91c5592548a7b1d6443378c143ca75ace35dfff57dc6dc4adce314e0702"
         
       labels:
         
@@ -10082,7 +10082,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "75cc95f1f9fdc790165c940934bf967f9f23aeb1f2db6fa07651eb88379998b"
+        configChecksum: "424d91c5592548a7b1d6443378c143ca75ace35dfff57dc6dc4adce314e0702"
         
       labels:
         

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -910,7 +910,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: ".dkr.ecr.test-region.amazonaws.com/union-dataplane"
-  authentication-type: "aws"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3812,7 +3812,7 @@ data:
         region: test-region
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: ".dkr.ecr.test-region.amazonaws.com/union-dataplane"
-  image-builder.authentication-type: "aws"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -10406,7 +10406,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "15078554163114187e6191f07b791dcd033dd3cd7ccca6f3fc54f9540df8e05"
+        configChecksum: "ab25585d71a4f2fd6ec3df1f44d9fb032303b51e857ed2855f7b607d0ef3e32"
         
       labels:
         
@@ -10541,7 +10541,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "15078554163114187e6191f07b791dcd033dd3cd7ccca6f3fc54f9540df8e05"
+        configChecksum: "ab25585d71a4f2fd6ec3df1f44d9fb032303b51e857ed2855f7b607d0ef3e32"
         
       labels:
         

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -778,7 +778,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: "union-dataplane.azurecr.io"
-  authentication-type: "azure"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3754,7 +3754,7 @@ data:
       type: stow
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: "union-dataplane.azurecr.io"
-  image-builder.authentication-type: "azure"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -10016,7 +10016,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bf26331f6c4ad12975cdfe53d4d09c3d5520eee22d7abdaca1156a926344d47"
+        configChecksum: "223b5279ab1837bf5306f4dbb6c825759c3ab2b782db0c927eecdeb180f0703"
         
       labels:
         
@@ -10152,7 +10152,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bf26331f6c4ad12975cdfe53d4d09c3d5520eee22d7abdaca1156a926344d47"
+        configChecksum: "223b5279ab1837bf5306f4dbb6c825759c3ab2b782db0c927eecdeb180f0703"
         
       labels:
         

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -778,7 +778,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: "union-dataplane.azurecr.io"
-  authentication-type: "azure"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3754,7 +3754,7 @@ data:
       type: stow
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: "union-dataplane.azurecr.io"
-  image-builder.authentication-type: "azure"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -10016,7 +10016,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b270461ed900b2258d647b1f92a2b105f8ea7af699ab7e85f2b7c2685d7c3c0"
+        configChecksum: "3f525b98cdec4b09e3ae97986be3a67487e86c952224d5a876debda05cfd85b"
         
       labels:
         
@@ -10152,7 +10152,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b270461ed900b2258d647b1f92a2b105f8ea7af699ab7e85f2b7c2685d7c3c0"
+        configChecksum: "3f525b98cdec4b09e3ae97986be3a67487e86c952224d5a876debda05cfd85b"
         
       labels:
         

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -790,7 +790,7 @@ data:
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   default-repository: "us-central1-docker.pkg.dev/test-gcp-project-123/union-dataplane"
-  authentication-type: "google"
+  authentication-type: "noop"
 ---
 # Source: dataplane/templates/imagebuilder/configmap.yaml
 apiVersion: v1
@@ -3702,7 +3702,7 @@ data:
             scopes: https://www.googleapis.com/auth/cloud-platform
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
   image-builder.default-repository: "us-central1-docker.pkg.dev/test-gcp-project-123/union-dataplane"
-  image-builder.authentication-type: "google"
+  image-builder.authentication-type: "noop"
 ---
 # Source: dataplane/templates/serving/bootstrap-configmap.yaml
 # We need to copy the default configmap here since knative-operator does not automatically update the
@@ -9962,7 +9962,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "762fa67e0a8a1ad90ef507b4cc3d857e052f0b66b5fba757e26a1f4756a4928"
+        configChecksum: "9e4a3a98ba2e91460d8b952b8ae0be8609f9608488bd48e630cc9e6c3af6ffd"
         
       labels:
         
@@ -10097,7 +10097,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "762fa67e0a8a1ad90ef507b4cc3d857e052f0b66b5fba757e26a1f4756a4928"
+        configChecksum: "9e4a3a98ba2e91460d8b952b8ae0be8609f9608488bd48e630cc9e6c3af6ffd"
         
       labels:
         


### PR DESCRIPTION
## Summary

Reverts the imageBuilder authentication-type auto-detection introduced in PR #210 ([commit `cb48bbcd`](https://github.com/unionai/helm-charts/commit/cb48bbcdbb544c4c2598bb480dbcc5b55add5fb2)). The configmaps now render the explicit `.Values.imageBuilder.authenticationType` directly, so an operator's configured value (including `"noop"`) is honored verbatim.

## Why

A selfhosted operator reported that their explicit `imageBuilder.authenticationType: "noop"` on AWS was being silently rewritten to `"aws"` by the helper, breaking their ECR auth setup.

- Helper introduced in: PR #210 "🚨 Breaking Change - Dataplane - Sane defaults" (commit [`cb48bbcd`](https://github.com/unionai/helm-charts/commit/cb48bbcdbb544c4c2598bb480dbcc5b55add5fb2))

The helper treated `"noop"` as a sentinel for "auto-detect", which prevented operators from intentionally selecting that mode on a recognized cloud. Explicit is better — operators who want the provider credential chain can set the value themselves.

## Changes

- Remove the `imagebuilder.authenticationType` helper from `charts/dataplane/templates/_helpers.tpl`
- Render `.Values.imageBuilder.authenticationType` directly in:
  - `charts/dataplane/templates/imagebuilder/build-image-configmap.yaml`
  - `charts/dataplane/templates/operator/configmap.yaml`
- Add a commented-out hint in each cloud overlay (`values.{aws,gcp,azure}*.yaml`) pointing operators at the explicit `authenticationType` value if they want the provider credential chain
- Regenerate snapshots — AWS/GCP/Azure tests now render `"noop"` (chart default) instead of the auto-derived cloud value

## Migration

Operators who relied on the auto-detection (i.e., didn't set `imageBuilder.authenticationType`) and need the cloud provider credential chain must now set the value explicitly in their values file:

```yaml
imageBuilder:
  authenticationType: aws    # or "google" / "azure" / "basic"
```

## Test plan

- [x] `make generate-expected` regenerated snapshots
- [ ] CI `make test` passes
- [ ] Operator confirms `"noop"` is now respected on their deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)