### PR TITLE
dataplane: GCP Cloud Logging for task logs (external link + post-GC streaming); drop subchart fluentbit

### DIFF
--- a/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
+++ b/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
@@ -306,6 +306,19 @@ config:
       gcpConfig:
         project: '{{ .Values.global.GOOGLE_PROJECT_ID }}'
 
+    # Persisted log source for the operator-proxy's TailLogs / TailTaskExecutionLogs
+    # handlers (cloud/operator/dataproxy/log_service.go). When the client requests
+    # LogsSource=PERSISTED_ONLY, the proxy reads historical task pod logs from the
+    # Cloud Logging API instead of the (live) Kubernetes pod log stream — which
+    # is what lets the UI keep showing logs after task pods are garbage-collected.
+    #
+    # Requires the operator-proxy GSA to hold roles/logging.viewer on the project.
+    persistedLogs:
+      sourceType: GCPStackdriver
+      gcpLogging:
+        gcp:
+          project: '{{ .Values.global.GOOGLE_PROJECT_ID }}'
+
   operator:
     # Disable Cloudflare tunnel (not needed for intra-cluster)
     enableTunnelService: false

--- a/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
+++ b/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
@@ -338,6 +338,48 @@ executor:
       injectSecret: true
       secretName: "EAGER_API_KEY"
 
+  # --- Task log links (GCP Cloud Logging) ---
+  # GKE ships container logs to Google Cloud Logging via the cluster's
+  # built-in logging agent (enabled by default in the
+  # selfmanaged/gcp/infra module — `logging.googleapis.com/kubernetes`
+  # with `SYSTEM_COMPONENTS` + `WORKLOADS`). These templates emit
+  # Cloud Console links the UI surfaces for task pods.
+  #
+  # `roles/logging.viewer` is granted to `union_backend_sa` (the GSA
+  # mapped to proxy + operator via Workload Identity) in
+  # `selfmanaged/gcp/dataplane/union_iam.tf` so the dataplane backend
+  # can serve log entries to the console. End users viewing logs via
+  # the Cloud Console link separately need `roles/logging.viewer` on
+  # the project. Mirrors the BYOC pattern in
+  # `cloud/deploy/dataplane/values-gcp.yaml` +
+  # `cloud/deploy/dataplane/template-gcp.yaml` (FAB-179).
+  task_logs:
+    plugins:
+      logs:
+        cloudwatch-enabled: false
+        kubernetes-enabled: false
+        templates:
+          - displayName: GCP Logs
+            templateUris:
+              - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22;startTime={{`{{.podRFC3339StartTime}}`}};endTime={{`{{.podRFC3339FinishTime}}`}}?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
+      k8s-array:
+        logs:
+          config:
+            cloudwatch-enabled: false
+            kubernetes-enabled: false
+            templates:
+              - displayName: GCP Logs
+                templateUris:
+                  - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
+      fasttask:
+        logs:
+          cloudwatch-enabled: false
+          kubernetes-enabled: false
+          templates:
+            - displayName: GCP Logs
+              templateUris:
+                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22;startTime={{`{{.taskStartTime}}`}};endTime={{`{{.taskEndTime}}`}}?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
+
 # ----------------------------------------------------------------------------
 # Ingress Configuration
 # ----------------------------------------------------------------------------

--- a/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
+++ b/charts/dataplane/values.gcp.selfhosted-intracluster.yaml
@@ -518,11 +518,20 @@ serving:
     enabled: false
 
 # ----------------------------------------------------------------------------
-# SECTION 6: Logging Configuration (REQUIRED)
+# SECTION 6: Logging Configuration
 # ----------------------------------------------------------------------------
-# FluentBit collects and forwards logs to the control plane.
+# GKE clusters with managed Cloud Logging enabled (loggingConfig.componentConfig
+# includes WORKLOADS) already ship workload container stdout/stderr to Cloud
+# Logging via Google's managed fluentbit-gke DaemonSet in kube-system. The
+# subchart fluentbit is disabled to avoid duplicate ingestion; log viewing
+# links out to console.cloud.google.com/logs/query (see executor.task_logs).
+#
+# Override back to true at the env-specific values layer if GKE managed Cloud
+# Logging is not enabled for the cluster. ServiceAccount fields below remain
+# documented for that case but are inert while enabled=false.
 
 fluentbit:
+  enabled: false
   serviceAccount:
     name: fluentbit-system
     # GKE Workload Identity annotation to grant FluentBit write access to GCS.

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -168,6 +168,22 @@ executor:
         spark-history-server-url: "{{.Values.cloudUrl}}/spark-history-server/org/{{.Release.Namespace}}/cluster/{{.Values.clusterName}}"
 
 # ----------------------------------------------------------------------------
