### PR TITLE
Release 2026.5.4

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,8 +3,8 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.2
-appVersion: 2026.5.2
+version: 2026.5.4
+appVersion: 2026.5.4
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane-crds
 description: Deploys the Union dataplane CRDs.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.2
-appVersion: 2026.5.2
+version: 2026.5.4
+appVersion: 2026.5.4
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: prometheus-operator-crds

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.2
-appVersion: 2026.5.2
+version: 2026.5.4
+appVersion: 2026.5.4
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.2
-appVersion: 2026.5.2
+version: 2026.5.4
+appVersion: 2026.5.4
 kubeVersion: '>= 1.28.0'

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -92,7 +92,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -103,10 +103,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -116,10 +116,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -128,10 +128,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -140,10 +140,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -152,10 +152,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -164,10 +164,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -176,10 +176,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -188,10 +188,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -200,10 +200,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -212,10 +212,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -225,10 +225,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -483,7 +483,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -549,10 +549,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -646,10 +646,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -736,10 +736,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -926,10 +926,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1038,10 +1038,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1123,10 +1123,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1213,10 +1213,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1296,10 +1296,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1380,10 +1380,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1575,7 +1575,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6780,7 +6780,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6834,7 +6834,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6994,7 +6994,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7021,10 +7021,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7049,10 +7049,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7088,10 +7088,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7127,10 +7127,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7162,10 +7162,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7197,10 +7197,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7232,10 +7232,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7271,10 +7271,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7306,10 +7306,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7341,10 +7341,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7888,7 +7888,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7899,7 +7899,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a7eb2969df625de68d1582ef35634d8e50257eae5d33389905b8f31c7644c9d"
+        configChecksum: "291a68516f0739f84ead2e91fc34bfaadf0d92eeefef181b8d219bc29141f65"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7908,7 +7908,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.2
+        helm.sh/chart: controlplane-2026.5.4
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8000,10 +8000,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8043,7 +8043,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.4"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8070,10 +8070,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8111,7 +8111,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8185,10 +8185,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8226,7 +8226,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8242,7 +8242,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8316,10 +8316,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8357,7 +8357,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8428,10 +8428,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8469,7 +8469,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8485,7 +8485,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8556,10 +8556,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8597,7 +8597,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8671,10 +8671,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8712,7 +8712,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8727,7 +8727,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8744,7 +8744,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8818,10 +8818,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8860,7 +8860,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8876,7 +8876,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8947,10 +8947,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8988,7 +8988,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9004,7 +9004,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9076,10 +9076,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9117,7 +9117,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9224,10 +9224,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -92,7 +92,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -103,10 +103,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -116,10 +116,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -128,10 +128,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -140,10 +140,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -152,10 +152,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -164,10 +164,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -176,10 +176,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -188,10 +188,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -200,10 +200,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -212,10 +212,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -225,10 +225,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -483,7 +483,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -549,10 +549,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -646,10 +646,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -736,10 +736,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -926,10 +926,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1038,10 +1038,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1123,10 +1123,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1213,10 +1213,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1296,10 +1296,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1380,10 +1380,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1575,7 +1575,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6780,7 +6780,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6834,7 +6834,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6994,7 +6994,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7021,10 +7021,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7049,10 +7049,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7088,10 +7088,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7127,10 +7127,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7162,10 +7162,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7197,10 +7197,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7232,10 +7232,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7271,10 +7271,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7306,10 +7306,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7341,10 +7341,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7888,7 +7888,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7899,7 +7899,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a7eb2969df625de68d1582ef35634d8e50257eae5d33389905b8f31c7644c9d"
+        configChecksum: "291a68516f0739f84ead2e91fc34bfaadf0d92eeefef181b8d219bc29141f65"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7909,7 +7909,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.2
+        helm.sh/chart: controlplane-2026.5.4
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8001,10 +8001,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8045,7 +8045,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.4"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8072,10 +8072,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8114,7 +8114,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8188,10 +8188,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8230,7 +8230,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8246,7 +8246,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8320,10 +8320,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8362,7 +8362,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8433,10 +8433,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8475,7 +8475,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8491,7 +8491,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8562,10 +8562,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8604,7 +8604,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8678,10 +8678,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8720,7 +8720,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8735,7 +8735,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8752,7 +8752,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8826,10 +8826,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8869,7 +8869,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8885,7 +8885,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8956,10 +8956,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8998,7 +8998,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9014,7 +9014,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9086,10 +9086,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9128,7 +9128,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9229,10 +9229,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -92,7 +92,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -105,10 +105,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -118,10 +118,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -130,10 +130,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -142,10 +142,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -154,10 +154,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -166,10 +166,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -178,10 +178,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -190,10 +190,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -202,10 +202,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -214,10 +214,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -227,10 +227,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -493,7 +493,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -564,10 +564,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -661,10 +661,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -751,10 +751,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -941,10 +941,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1053,10 +1053,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1138,10 +1138,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1228,10 +1228,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1311,10 +1311,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1395,10 +1395,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1590,7 +1590,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6798,7 +6798,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6852,7 +6852,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7012,7 +7012,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7039,10 +7039,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7067,10 +7067,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7106,10 +7106,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7145,10 +7145,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7180,10 +7180,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7215,10 +7215,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7250,10 +7250,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7289,10 +7289,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7324,10 +7324,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7359,10 +7359,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7906,7 +7906,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7917,7 +7917,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4ee6e6a267b9c27b6dfb2c48804a674053de2b12964c0674972774ca765b598"
+        configChecksum: "9f74b9ec811eea8a8055b0d346fd41db11948d2d5dee11d4f2403a0022b24fe"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7926,7 +7926,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.2
+        helm.sh/chart: controlplane-2026.5.4
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8018,10 +8018,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8061,7 +8061,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.4"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8088,10 +8088,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8129,7 +8129,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8203,10 +8203,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8244,7 +8244,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8260,7 +8260,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8334,10 +8334,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8375,7 +8375,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8446,10 +8446,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8487,7 +8487,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8503,7 +8503,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8574,10 +8574,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8615,7 +8615,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8689,10 +8689,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8730,7 +8730,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8745,7 +8745,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8762,7 +8762,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8836,10 +8836,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8878,7 +8878,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8894,7 +8894,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8965,10 +8965,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9006,7 +9006,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9022,7 +9022,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9094,10 +9094,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9135,7 +9135,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9242,10 +9242,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -90,7 +90,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -101,10 +101,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -114,10 +114,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -126,10 +126,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -138,10 +138,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -150,10 +150,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -162,10 +162,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -174,10 +174,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -186,10 +186,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -198,10 +198,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -210,10 +210,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -223,10 +223,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -484,7 +484,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -550,10 +550,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -651,10 +651,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -741,10 +741,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -931,10 +931,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1043,10 +1043,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1128,10 +1128,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1218,10 +1218,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1301,10 +1301,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1385,10 +1385,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1580,7 +1580,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6785,7 +6785,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6839,7 +6839,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6999,7 +6999,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7026,10 +7026,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7054,10 +7054,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7093,10 +7093,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7132,10 +7132,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7167,10 +7167,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7202,10 +7202,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7237,10 +7237,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7276,10 +7276,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7311,10 +7311,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7346,10 +7346,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7893,7 +7893,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -7904,7 +7904,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "938536d375ec65246c12bba3a8c407ccffd719d24f7a26bbca4ba8f52231090"
+        configChecksum: "7c7744947d7a946640007fed59435f5bf86854b30dfe739e764147d11c71114"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -7913,7 +7913,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.2
+        helm.sh/chart: controlplane-2026.5.4
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8005,10 +8005,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8048,7 +8048,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.4"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8075,10 +8075,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8116,7 +8116,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8190,10 +8190,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8231,7 +8231,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8247,7 +8247,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8321,10 +8321,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8362,7 +8362,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8433,10 +8433,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8474,7 +8474,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8490,7 +8490,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8561,10 +8561,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8602,7 +8602,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8676,10 +8676,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8717,7 +8717,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8732,7 +8732,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8749,7 +8749,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -8823,10 +8823,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8865,7 +8865,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -8881,7 +8881,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -8952,10 +8952,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8993,7 +8993,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9009,7 +9009,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9081,10 +9081,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9122,7 +9122,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9229,10 +9229,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -37,10 +37,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -107,10 +107,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/cacheservice/rbac.yaml
@@ -122,7 +122,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -133,10 +133,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -146,10 +146,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -158,10 +158,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -170,10 +170,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -182,10 +182,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -194,10 +194,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -206,10 +206,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -218,10 +218,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -230,10 +230,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -242,10 +242,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/union-serviceaccount.yaml
@@ -255,10 +255,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/charts/flyte/templates/admin/secret.yaml
@@ -510,10 +510,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -559,7 +559,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -625,10 +625,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -734,10 +734,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -824,10 +824,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1014,10 +1014,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1126,10 +1126,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1211,10 +1211,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1301,10 +1301,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1384,10 +1384,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1468,10 +1468,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1663,7 +1663,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -6865,10 +6865,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -6884,7 +6884,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -6935,10 +6935,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6958,7 +6958,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7114,10 +7114,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7140,7 +7140,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7167,10 +7167,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7195,10 +7195,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7234,10 +7234,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7273,10 +7273,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7308,10 +7308,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7343,10 +7343,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7378,10 +7378,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7417,10 +7417,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7452,10 +7452,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -7487,10 +7487,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8031,10 +8031,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8049,7 +8049,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 02a65f57e1c4697937fe0377832f790177f548e8ce980aa8f0b5205aa3cbc5b2
+        checksum/config: f9124c453ac5549e13c72fab644acce083d4daadd5a943682c6717a8ad6726d0
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8075,7 +8075,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -8150,7 +8150,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -8161,7 +8161,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a7eb2969df625de68d1582ef35634d8e50257eae5d33389905b8f31c7644c9d"
+        configChecksum: "291a68516f0739f84ead2e91fc34bfaadf0d92eeefef181b8d219bc29141f65"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -8170,7 +8170,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.5.2
+        helm.sh/chart: controlplane-2026.5.4
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -8262,10 +8262,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -8305,7 +8305,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.2"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.5.4"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -8332,10 +8332,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8373,7 +8373,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -8447,10 +8447,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8488,7 +8488,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -8504,7 +8504,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -8578,10 +8578,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8619,7 +8619,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -8690,10 +8690,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8731,7 +8731,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -8747,7 +8747,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -8818,10 +8818,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8859,7 +8859,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -8933,10 +8933,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -8974,7 +8974,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -8989,7 +8989,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -9006,7 +9006,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -9080,10 +9080,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -9122,7 +9122,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -9138,7 +9138,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -9209,10 +9209,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9250,7 +9250,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -9266,7 +9266,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -9338,10 +9338,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -9379,7 +9379,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.5.2
+          image: registry.unionai.cloud/controlplane/services:2026.5.4
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -9480,10 +9480,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -9506,10 +9506,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.5.2
+    helm.sh/chart: controlplane-2026.5.4
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -9769,7 +9769,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9869,7 +9869,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9977,7 +9977,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10045,7 +10045,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10112,7 +10112,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10222,7 +10222,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10537,10 +10537,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10587,10 +10587,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -9799,7 +9799,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9897,7 +9897,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10003,7 +10003,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10071,7 +10071,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10136,7 +10136,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10244,7 +10244,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10559,10 +10559,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10609,10 +10609,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -10300,7 +10300,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10398,7 +10398,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10504,7 +10504,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10572,7 +10572,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10637,7 +10637,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10745,7 +10745,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -11147,10 +11147,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -11197,10 +11197,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -9768,7 +9768,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9866,7 +9866,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9972,7 +9972,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10040,7 +10040,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10105,7 +10105,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10213,7 +10213,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10648,10 +10648,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10698,10 +10698,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -10227,7 +10227,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10325,7 +10325,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10431,7 +10431,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10499,7 +10499,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10564,7 +10564,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10672,7 +10672,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -11017,10 +11017,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -11067,10 +11067,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -9836,7 +9836,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9935,7 +9935,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10042,7 +10042,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10110,7 +10110,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10176,7 +10176,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10285,7 +10285,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10600,10 +10600,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10650,10 +10650,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -9836,7 +9836,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9935,7 +9935,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10042,7 +10042,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10110,7 +10110,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10176,7 +10176,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10285,7 +10285,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10600,10 +10600,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10650,10 +10650,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -9713,7 +9713,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -9964,7 +9964,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10062,7 +10062,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10170,7 +10170,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10238,7 +10238,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10303,7 +10303,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10411,7 +10411,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10713,10 +10713,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10763,10 +10763,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -9785,7 +9785,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9883,7 +9883,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9989,7 +9989,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10057,7 +10057,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10122,7 +10122,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10230,7 +10230,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10545,10 +10545,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10595,10 +10595,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -10110,7 +10110,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10208,7 +10208,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10314,7 +10314,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10382,7 +10382,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10447,7 +10447,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10555,7 +10555,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10900,10 +10900,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10950,10 +10950,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -9784,7 +9784,7 @@ spec:
             name: leaseworker
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9872,7 +9872,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9971,7 +9971,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10073,7 +10073,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10179,7 +10179,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10617,10 +10617,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10667,10 +10667,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -9783,7 +9783,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9881,7 +9881,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9987,7 +9987,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10055,7 +10055,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10120,7 +10120,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10228,7 +10228,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10543,10 +10543,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10593,10 +10593,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -9807,7 +9807,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9905,7 +9905,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10011,7 +10011,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10079,7 +10079,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10144,7 +10144,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10252,7 +10252,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10567,10 +10567,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10617,10 +10617,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -11892,7 +11892,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -11990,7 +11990,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -12096,7 +12096,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -12164,7 +12164,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -12229,7 +12229,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -12337,7 +12337,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -17106,10 +17106,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -17156,10 +17156,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -9234,7 +9234,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9930,7 +9930,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -10028,7 +10028,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10134,7 +10134,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10202,7 +10202,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10267,7 +10267,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10375,7 +10375,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10690,10 +10690,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10740,10 +10740,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -9828,7 +9828,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9940,7 +9940,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -10060,7 +10060,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10134,7 +10134,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -10207,7 +10207,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -10329,7 +10329,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.2"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.5.4"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10658,10 +10658,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.5.2
+    helm.sh/chart: dataplane-2026.5.4
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.5.2"
+    app.kubernetes.io/version: "2026.5.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -10708,10 +10708,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.5.2
+      helm.sh/chart: dataplane-2026.5.4
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.5.2"
+      app.kubernetes.io/version: "2026.5.4"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:


### PR DESCRIPTION
## Summary

Bump chart `version` and image tag (`appVersion`) to **2026.5.4** across `controlplane`, `dataplane`, `dataplane-crds`, and `sandbox`.

> **Note:** This release skips the `2026.5.3` serial — no chart-only release was cut at that point. The published image tag from `buildkite/publish-images-release/builds/48` is `2026.5.4`, and chart `version` is aligned with `appVersion` so the two stay in lockstep (consistent with prior release PRs).

---

## Helm Chart Changes (since 2026.5.2)

### Revert imageBuilder `authenticationType` auto-detect ([#388](https://github.com/unionai/helm-charts/pull/388))
- Removes the `imagebuilder.authenticationType` helper template that auto-derived the value from `storage.provider` / top-level `provider` whenever the configured value was empty or `"noop"`.
- `build-image-configmap.yaml` and `operator/configmap.yaml` now render `.Values.imageBuilder.authenticationType` directly, so an operator's configured value (including `"noop"`) is honored verbatim.
- Each cloud overlay (`charts/dataplane/values.{aws,gcp,azure}*.yaml`) gains a commented-out hint pointing operators at the explicit `authenticationType` value if they want the provider credential chain.

### dataplane: disable 2nd `MutatingWebhookConfiguration` when `managedConfig` is set ([#387](https://github.com/unionai/helm-charts/pull/387))
- Skips the legacy self-registered MWC when `flytepropellerwebhook.managedConfig: true`. Prevents duplicate webhook registrations on chart upgrade for deployments already on the helm-managed config.

