### PR TITLE
controlplane: auto-register build-image task via post-install Helm hook

### DIFF
--- a/charts/controlplane/files/build_image_task.py
+++ b/charts/controlplane/files/build_image_task.py
@@ -1,0 +1,183 @@
+"""build-image ContainerTask definition, registered automatically by the
+controlplane chart's post-install / post-upgrade Helm hook Job
+(see templates/image-builder-bootstrap/).
+
+Two env vars are required at registration time:
+  APP_VERSION              — image tag for build-image + frontend-v2
+                             (set by the Job from .Chart.AppVersion).
+  UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                             frontend-v2 images live
+                             (set by the Job from values.imageBuilder.bootstrap
+                             .unionImageNamePrefix).
+
+Per-namespace defaults consumed at task execution time come from the
+`build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+"""
+import os
+
+from kubernetes.client import (
+    V1PodSpec,
+    V1Container,
+    V1EnvVar,
+    V1VolumeMount,
+    V1EnvVarSource,
+    V1ObjectFieldSelector,
+    V1ConfigMapKeySelector,
+    V1Volume,
+    V1ProjectedVolumeSource,
+    V1VolumeProjection,
+    V1ServiceAccountTokenProjection,
+    V1ConfigMapVolumeSource,
+    V1KeyToPath,
+)
+
+import flyte
+from flyte.extras import ContainerTask
+
+
+_DEFAULT_CONFIGMAP_NAME = "build-image-config"
+_STORAGE_YAML_KEY = "storage.yaml"
+_CONFIG_DIR = "/etc/union/config"
+
+config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+log_level = os.getenv("LOG_LEVEL", "5")
+
+union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+if not union_image_name_prefix:
+    raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+
+app_version = os.getenv("APP_VERSION")
+if not app_version:
+    raise ValueError("APP_VERSION environment variable must be set")
+
+build_image_task = ContainerTask(
+    name="build-image",
+    cache=flyte.Cache(behavior="auto"),
+    image=f"{union_image_name_prefix}/build-image:{app_version}",
+    inputs={"spec": str, "context": str, "target_image": str},
+    outputs={"fully_qualified_image": str},
+    pod_template=flyte.PodTemplate(
+        primary_container_name="main",
+        pod_spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="main",
+                    image_pull_policy="Always",
+                    termination_message_policy="FallbackToLogsOnError",
+                    volume_mounts=[
+                        V1VolumeMount(
+                            mount_path="/var/run/secrets/union/registry",
+                            name="registry-token",
+                            read_only=True,
+                        ),
+                        V1VolumeMount(
+                            name="config-volume",
+                            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                            sub_path=_STORAGE_YAML_KEY,
+                        ),
+                    ],
+                    env=[
+                        V1EnvVar(
+                            name="ORGANIZATION",
+                            value_from=V1EnvVarSource(
+                                field_ref=V1ObjectFieldSelector(
+                                    field_path="metadata.labels['organization']"
+                                )
+                            ),
+                        ),
+                        V1EnvVar(
+                            name="UNION_BUILDKIT_URI",
+                            value_from=V1EnvVarSource(
+                                config_map_key_ref=V1ConfigMapKeySelector(
+                                    name=config_map_name,
+                                    key="buildkit-uri",
+                                )
+                            ),
+                        ),
+                        V1EnvVar(
+                            name="UNION_DEFAULT_REPOSITORY",
+                            value_from=V1EnvVarSource(
+                                config_map_key_ref=V1ConfigMapKeySelector(
+                                    name=config_map_name,
+                                    key="default-repository",
+                                )
+                            ),
+                        ),
+                        V1EnvVar(
+                            name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                            value_from=V1EnvVarSource(
+                                config_map_key_ref=V1ConfigMapKeySelector(
+                                    name=config_map_name,
+                                    key="authentication-type",
+                                )
+                            ),
+                        ),
+                        V1EnvVar(
+                            name="UNION_IMAGE_NAME_PREFIX",
+                            value=union_image_name_prefix,
+                        ),
+                        V1EnvVar(
+                            name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                            value_from=V1EnvVarSource(
+                                config_map_key_ref=V1ConfigMapKeySelector(
+                                    name=config_map_name,
+                                    key="enable-image-optimization",
+                                    optional=True,
+                                )
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+            volumes=[
+                V1Volume(
+                    name="registry-token",
+                    projected=V1ProjectedVolumeSource(
+                        sources=[
+                            V1VolumeProjection(
+                                service_account_token=V1ServiceAccountTokenProjection(
+                                    audience="registry",
+                                    expiration_seconds=7200,
+                                    path="token",
+                                )
+                            )
+                        ]
+                    ),
+                ),
+                V1Volume(
+                    name="config-volume",
+                    config_map=V1ConfigMapVolumeSource(
+                        name=config_map_name,
+                        items=[
+                            V1KeyToPath(
+                                key=_STORAGE_YAML_KEY,
+                                path=_STORAGE_YAML_KEY,
+                            )
+                        ],
+                    ),
+                ),
+            ],
+        ),
+    ),
+    command=[
+        "imagebuild",
+        "--logger.formatter.type=text",
+        f"--logger.level={log_level}",
+        "--context",
+        "{{.inputs.context}}",
+        "--frontend",
+        f"{union_image_name_prefix}/frontend-v2:{app_version}",
+        "--remote-outputs-prefix",
+        "{{.outputPrefix}}",
+        "--spec",
+        "{{.inputs.spec}}",
+        "--target-image",
+        "{{.inputs.target_image}}",
+        "--optimize",
+    ],
+)
+
+build_image_task_env = flyte.TaskEnvironment.from_task(
+    "build_image_task", build_image_task
+)

--- a/charts/controlplane/templates/image-builder-bootstrap/configmap.yaml
+++ b/charts/controlplane/templates/image-builder-bootstrap/configmap.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.imageBuilder.bootstrap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-build-image-bootstrap
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+{{ .Files.Get "files/build_image_task.py" | indent 4 }}
+  flyte-config.yaml: |
+    admin:
+      {{- tpl (toYaml .Values.imageBuilder.bootstrap.admin) . | nindent 6 }}
+    task:
+      org: {{ .Values.global.UNION_ORG | default "" | quote }}
+      project: {{ .Values.imageBuilder.bootstrap.project | quote }}
+      domain: {{ .Values.imageBuilder.bootstrap.domain | quote }}
+{{- end }}

--- a/charts/controlplane/templates/image-builder-bootstrap/job.yaml
+++ b/charts/controlplane/templates/image-builder-bootstrap/job.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.imageBuilder.bootstrap.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-build-image-bootstrap
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.imageBuilder.bootstrap.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.imageBuilder.bootstrap.ttlSecondsAfterFinished }}
+  template:
+    {{- if or .Values.imageBuilder.bootstrap.podAnnotations .Values.imageBuilder.bootstrap.podLabels }}
+    metadata:
+      {{- with .Values.imageBuilder.bootstrap.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imageBuilder.bootstrap.podLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    spec:
+      restartPolicy: {{ .Values.imageBuilder.bootstrap.restartPolicy }}
+      containers:
+        - name: bootstrap
+          image: {{ .Values.imageBuilder.bootstrap.image | quote }}
+          env:
+            - name: APP_VERSION
+              value: {{ tpl .Values.image.tag . | quote }}
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: {{ .Values.imageBuilder.bootstrap.unionImageNamePrefix | quote }}
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              pip install --root-user-action=ignore --quiet uv
+              uv pip install --quiet --system flyte kubernetes
+
+              flyte create project \
+                --id   {{ .Values.imageBuilder.bootstrap.project | quote }} \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project {{ .Values.imageBuilder.bootstrap.project | quote }} \
+                --domain  {{ .Values.imageBuilder.bootstrap.domain | quote }} \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: {{ .Release.Name }}-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: {{ .Release.Name }}-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: {{ tpl .Values.defaults.secretName . | quote }}
+{{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -129,6 +129,65 @@ strategy:
     maxSurge: 1
 secrets: {}
 
+# --- Image-builder bootstrap ---
+#
+# Helm post-install/post-upgrade hook Job that registers the `build-image`
+# ContainerTask in flyteadmin so the SDK can invoke remote image builds
+# without operators running `flyte deploy` manually after every helm upgrade.
+imageBuilder:
+  bootstrap:
+    # When false, the bootstrap Job + ConfigMap are not rendered (use this
+    # if the customer prefers to manage build-image registration themselves
+    # or has an existing registration that must not be overwritten).
+    enabled: true
+
+    # Container image the bootstrap Job runs in. Needs Python + a shell;
+    # no Union image currently ships `uv` + `flyte` CLI so the Job
+    # `pip install`s them at startup (~30s, idempotent on re-runs).
+    image: python:3.13-slim
+
+    # Registry prefix the build-image + frontend-v2 task images are pulled
+    # from. Defaults to Union's public ECR staging; override per env if
+    # mirroring to a private registry.
+    unionImageNamePrefix: public.ecr.aws/g1m2l3c1/imagebuilder-staging
+
+    # Where the build-image task is registered. Convention is system/production.
+    # The Job creates the project if it doesn't already exist.
+    project: system
+    domain: production
+
+    # Annotations + labels added to the Job's pod template. Useful for
+    # service-mesh sidecar control (e.g. linkerd.io/inject: disabled to
+    # keep the one-shot Job from getting a sidecar that never exits),
+    # Prometheus scrape opt-in/out, cost-attribution labels, etc.
+    podAnnotations: {}
+    podLabels: {}
+
+    # Job-spec tunables. Defaults are conservative for a one-shot
+    # post-install hook; override for stricter retry / cleanup policies.
+    backoffLimit: 2
+    ttlSecondsAfterFinished: 600
+    restartPolicy: Never
+
+    # Flyte admin connection used by the bootstrap Job. Rendered into
+    # /etc/flyte/config.yaml inside the Job pod and consumed by `flyte deploy`.
+    #
+    # NOTE: deliberately not derived from `.Values.configMap.admin` (the CP
+    # service-to-service block). That one uses the intra-cluster gRPC path
+    # (flyteadmin.<ns>.svc.cluster.local:81, insecure) which the Python SDK's
+    # OAuth discovery can't reproduce, so the bootstrap Job goes through the
+    # public ingress instead. Override here only if your env needs different
+    # auth (e.g. PKCE, custom token endpoint, alternate clientSecretLocation).
+    #
+    # String values are templated with `tpl` so `{{ .Values.global.X }}`-style
+    # references resolve at render time.
+    admin:
+      endpoint: '{{ .Values.global.UNION_HOST }}'
+      insecure: false
+      authType: ClientSecret
+      clientId: '{{ .Values.global.INTERNAL_CLIENT_ID }}'
+      clientSecretLocation: /etc/secrets/union/client_secret
+
 imagePullSecrets:
   - name: union-registry-secret
 

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -12152,7 +12152,7 @@ spec:
           image: "python:3.13-slim"
           env:
             - name: APP_VERSION
-              value: "2026.5.5"
+              value: "2026.5.7"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -11921,3 +11921,288 @@ spec:
       storage:
         capacity: 100Gi
         storageClassName: scylladb
+---
+# Source: controlplane/templates/image-builder-bootstrap/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+    """build-image ContainerTask definition, registered automatically by the
+    controlplane chart's post-install / post-upgrade Helm hook Job
+    (see templates/image-builder-bootstrap/).
+    
+    Two env vars are required at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2
+                                 (set by the Job from .Chart.AppVersion).
+      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                                 frontend-v2 images live
+                                 (set by the Job from values.imageBuilder.bootstrap
+                                 .unionImageNamePrefix).
+    
+    Per-namespace defaults consumed at task execution time come from the
+    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    """
+    import os
+    
+    from kubernetes.client import (
+        V1PodSpec,
+        V1Container,
+        V1EnvVar,
+        V1VolumeMount,
+        V1EnvVarSource,
+        V1ObjectFieldSelector,
+        V1ConfigMapKeySelector,
+        V1Volume,
+        V1ProjectedVolumeSource,
+        V1VolumeProjection,
+        V1ServiceAccountTokenProjection,
+        V1ConfigMapVolumeSource,
+        V1KeyToPath,
+    )
+    
+    import flyte
+    from flyte.extras import ContainerTask
+    
+    
+    _DEFAULT_CONFIGMAP_NAME = "build-image-config"
+    _STORAGE_YAML_KEY = "storage.yaml"
+    _CONFIG_DIR = "/etc/union/config"
+    
+    config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+    log_level = os.getenv("LOG_LEVEL", "5")
+    
+    union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+    if not union_image_name_prefix:
+        raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+    
+    app_version = os.getenv("APP_VERSION")
+    if not app_version:
+        raise ValueError("APP_VERSION environment variable must be set")
+    
+    build_image_task = ContainerTask(
+        name="build-image",
+        cache=flyte.Cache(behavior="auto"),
+        image=f"{union_image_name_prefix}/build-image:{app_version}",
+        inputs={"spec": str, "context": str, "target_image": str},
+        outputs={"fully_qualified_image": str},
+        pod_template=flyte.PodTemplate(
+            primary_container_name="main",
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="main",
+                        image_pull_policy="Always",
+                        termination_message_policy="FallbackToLogsOnError",
+                        volume_mounts=[
+                            V1VolumeMount(
+                                mount_path="/var/run/secrets/union/registry",
+                                name="registry-token",
+                                read_only=True,
+                            ),
+                            V1VolumeMount(
+                                name="config-volume",
+                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                                sub_path=_STORAGE_YAML_KEY,
+                            ),
+                        ],
+                        env=[
+                            V1EnvVar(
+                                name="ORGANIZATION",
+                                value_from=V1EnvVarSource(
+                                    field_ref=V1ObjectFieldSelector(
+                                        field_path="metadata.labels['organization']"
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_BUILDKIT_URI",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="buildkit-uri",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_DEFAULT_REPOSITORY",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="default-repository",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="authentication-type",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_IMAGE_NAME_PREFIX",
+                                value=union_image_name_prefix,
+                            ),
+                            V1EnvVar(
+                                name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="enable-image-optimization",
+                                        optional=True,
+                                    )
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    V1Volume(
+                        name="registry-token",
+                        projected=V1ProjectedVolumeSource(
+                            sources=[
+                                V1VolumeProjection(
+                                    service_account_token=V1ServiceAccountTokenProjection(
+                                        audience="registry",
+                                        expiration_seconds=7200,
+                                        path="token",
+                                    )
+                                )
+                            ]
+                        ),
+                    ),
+                    V1Volume(
+                        name="config-volume",
+                        config_map=V1ConfigMapVolumeSource(
+                            name=config_map_name,
+                            items=[
+                                V1KeyToPath(
+                                    key=_STORAGE_YAML_KEY,
+                                    path=_STORAGE_YAML_KEY,
+                                )
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        command=[
+            "imagebuild",
+            "--logger.formatter.type=text",
+            f"--logger.level={log_level}",
+            "--context",
+            "{{.inputs.context}}",
+            "--frontend",
+            f"{union_image_name_prefix}/frontend-v2:{app_version}",
+            "--remote-outputs-prefix",
+            "{{.outputPrefix}}",
+            "--spec",
+            "{{.inputs.spec}}",
+            "--target-image",
+            "{{.inputs.target_image}}",
+            "--optimize",
+        ],
+    )
+    
+    build_image_task_env = flyte.TaskEnvironment.from_task(
+        "build_image_task", build_image_task
+    )
+    
+  flyte-config.yaml: |
+    admin:
+      authType: ClientSecret
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: 'test.example.com'
+      insecure: false
+    task:
+      org: ""
+      project: "system"
+      domain: "production"
+
+---
+# Source: controlplane/templates/image-builder-bootstrap/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          image: "python:3.13-slim"
+          env:
+            - name: APP_VERSION
+              value: "2026.5.5"
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              pip install --root-user-action=ignore --quiet uv
+              uv pip install --quiet --system flyte kubernetes
+
+              flyte create project \
+                --id   "system" \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project "system" \
+                --domain  "production" \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: ""
+

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -11912,3 +11912,288 @@ spec:
       storage:
         capacity: 100Gi
         storageClassName: scylladb
+---
+# Source: controlplane/templates/image-builder-bootstrap/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+    """build-image ContainerTask definition, registered automatically by the
+    controlplane chart's post-install / post-upgrade Helm hook Job
+    (see templates/image-builder-bootstrap/).
+    
+    Two env vars are required at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2
+                                 (set by the Job from .Chart.AppVersion).
+      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                                 frontend-v2 images live
+                                 (set by the Job from values.imageBuilder.bootstrap
+                                 .unionImageNamePrefix).
+    
+    Per-namespace defaults consumed at task execution time come from the
+    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    """
+    import os
+    
+    from kubernetes.client import (
+        V1PodSpec,
+        V1Container,
+        V1EnvVar,
+        V1VolumeMount,
+        V1EnvVarSource,
+        V1ObjectFieldSelector,
+        V1ConfigMapKeySelector,
+        V1Volume,
+        V1ProjectedVolumeSource,
+        V1VolumeProjection,
+        V1ServiceAccountTokenProjection,
+        V1ConfigMapVolumeSource,
+        V1KeyToPath,
+    )
+    
+    import flyte
+    from flyte.extras import ContainerTask
+    
+    
+    _DEFAULT_CONFIGMAP_NAME = "build-image-config"
+    _STORAGE_YAML_KEY = "storage.yaml"
+    _CONFIG_DIR = "/etc/union/config"
+    
+    config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+    log_level = os.getenv("LOG_LEVEL", "5")
+    
+    union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+    if not union_image_name_prefix:
+        raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+    
+    app_version = os.getenv("APP_VERSION")
+    if not app_version:
+        raise ValueError("APP_VERSION environment variable must be set")
+    
+    build_image_task = ContainerTask(
+        name="build-image",
+        cache=flyte.Cache(behavior="auto"),
+        image=f"{union_image_name_prefix}/build-image:{app_version}",
+        inputs={"spec": str, "context": str, "target_image": str},
+        outputs={"fully_qualified_image": str},
+        pod_template=flyte.PodTemplate(
+            primary_container_name="main",
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="main",
+                        image_pull_policy="Always",
+                        termination_message_policy="FallbackToLogsOnError",
+                        volume_mounts=[
+                            V1VolumeMount(
+                                mount_path="/var/run/secrets/union/registry",
+                                name="registry-token",
+                                read_only=True,
+                            ),
+                            V1VolumeMount(
+                                name="config-volume",
+                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                                sub_path=_STORAGE_YAML_KEY,
+                            ),
+                        ],
+                        env=[
+                            V1EnvVar(
+                                name="ORGANIZATION",
+                                value_from=V1EnvVarSource(
+                                    field_ref=V1ObjectFieldSelector(
+                                        field_path="metadata.labels['organization']"
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_BUILDKIT_URI",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="buildkit-uri",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_DEFAULT_REPOSITORY",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="default-repository",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="authentication-type",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_IMAGE_NAME_PREFIX",
+                                value=union_image_name_prefix,
+                            ),
+                            V1EnvVar(
+                                name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="enable-image-optimization",
+                                        optional=True,
+                                    )
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    V1Volume(
+                        name="registry-token",
+                        projected=V1ProjectedVolumeSource(
+                            sources=[
+                                V1VolumeProjection(
+                                    service_account_token=V1ServiceAccountTokenProjection(
+                                        audience="registry",
+                                        expiration_seconds=7200,
+                                        path="token",
+                                    )
+                                )
+                            ]
+                        ),
+                    ),
+                    V1Volume(
+                        name="config-volume",
+                        config_map=V1ConfigMapVolumeSource(
+                            name=config_map_name,
+                            items=[
+                                V1KeyToPath(
+                                    key=_STORAGE_YAML_KEY,
+                                    path=_STORAGE_YAML_KEY,
+                                )
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        command=[
+            "imagebuild",
+            "--logger.formatter.type=text",
+            f"--logger.level={log_level}",
+            "--context",
+            "{{.inputs.context}}",
+            "--frontend",
+            f"{union_image_name_prefix}/frontend-v2:{app_version}",
+            "--remote-outputs-prefix",
+            "{{.outputPrefix}}",
+            "--spec",
+            "{{.inputs.spec}}",
+            "--target-image",
+            "{{.inputs.target_image}}",
+            "--optimize",
+        ],
+    )
+    
+    build_image_task_env = flyte.TaskEnvironment.from_task(
+        "build_image_task", build_image_task
+    )
+    
+  flyte-config.yaml: |
+    admin:
+      authType: ClientSecret
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: 'test.example.com'
+      insecure: false
+    task:
+      org: ""
+      project: "system"
+      domain: "production"
+
+---
+# Source: controlplane/templates/image-builder-bootstrap/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          image: "python:3.13-slim"
+          env:
+            - name: APP_VERSION
+              value: "2026.5.5"
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              pip install --root-user-action=ignore --quiet uv
+              uv pip install --quiet --system flyte kubernetes
+
+              flyte create project \
+                --id   "system" \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project "system" \
+                --domain  "production" \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: ""
+

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -12143,7 +12143,7 @@ spec:
           image: "python:3.13-slim"
           env:
             - name: APP_VERSION
-              value: "2026.5.5"
+              value: "2026.5.7"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -12156,7 +12156,7 @@ spec:
           image: "python:3.13-slim"
           env:
             - name: APP_VERSION
-              value: "2026.5.5"
+              value: "2026.5.7"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -11925,3 +11925,288 @@ spec:
       storage:
         capacity: 100Gi
         storageClassName: scylladb
+---
+# Source: controlplane/templates/image-builder-bootstrap/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+    """build-image ContainerTask definition, registered automatically by the
+    controlplane chart's post-install / post-upgrade Helm hook Job
+    (see templates/image-builder-bootstrap/).
+    
+    Two env vars are required at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2
+                                 (set by the Job from .Chart.AppVersion).
+      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                                 frontend-v2 images live
+                                 (set by the Job from values.imageBuilder.bootstrap
+                                 .unionImageNamePrefix).
+    
+    Per-namespace defaults consumed at task execution time come from the
+    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    """
+    import os
+    
+    from kubernetes.client import (
+        V1PodSpec,
+        V1Container,
+        V1EnvVar,
+        V1VolumeMount,
+        V1EnvVarSource,
+        V1ObjectFieldSelector,
+        V1ConfigMapKeySelector,
+        V1Volume,
+        V1ProjectedVolumeSource,
+        V1VolumeProjection,
+        V1ServiceAccountTokenProjection,
+        V1ConfigMapVolumeSource,
+        V1KeyToPath,
+    )
+    
+    import flyte
+    from flyte.extras import ContainerTask
+    
+    
+    _DEFAULT_CONFIGMAP_NAME = "build-image-config"
+    _STORAGE_YAML_KEY = "storage.yaml"
+    _CONFIG_DIR = "/etc/union/config"
+    
+    config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+    log_level = os.getenv("LOG_LEVEL", "5")
+    
+    union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+    if not union_image_name_prefix:
+        raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+    
+    app_version = os.getenv("APP_VERSION")
+    if not app_version:
+        raise ValueError("APP_VERSION environment variable must be set")
+    
+    build_image_task = ContainerTask(
+        name="build-image",
+        cache=flyte.Cache(behavior="auto"),
+        image=f"{union_image_name_prefix}/build-image:{app_version}",
+        inputs={"spec": str, "context": str, "target_image": str},
+        outputs={"fully_qualified_image": str},
+        pod_template=flyte.PodTemplate(
+            primary_container_name="main",
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="main",
+                        image_pull_policy="Always",
+                        termination_message_policy="FallbackToLogsOnError",
+                        volume_mounts=[
+                            V1VolumeMount(
+                                mount_path="/var/run/secrets/union/registry",
+                                name="registry-token",
+                                read_only=True,
+                            ),
+                            V1VolumeMount(
+                                name="config-volume",
+                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                                sub_path=_STORAGE_YAML_KEY,
+                            ),
+                        ],
+                        env=[
+                            V1EnvVar(
+                                name="ORGANIZATION",
+                                value_from=V1EnvVarSource(
+                                    field_ref=V1ObjectFieldSelector(
+                                        field_path="metadata.labels['organization']"
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_BUILDKIT_URI",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="buildkit-uri",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_DEFAULT_REPOSITORY",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="default-repository",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="authentication-type",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_IMAGE_NAME_PREFIX",
+                                value=union_image_name_prefix,
+                            ),
+                            V1EnvVar(
+                                name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="enable-image-optimization",
+                                        optional=True,
+                                    )
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    V1Volume(
+                        name="registry-token",
+                        projected=V1ProjectedVolumeSource(
+                            sources=[
+                                V1VolumeProjection(
+                                    service_account_token=V1ServiceAccountTokenProjection(
+                                        audience="registry",
+                                        expiration_seconds=7200,
+                                        path="token",
+                                    )
+                                )
+                            ]
+                        ),
+                    ),
+                    V1Volume(
+                        name="config-volume",
+                        config_map=V1ConfigMapVolumeSource(
+                            name=config_map_name,
+                            items=[
+                                V1KeyToPath(
+                                    key=_STORAGE_YAML_KEY,
+                                    path=_STORAGE_YAML_KEY,
+                                )
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        command=[
+            "imagebuild",
+            "--logger.formatter.type=text",
+            f"--logger.level={log_level}",
+            "--context",
+            "{{.inputs.context}}",
+            "--frontend",
+            f"{union_image_name_prefix}/frontend-v2:{app_version}",
+            "--remote-outputs-prefix",
+            "{{.outputPrefix}}",
+            "--spec",
+            "{{.inputs.spec}}",
+            "--target-image",
+            "{{.inputs.target_image}}",
+            "--optimize",
+        ],
+    )
+    
+    build_image_task_env = flyte.TaskEnvironment.from_task(
+        "build_image_task", build_image_task
+    )
+    
+  flyte-config.yaml: |
+    admin:
+      authType: ClientSecret
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: 'test.example.com'
+      insecure: false
+    task:
+      org: ""
+      project: "system"
+      domain: "production"
+
+---
+# Source: controlplane/templates/image-builder-bootstrap/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          image: "python:3.13-slim"
+          env:
+            - name: APP_VERSION
+              value: "2026.5.5"
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              pip install --root-user-action=ignore --quiet uv
+              uv pip install --quiet --system flyte kubernetes
+
+              flyte create project \
+                --id   "system" \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project "system" \
+                --domain  "production" \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: ""
+

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -11912,3 +11912,288 @@ spec:
       storage:
         capacity: 100Gi
         storageClassName: scylladb
+---
+# Source: controlplane/templates/image-builder-bootstrap/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+    """build-image ContainerTask definition, registered automatically by the
+    controlplane chart's post-install / post-upgrade Helm hook Job
+    (see templates/image-builder-bootstrap/).
+    
+    Two env vars are required at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2
+                                 (set by the Job from .Chart.AppVersion).
+      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                                 frontend-v2 images live
+                                 (set by the Job from values.imageBuilder.bootstrap
+                                 .unionImageNamePrefix).
+    
+    Per-namespace defaults consumed at task execution time come from the
+    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    """
+    import os
+    
+    from kubernetes.client import (
+        V1PodSpec,
+        V1Container,
+        V1EnvVar,
+        V1VolumeMount,
+        V1EnvVarSource,
+        V1ObjectFieldSelector,
+        V1ConfigMapKeySelector,
+        V1Volume,
+        V1ProjectedVolumeSource,
+        V1VolumeProjection,
+        V1ServiceAccountTokenProjection,
+        V1ConfigMapVolumeSource,
+        V1KeyToPath,
+    )
+    
+    import flyte
+    from flyte.extras import ContainerTask
+    
+    
+    _DEFAULT_CONFIGMAP_NAME = "build-image-config"
+    _STORAGE_YAML_KEY = "storage.yaml"
+    _CONFIG_DIR = "/etc/union/config"
+    
+    config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+    log_level = os.getenv("LOG_LEVEL", "5")
+    
+    union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+    if not union_image_name_prefix:
+        raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+    
+    app_version = os.getenv("APP_VERSION")
+    if not app_version:
+        raise ValueError("APP_VERSION environment variable must be set")
+    
+    build_image_task = ContainerTask(
+        name="build-image",
+        cache=flyte.Cache(behavior="auto"),
+        image=f"{union_image_name_prefix}/build-image:{app_version}",
+        inputs={"spec": str, "context": str, "target_image": str},
+        outputs={"fully_qualified_image": str},
+        pod_template=flyte.PodTemplate(
+            primary_container_name="main",
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="main",
+                        image_pull_policy="Always",
+                        termination_message_policy="FallbackToLogsOnError",
+                        volume_mounts=[
+                            V1VolumeMount(
+                                mount_path="/var/run/secrets/union/registry",
+                                name="registry-token",
+                                read_only=True,
+                            ),
+                            V1VolumeMount(
+                                name="config-volume",
+                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                                sub_path=_STORAGE_YAML_KEY,
+                            ),
+                        ],
+                        env=[
+                            V1EnvVar(
+                                name="ORGANIZATION",
+                                value_from=V1EnvVarSource(
+                                    field_ref=V1ObjectFieldSelector(
+                                        field_path="metadata.labels['organization']"
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_BUILDKIT_URI",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="buildkit-uri",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_DEFAULT_REPOSITORY",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="default-repository",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="authentication-type",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_IMAGE_NAME_PREFIX",
+                                value=union_image_name_prefix,
+                            ),
+                            V1EnvVar(
+                                name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="enable-image-optimization",
+                                        optional=True,
+                                    )
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    V1Volume(
+                        name="registry-token",
+                        projected=V1ProjectedVolumeSource(
+                            sources=[
+                                V1VolumeProjection(
+                                    service_account_token=V1ServiceAccountTokenProjection(
+                                        audience="registry",
+                                        expiration_seconds=7200,
+                                        path="token",
+                                    )
+                                )
+                            ]
+                        ),
+                    ),
+                    V1Volume(
+                        name="config-volume",
+                        config_map=V1ConfigMapVolumeSource(
+                            name=config_map_name,
+                            items=[
+                                V1KeyToPath(
+                                    key=_STORAGE_YAML_KEY,
+                                    path=_STORAGE_YAML_KEY,
+                                )
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        command=[
+            "imagebuild",
+            "--logger.formatter.type=text",
+            f"--logger.level={log_level}",
+            "--context",
+            "{{.inputs.context}}",
+            "--frontend",
+            f"{union_image_name_prefix}/frontend-v2:{app_version}",
+            "--remote-outputs-prefix",
+            "{{.outputPrefix}}",
+            "--spec",
+            "{{.inputs.spec}}",
+            "--target-image",
+            "{{.inputs.target_image}}",
+            "--optimize",
+        ],
+    )
+    
+    build_image_task_env = flyte.TaskEnvironment.from_task(
+        "build_image_task", build_image_task
+    )
+    
+  flyte-config.yaml: |
+    admin:
+      authType: ClientSecret
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: 'test.example.com'
+      insecure: false
+    task:
+      org: ""
+      project: "system"
+      domain: "production"
+
+---
+# Source: controlplane/templates/image-builder-bootstrap/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          image: "python:3.13-slim"
+          env:
+            - name: APP_VERSION
+              value: "2026.5.5"
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              pip install --root-user-action=ignore --quiet uv
+              uv pip install --quiet --system flyte kubernetes
+
+              flyte create project \
+                --id   "system" \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project "system" \
+                --domain  "production" \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: ""
+

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -12143,7 +12143,7 @@ spec:
           image: "python:3.13-slim"
           env:
             - name: APP_VERSION
-              value: "2026.5.5"
+              value: "2026.5.7"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -12196,3 +12196,288 @@ spec:
       storage:
         capacity: 100Gi
         storageClassName: scylladb
+---
+# Source: controlplane/templates/image-builder-bootstrap/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+    """build-image ContainerTask definition, registered automatically by the
+    controlplane chart's post-install / post-upgrade Helm hook Job
+    (see templates/image-builder-bootstrap/).
+    
+    Two env vars are required at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2
+                                 (set by the Job from .Chart.AppVersion).
+      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                                 frontend-v2 images live
+                                 (set by the Job from values.imageBuilder.bootstrap
+                                 .unionImageNamePrefix).
+    
+    Per-namespace defaults consumed at task execution time come from the
+    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    """
+    import os
+    
+    from kubernetes.client import (
+        V1PodSpec,
+        V1Container,
+        V1EnvVar,
+        V1VolumeMount,
+        V1EnvVarSource,
+        V1ObjectFieldSelector,
+        V1ConfigMapKeySelector,
+        V1Volume,
+        V1ProjectedVolumeSource,
+        V1VolumeProjection,
+        V1ServiceAccountTokenProjection,
+        V1ConfigMapVolumeSource,
+        V1KeyToPath,
+    )
+    
+    import flyte
+    from flyte.extras import ContainerTask
+    
+    
+    _DEFAULT_CONFIGMAP_NAME = "build-image-config"
+    _STORAGE_YAML_KEY = "storage.yaml"
+    _CONFIG_DIR = "/etc/union/config"
+    
+    config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+    log_level = os.getenv("LOG_LEVEL", "5")
+    
+    union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+    if not union_image_name_prefix:
+        raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+    
+    app_version = os.getenv("APP_VERSION")
+    if not app_version:
+        raise ValueError("APP_VERSION environment variable must be set")
+    
+    build_image_task = ContainerTask(
+        name="build-image",
+        cache=flyte.Cache(behavior="auto"),
+        image=f"{union_image_name_prefix}/build-image:{app_version}",
+        inputs={"spec": str, "context": str, "target_image": str},
+        outputs={"fully_qualified_image": str},
+        pod_template=flyte.PodTemplate(
+            primary_container_name="main",
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="main",
+                        image_pull_policy="Always",
+                        termination_message_policy="FallbackToLogsOnError",
+                        volume_mounts=[
+                            V1VolumeMount(
+                                mount_path="/var/run/secrets/union/registry",
+                                name="registry-token",
+                                read_only=True,
+                            ),
+                            V1VolumeMount(
+                                name="config-volume",
+                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                                sub_path=_STORAGE_YAML_KEY,
+                            ),
+                        ],
+                        env=[
+                            V1EnvVar(
+                                name="ORGANIZATION",
+                                value_from=V1EnvVarSource(
+                                    field_ref=V1ObjectFieldSelector(
+                                        field_path="metadata.labels['organization']"
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_BUILDKIT_URI",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="buildkit-uri",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_DEFAULT_REPOSITORY",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="default-repository",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="authentication-type",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_IMAGE_NAME_PREFIX",
+                                value=union_image_name_prefix,
+                            ),
+                            V1EnvVar(
+                                name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="enable-image-optimization",
+                                        optional=True,
+                                    )
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    V1Volume(
+                        name="registry-token",
+                        projected=V1ProjectedVolumeSource(
+                            sources=[
+                                V1VolumeProjection(
+                                    service_account_token=V1ServiceAccountTokenProjection(
+                                        audience="registry",
+                                        expiration_seconds=7200,
+                                        path="token",
+                                    )
+                                )
+                            ]
+                        ),
+                    ),
+                    V1Volume(
+                        name="config-volume",
+                        config_map=V1ConfigMapVolumeSource(
+                            name=config_map_name,
+                            items=[
+                                V1KeyToPath(
+                                    key=_STORAGE_YAML_KEY,
+                                    path=_STORAGE_YAML_KEY,
+                                )
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        command=[
+            "imagebuild",
+            "--logger.formatter.type=text",
+            f"--logger.level={log_level}",
+            "--context",
+            "{{.inputs.context}}",
+            "--frontend",
+            f"{union_image_name_prefix}/frontend-v2:{app_version}",
+            "--remote-outputs-prefix",
+            "{{.outputPrefix}}",
+            "--spec",
+            "{{.inputs.spec}}",
+            "--target-image",
+            "{{.inputs.target_image}}",
+            "--optimize",
+        ],
+    )
+    
+    build_image_task_env = flyte.TaskEnvironment.from_task(
+        "build_image_task", build_image_task
+    )
+    
+  flyte-config.yaml: |
+    admin:
+      authType: ClientSecret
+      clientId: ''
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: 'test.example.com'
+      insecure: false
+    task:
+      org: "test-org"
+      project: "system"
+      domain: "production"
+
+---
+# Source: controlplane/templates/image-builder-bootstrap/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          image: "python:3.13-slim"
+          env:
+            - name: APP_VERSION
+              value: "2026.5.5"
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              pip install --root-user-action=ignore --quiet uv
+              uv pip install --quiet --system flyte kubernetes
+
+              flyte create project \
+                --id   "system" \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project "system" \
+                --domain  "production" \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: ""
+

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -12427,7 +12427,7 @@ spec:
           image: "python:3.13-slim"
           env:
             - name: APP_VERSION
-              value: "2026.5.5"
+              value: "2026.5.7"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG


### PR DESCRIPTION
## Summary

Customers had to manually run `flyte deploy ... build_image_task.py` after every helm install/upgrade to make `flyte.Image.from_*` work. Move that registration into the controlplane chart as a post-install/post-upgrade/post-rollback Helm hook so `helm upgrade` is the only operator step.

## What's added

Under `charts/controlplane/`:

- `files/build_image_task.py` — Python task definition (the same code customers ran manually), but with `UNION_IMAGE_NAME_PREFIX` and `APP_VERSION` read from env so the file is usable both by the chart Job and by anyone who still wants to register out-of-band.
- `templates/image-builder-bootstrap/configmap.yaml` — single ConfigMap with two keys:
  - `build_image_task.py` — the task source, loaded from `files/`
  - `flyte-config.yaml` — the flyte CLI config, rendered from `imageBuilder.bootstrap.admin` via `tpl + toYaml` so any flyte SDK admin field (`endpoint`, `insecure`, `authType`, `authMode`, `clientId`, `clientSecretLocation`, …) can be overridden without a chart change
  Mounted into the Job at `/etc/build-image-task/` + `/etc/flyte/`. Hook-weight 0.
- `templates/image-builder-bootstrap/job.yaml` — the bootstrap Job. Hook-weight 10 (runs after CP deployments are healthy). Installs `flyte` + `kubernetes` via `uv pip install` at startup (~30s; both `pip install uv` and `uv pip install` are idempotent on re-runs). `flyte create project ... || true` (idempotent), then `flyte deploy --version ${APP_VERSION}` to register the task at the same tag as the deployed services so every upgrade re-registers in lockstep.
- `values.yaml` additions under `imageBuilder.bootstrap`:
  ```yaml
  imageBuilder:
    bootstrap:
      enabled: true                  # opt out with false
      image: python:3.13-slim
      unionImageNamePrefix: <registry>
      project: system
      domain: production
      podAnnotations: {}             # e.g. linkerd.io/inject: disabled
      podLabels: {}
      backoffLimit: 2
      ttlSecondsAfterFinished: 600
      restartPolicy: Never
      admin:                         # flyte SDK admin block; open schema
        endpoint: '{{ .Values.global.UNION_HOST }}'
        insecure: false
        authType: ClientSecret
        clientId: '{{ .Values.global.INTERNAL_CLIENT_ID }}'
        clientSecretLocation: /etc/secrets/union/client_secret
  ```

## Design notes

- **`APP_VERSION` comes from `image.tag`** (defaults to `.Chart.AppVersion`), not from `.Chart.AppVersion` directly. This keeps the registered task images in lockstep with the deployed service images whenever an external pipeline overrides `image.tag` to a SHA at deploy time.
- **Auth path**: the bootstrap Job goes through the public ingress (`UNION_HOST`) rather than the intra-cluster `flyteadmin.<ns>.svc.cluster.local:81` block from `configMap.admin`. The two are deliberately separate because the flyte Python SDK's OAuth metadata discovery can't reproduce the CP service-to-service flow that the Go services use against the intra-cluster path.
- **Secret name**: pulled from the chart's `defaults.secretName` convention (which already resolves to `global.KUBERNETES_SECRET_NAME`), so the bootstrap Job mounts the same Secret all other CP services mount at `/etc/secrets/union/`.
- **Hook annotations are not exposed** as values — they're chart-internal mechanics. To opt out entirely, set `imageBuilder.bootstrap.enabled: false`.
- **Image choice**: `python:3.13-slim` + install at startup. No existing Union image ships `uv + flyte`; happy to swap to a pre-baked Union image in a follow-up if review prefers faster Job startup over the third-party-pull surface.

## Validation

End-to-end on an internal selfmanaged GCP cluster:

- ArgoCD sync drives the Helm hook → bootstrap Job runs to completion in ~18s → Job auto-deletes (per `hook-succeeded` policy).
- `flyte get task -p system -d production build-image` shows the task registered at the chart's deployed tag.
- Override paths verified: `imageBuilder.bootstrap.admin.{endpoint,insecure,authType,...}`, `podAnnotations`, `podLabels`, `backoffLimit`, `ttlSecondsAfterFinished`, `restartPolicy`, `image.tag` — all flow through render correctly.
- Snapshot tests regenerated; `make helm-test` passes.

## Out of scope

- End-to-end smoke verification as part of the Job. Registration-only here; a `helm.sh/hook: test` Job that calls `flyte run ...build_image_task` could be added in a follow-up.
- AWS equivalence. AWS DPs have the same image-builder registration friction; same chart pattern would apply with the IRSA-bound Secret. Deliberate scope-limit on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