+# Logging Configuration (GCP/GKE specific)
+# ----------------------------------------------------------------------------
+
+# GKE clusters with managed Cloud Logging enabled (loggingConfig.componentConfig
+# includes WORKLOADS) already ship workload container stdout/stderr to Cloud
+# Logging via Google's managed fluentbit-gke DaemonSet in kube-system. Disable
+# the subchart fluentbit to avoid duplicate ingestion; rely on Google's agent,
+# and link out to console.cloud.google.com/logs/query for log viewing
+# (configured in executor.task_logs above).
+#
+# Override back to true at the env-specific values layer if GKE managed Cloud
+# Logging is not enabled for the cluster.
+fluentbit:
+  enabled: false
+
+# ----------------------------------------------------------------------------
 # Monitoring Configuration (GCP/GKE specific)
 # ----------------------------------------------------------------------------
 

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -62,18 +62,18 @@ executor:
         cloudwatch-enabled: false
         kubernetes-enabled: false
         templates:
-          - displayName: Stackdriver Logs
+          - displayName: GCP Logs
             templateUris:
-              - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22;startTime={{`{{.podRFC3339StartTime}}`}};endTime={{`{{.podRFC3339FinishTime}}`}}?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+              - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22;startTime={{`{{.podRFC3339StartTime}}`}};endTime={{`{{.podRFC3339FinishTime}}`}}?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
       k8s-array:
         logs:
           config:
             cloudwatch-enabled: false
             kubernetes-enabled: false
             templates:
-              - displayName: Stackdriver Logs
+              - displayName: GCP Logs
                 templateUris:
-                  - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+                  - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
       fasttask:
         logs:
           cloudwatch-enabled: false
@@ -85,9 +85,9 @@ executor:
                 templateUris:
                   - "/dataplane/pod/v1/generated_name/task/{{`{{.executionProject}}`}}/{{`{{.executionDomain}}`}}/{{`{{.executionName}}`}}/{{`{{.nodeID}}`}}/{{`{{.taskRetryAttempt}}`}}/{{.Values.clusterName}}/{{`{{.namespace}}`}}/{{`{{.taskProject}}`}}/{{`{{.taskDomain}}`}}/{{`{{.taskID}}`}}/{{`{{.taskVersion}}`}}/{{`{{.generatedName}}`}}/"
           templates:
-            - displayName: Stackdriver Logs
+            - displayName: GCP Logs
               templateUris:
-                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22;startTime={{`{{.taskStartTime}}`}};endTime={{`{{.taskEndTime}}`}}?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22{{`{{.containerName}}`}}%22;startTime={{`{{.taskStartTime}}`}};endTime={{`{{.taskEndTime}}`}}?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
       dask:
         # -- Configuration section for all K8s specific plugins [Configuration structure](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/pluginmachinery/flytek8s/config)
         logs:
@@ -101,10 +101,10 @@ executor:
                 templateUris:
                   - "/dataplane/pod/v1/generated_name/6060/task/{{`{{.executionProject}}`}}/{{`{{.executionDomain}}`}}/{{`{{.executionName}}`}}/{{`{{.nodeID}}`}}/{{`{{.taskRetryAttempt}}`}}/{{.Values.clusterName}}/{{`{{.namespace}}`}}/{{`{{.taskProject}}`}}/{{`{{.taskDomain}}`}}/{{`{{.taskID}}`}}/{{`{{.taskVersion}}`}}/{{`{{.podName}}`}}/"
           templates:
-            - displayName: "Stackdriver Logs"
+            - displayName: "GCP Logs"
               scheme: TaskExecution
               templateUris:
-                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22job-runner%22?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22%0Aresource.labels.container_name%3D%22job-runner%22?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
             - displayName: Dask Dashboard
               linkType: dashboard
               scheme: TaskExecution
@@ -127,13 +127,13 @@ executor:
             - displayName: "Stacktrace Logs (Ray All)"
               scheme: TaskExecution
               templateUris:
-                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%7E%22{{`{{.executionName}}`}}-{{`{{.nodeID}}`}}-{{`{{.taskRetryAttempt}}`}}%22?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+                - "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%7E%22{{`{{.executionName}}`}}-{{`{{.nodeID}}`}}-{{`{{.taskRetryAttempt}}`}}%22?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
       spark:
         logs:
           mixed:
             kubernetes-enabled: false
             stackdriver-enabled: true
-            stackdriver-template-uri: "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+            stackdriver-template-uri: "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%22{{`{{.podName}}`}}%22?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
             dynamic-log-links:
               - vscode:
                   displayName: VSCode
@@ -148,7 +148,7 @@ executor:
           all-user:
             kubernetes-enabled: false
             stackdriver-enabled: true
-            stackdriver-template-uri: "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%7E%22{{`{{.podName}}`}}-exec%22?project={{.Values.storage.gcs.projectId}}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{.Values.storage.gcs.projectId}}"
+            stackdriver-template-uri: "https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{`{{.namespace}}`}}%22%0Aresource.labels.pod_name%3D%7E%22{{`{{.podName}}`}}-exec%22?project={{ .Values.global.GOOGLE_PROJECT_ID }}&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3D{{ .Values.global.GOOGLE_PROJECT_ID }}"
         spark-config-default:
           - spark.driver.cores: "1"
           - spark.eventLog.enabled: "true"


### PR DESCRIPTION
## Summary

End-to-end Cloud Logging integration for selfhosted GCP deployments. Three independently useful pieces:

### 1. External "GCP Logs" link templates

`executor.task_logs` templates link to `console.cloud.google.com/logs/query` filtered by `resource.labels.{namespace_name, pod_name, container_name}` and labeled "GCP Logs" (replaces the prior "Stackdriver" label). Project ID is interpolated from `.Values.global.GOOGLE_PROJECT_ID`. Applies to every task plugin that previously produced a Stackdriver link (fasttask, k8s-array, logs, dask, ray, spark).

### 2. Retire the subchart fluentbit on GCP

Disable the subchart `fluentbit` by default for GCP. Two reasons:

- GKE clusters with managed Cloud Logging enabled (`loggingConfig.componentConfig` includes `WORKLOADS`) already ship workload container stdout/stderr to Cloud Logging via Google's managed `fluentbit-gke` DaemonSet in `kube-system`. The subchart duplicates ingestion.
- The chart's GCP output path was broken: `templates/_helpers.tpl` only emits an `s3` plugin `[OUTPUT]` for the ObjectStore source type, with no GCS endpoint override or HMAC credentials, so on a GCP env the DaemonSet pods loop trying to reach AWS S3 endpoints. Verified by inspecting the live `union-operator-fluentbit` DaemonSet (5 desired, 0 ready) and `gs://` buckets in the project containing zero `persisted-logs/` objects.

The toggle lives in both `values.gcp.yaml` (platform default) and `values.gcp.selfhosted-intracluster.yaml` (the only file fetched by the selfmanaged terraform module today; `union_extension/gcp/dataplane.tf` doesn't layer `values.gcp.yaml`). Env-specific layers can re-enable if a deployment runs without GKE managed Cloud Logging.

### 3. Switch `persistedLogs` source to `GCPStackdriver` for selfhosted GCP

The operator-proxy's `TailTaskExecutionLogs` handler at `cloud/operator/dataproxy/log_service.go:319-374` already falls through to `streamPersistedLogs` when the live pod returns `NotFound` from the k8s API. Until this PR the chart-default `sourceType: ObjectStore` on a GCP env pointed at an empty bucket (see piece 2), so post-GC log requests returned nothing. After the switch, the existing `gcp_stackdriver_logs_source.go` queries Cloud Logging directly for entries matching the task pod's namespace + pod labels — the same data the managed fluentbit-gke is already producing.

Requires the operator-proxy GSA (default: `dp-1-backend@<project>`) to hold `roles/logging.viewer` on the project. Already provisioned for mike-apple-gcp.

## Validation

- `helm template` with `values.gcp.yaml` + `values.gcp.selfhosted-intracluster.yaml`: 105 resources rendered, zero `fluentbit` resources. Setting `--set fluentbit.enabled=true` re-emits the configmap / serviceaccount / clusterrole / clusterrolebinding / service / daemonset, confirming the toggle works both directions.
- Snapshot suite (`make test`) passes.
- Deployed to a selfhosted GCP staging env via `helm upgrade union-operator` (revision 5):
  - `executor` and `leaseworker` ConfigMaps rendered `task_logs.yaml` with three template variants (fasttask / k8s-array / logs) and Project ID interpolated.
  - `union-operator` ConfigMap rendered `proxy.persistedLogs.sourceType: GCPStackdriver` + `gcpLogging.gcp.project: <project>`.
  - operator-proxy pod restarted via `configChecksum` annotation and logged: `creating new persisted logs source object, type = "GCPStackdriver"`.
- **Live post-GC test on the env**: ran a workflow, deleted one Completed task pod, opened the v2 console logs panel for that action. The UI displayed the pod's stdout from before deletion. operator-proxy logs show the path that was taken:
  ```
  log_request.go:56   Received request for method ".../TailTaskExecutionLogs"
  gcp_stackdriver_logs_source.go:80   log query: resource names = ["projects/<project>"],
      filter = "resource.labels.namespace_name = "development"
                AND resource.labels.pod_name = "<deleted-pod>"
                AND resource.labels.container_name = "<deleted-pod>"
                AND timestamp >= "..." AND timestamp < "...""
  log_request.go:65   Successfully processed request for method ".../TailTaskExecutionLogs"
  ```
- No clientsv2 change required for the post-GC path: `TailTaskExecutionLogs` auto-falls-back to `persistedLogsSource` when the pod is `NotFound`. (The `TailLogs` RPC still requires explicit `LogsSource.PERSISTED_ONLY` from the client, which the console doesn't set today — a separate UX improvement for live → persisted handover.)

## Test plan

- [ ] Open a task execution view in the console after a workflow run on a selfhosted GCP deployment; click "GCP Logs" — should land on `console.cloud.google.com/logs/query` filtered for that task's pod.
- [ ] Confirm no `union-operator-fluentbit` pods remain in the dataplane namespace after helm upgrade (only `fluentbit-gke-*` in `kube-system` should be running).
- [ ] Wait for / force GKE to GC a task pod, then open the v2 console logs panel for that action. The stdout that was visible while the pod existed should still display.
- [ ] Confirm the operator-proxy startup log includes `creating new persisted logs source object, type = "GCPStackdriver"`.