### identity service scope ([#385](https://github.com/unionai/helm-charts/pull/385))
- Tightens the identity service's helm template scope and namespace handling.

### dataplane + controlplane: chart values cleanup ([#384](https://github.com/unionai/helm-charts/pull/384))
- Cleans up cluster-resource-sync (CRS) scope handling, removes duplicate keys, and disables cloud-managed `kube-*` monitoring targets that don't render scrape-able endpoints (control-manager / scheduler / etcd / proxy on EKS/GKE/AKS).

### controlplane: only render PDBs when `replicaCount > 1` ([#383](https://github.com/unionai/helm-charts/pull/383))
- Gates PodDisruptionBudget rendering on `replicaCount > 1`. Single-replica deployments (the default for several services) no longer ship with a PDB that would block voluntary evictions.

### knative configmaps: remove conflicting label, bump subchart ([#382](https://github.com/unionai/helm-charts/pull/382))
- Bumps the knative-operator subchart and removes a top-level label that conflicted with the subchart's own labels on upgrade.

### Surface `propeller.limit-namespace` in webhook minimal config ([#380](https://github.com/unionai/helm-charts/pull/380))
- Adds the `limit-namespace` propeller setting to the minimal webhook config render so it matches the full propeller config.

### Fix SSA conflict on `admissionregistration` ([#381](https://github.com/unionai/helm-charts/pull/381))
- Resolves a server-side-apply ownership conflict on `admissionregistration.k8s.io` resources during chart upgrades (ArgoCD path).

---

## Image Changes (2026.5.2 → 2026.5.4)

Image cut from `buildkite/publish-images-release/builds/48`. Refer to the cloud repo `CHANGELOG` / release notes for the full enumeration of cloud-side changes between the two image tags.

---

## Configuration Changes

### Behavior change: `imageBuilder.authenticationType` is now explicit

Operators who relied on the previous auto-detection (i.e., did **not** explicitly set `imageBuilder.authenticationType` and were running on AWS/GCP/Azure) must now set the value explicitly in their dataplane values overlay if they want the cloud provider credential chain:

```yaml
imageBuilder:
  authenticationType: aws    # or "google" / "azure" / "basic"
```

Operators who were explicitly setting `imageBuilder.authenticationType: "noop"` (and getting it silently rewritten by the auto-detect) will now have their value honored verbatim. No action required on their part — the cloud overlays in this chart ship commented-out hints for the explicit value when needed.

### No other migration needed

All other changes in this release are backward-compatible chart-internal improvements.

---

## Related PRs

- Helm charts: [#380](https://github.com/unionai/helm-charts/pull/380), [#381](https://github.com/unionai/helm-charts/pull/381), [#382](https://github.com/unionai/helm-charts/pull/382), [#383](https://github.com/unionai/helm-charts/pull/383), [#384](https://github.com/unionai/helm-charts/pull/384), [#385](https://github.com/unionai/helm-charts/pull/385), [#387](https://github.com/unionai/helm-charts/pull/387), [#388](https://github.com/unionai/helm-charts/pull/388)

---

## Test plan

- [x] `make gen_version_bump` (run twice to align `version` with `appVersion` after the `.3` skip)
- [x] `make generate-expected` regenerated snapshots — image refs now render as `:2026.5.4`
- [ ] CI `make test` passes