### PR TITLE
dataplane: bundle FlyteWorkflow CRD in chart's crds/; mirror to crds/flyte-v1/

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ secrets:
 
 4. Install the Union operator and CRDs:
 ```shell
-helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds
+# The dataplane chart bundles the FlyteWorkflow CRD under `crds/`; Helm
+# installs it automatically on first install. Drop `--skip-crds` if you'd
+# rather Helm handle the CRD; pass `--skip-crds` here and apply
+# `crds/flyte-v1/` separately if you manage CRDs out-of-band (SSA / ArgoCD).
 helm upgrade --install unionai-dataplane unionai/dataplane \
     --create-namespace \
     --namespace union \

--- a/charts/dataplane/README.md
+++ b/charts/dataplane/README.md
@@ -49,7 +49,15 @@ Union requires Custom Resource Definitions to be installed first.
 kubectl apply --server-side --force-conflicts -f crds/flyte-v1/
 ```
 
-(Equivalent legacy path: `helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds --namespace union --create-namespace`. That chart is now deprecated; prefer the vendored directory above so the CRDs land via server-side apply and don't trip the 256 KiB `last-applied-configuration` limit on larger CRDs nearby.)
+`crds/flyte-v1/` is a byte-identical mirror of the chart-bundled CRD at
+`charts/dataplane/crds/`. The mirror exists so an ArgoCD `Application`
+(or this `kubectl apply`) can install via SSA when you pass `--skip-crds`
+to Helm in Step 4. If you instead drop `--skip-crds`, Helm will install
+the bundled CRD itself on first install — note that Helm's `crds/`
+directory is **install-only and never modified by `helm upgrade`**, so
+schema changes (rare for FlyteWorkflow) must be reapplied out-of-band.
+
+(Equivalent legacy path: `helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds --namespace union --create-namespace`. That chart is now deprecated; prefer one of the two paths above.)
 
 **Optional — install only the sets that match the dataplane features you enable:**
 

--- a/charts/dataplane/SELFHOSTED_INTRA_CLUSTER_AWS.md
+++ b/charts/dataplane/SELFHOSTED_INTRA_CLUSTER_AWS.md
@@ -49,11 +49,18 @@ In addition to the standard prerequisites, you need:
 
 ### Step 1: Install Dataplane CRDs
 
+The `FlyteWorkflow` CRD is bundled with the dataplane chart (Helm 3
+`crds/` convention) and would otherwise install automatically. Because
+this guide passes `--skip-crds` in Step 3 (to keep CRD lifecycle out of
+Helm), install it directly via server-side apply from the byte-identical
+mirror under `crds/flyte-v1/`:
+
 ```bash
-helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds \
-  --namespace union \
-  --create-namespace
+# From a checkout of unionai/helm-charts
+kubectl apply --server-side --force-conflicts -f crds/flyte-v1/
 ```
+
+(Legacy: `helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds --namespace union --create-namespace`. That chart is deprecated; prefer the command above.)
 
 ### Step 1b: Install Vendored CRDs (when monitoring.enabled=true)
 

--- a/charts/dataplane/SELFHOSTED_INTRA_CLUSTER_GCP.md
+++ b/charts/dataplane/SELFHOSTED_INTRA_CLUSTER_GCP.md
@@ -49,11 +49,18 @@ In addition to the standard prerequisites, you need:
 
 ### Step 1: Install Dataplane CRDs
 
+The `FlyteWorkflow` CRD is bundled with the dataplane chart (Helm 3
+`crds/` convention) and would otherwise install automatically. Because
+this guide passes `--skip-crds` in Step 3 (to keep CRD lifecycle out of
+Helm), install it directly via server-side apply from the byte-identical
+mirror under `crds/flyte-v1/`:
+
 ```bash
-helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds \
-  --namespace union \
-  --create-namespace
+# From a checkout of unionai/helm-charts
+kubectl apply --server-side --force-conflicts -f crds/flyte-v1/
 ```
+
+(Legacy: `helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds --namespace union --create-namespace`. That chart is deprecated; prefer the command above.)
 
 ### Step 1b: Install Vendored CRDs (when monitoring.enabled=true)
 

--- a/charts/dataplane/crds/crd-flyteworkflows.yaml
+++ b/charts/dataplane/crds/crd-flyteworkflows.yaml
@@ -1,5 +1,3 @@
-# AUTO-GENERATED — do not edit. Run scripts/sync.sh in this directory to regenerate.
-# Source: charts/dataplane/crds/crd-flyteworkflows.yaml
 # Union-maintained FlyteWorkflow CRD. Installed automatically on `helm install`
 # (Helm 3 `crds/` convention); pass `--skip-crds` and apply `crds/flyte-v1/`
 # instead if you manage CRDs out-of-band (ArgoCD / kubectl SSA). That sibling

--- a/crds/README.md
+++ b/crds/README.md
@@ -36,7 +36,7 @@ background on the failure mode.
 | `kube-prometheus-stack/`   | `prometheus-community/kube-prometheus-stack`        | `controlplane`, `dataplane` |
 | `scylla-operator/`         | `scylla/scylla-operator`                            | `controlplane`            |
 | `envoy-gateway/`           | `oci://docker.io/envoyproxy/gateway-helm`           | `controlplane`            |
-| `flyte-v1/`                | Union-maintained (no upstream sync)                 | `dataplane` (FlyteWorkflow); replaces `charts/dataplane-crds` |
+| `flyte-v1/`                | Union-maintained; mirror of `charts/dataplane/crds/` | `dataplane` (FlyteWorkflow); replaces `charts/dataplane-crds` |
 | `knative-operator/`        | `knative/serving` + `knative/operator` releases     | App Serving; replaces `charts/knative-operator-crds` |
 
 The corresponding parent chart's subchart `crds/` directory is NOT rendered
@@ -47,22 +47,31 @@ source so the same CRDs aren't applied twice.
 
 ```
 crds/<name>/
-  VERSION                   # upstream chart version this dir tracks (omit for Union-maintained CRDs)
-  scripts/                  # omit for Union-maintained CRDs
-    sync.sh                 # re-vendor from upstream + bump VERSION
+  VERSION                   # upstream chart version this dir tracks (omit for chart-mirrored dirs)
+  scripts/
+    sync.sh                 # (re-)populate crd-*.yaml — from upstream OR from a chart-dir mirror source
     check.sh                # CI gate: cross-validate + detect drift
   crd-*.yaml                # vendored CRDs with an "AUTO-GENERATED — do not edit" header
 ```
 
-For upstream-tracked dirs (KPS / scylla / envoy-gateway), `scripts/sync.sh`
-is the only thing that should ever write to the `crd-*.yaml` files. Hand
-edits will be overwritten on the next sync; if you need to patch a CRD, do
-it via a downstream layer (kustomize on the ArgoCD source, or a helm
-post-render), not in `crd-*.yaml` directly.
+Each directory falls into one of two subtypes — both end up as
+byte-identical `crd-*.yaml` plus a `scripts/` pair, so `make vendor-crds`
+and `make check-vendored-crds` iterate over them uniformly.
 
-For Union-maintained dirs (e.g. `flyte-v1/`), `crd-*.yaml` is the source of
-truth — edit it directly. No `scripts/` is needed; the `make vendor-crds`
-loop simply skips dirs that lack a sync script.
+**Upstream-tracked** (KPS / scylla / envoy-gateway): `scripts/sync.sh`
+pulls from the upstream chart at the version declared in
+`charts/controlplane/Chart.yaml`, writes that version to `VERSION`, and
+re-emits the `crd-*.yaml` files. Hand edits are overwritten on the next
+sync; patch downstream (kustomize on the ArgoCD source, or a helm
+post-render), not `crd-*.yaml` directly.
+
+**Chart-mirrored** (`flyte-v1/`): the source of truth is a CRD file inside
+a chart's Helm-native `crds/` directory (e.g.
+`charts/dataplane/crds/crd-flyteworkflows.yaml`). `scripts/sync.sh` copies
+that file here so the mirror can be installed via SSA by a dedicated
+ArgoCD `Application` (when the customer runs `helm install --skip-crds`).
+No `VERSION` file — there's no upstream version to track. Edit the
+chart-dir file, then `make vendor-crds`.
 
 ## Adding a new vendored CRD set
 
@@ -94,6 +103,6 @@ make check-vendored-crds
 ```
 
 `check.sh` fails the build if any of:
-- the parent-chart dep version disagrees between controlplane and dataplane
-- `crds/<name>/VERSION` disagrees with the parent-chart dep version
-- the vendored `crd-*.yaml` files differ from a fresh `sync.sh` re-run
+- the parent-chart dep version disagrees between controlplane and dataplane (upstream-tracked dirs only)
+- `crds/<name>/VERSION` disagrees with the parent-chart dep version (upstream-tracked dirs only)
+- the vendored `crd-*.yaml` files differ from a fresh `sync.sh` re-run (all dirs)

--- a/crds/flyte-v1/README.md
+++ b/crds/flyte-v1/README.md
@@ -1,10 +1,30 @@
-# Flyte v1 CRDs
+# Flyte v1 CRDs (mirror)
 
 Union-maintained CRDs for Flyte v1 (currently just `flyteworkflows.flyte.lyft.com`).
-Edit `crd-*.yaml` directly — there is no upstream chart to sync from, so this
-directory ships no `scripts/sync.sh` (unlike the other `crds/<name>/` dirs).
 
-Replaces the `flyteworkflow` template that lived in
-[`charts/dataplane-crds`](../../charts/dataplane-crds/) (now deprecated).
+**This directory is a mirror, not the source of truth.** The canonical file
+lives in the dataplane chart's Helm-managed `crds/` directory at:
 
-See [`../README.md`](../README.md) for the broader vendoring rationale.
+  [`charts/dataplane/crds/crd-flyteworkflows.yaml`](../../charts/dataplane/crds/crd-flyteworkflows.yaml)
+
+That chart-dir copy is installed automatically by `helm install` (Helm 3
+`crds/` convention). The mirror here exists so a dedicated ArgoCD
+`Application` (or `kubectl apply --server-side -f crds/flyte-v1/`) can
+install the same CRD with SSA when the customer opts out of Helm-managed
+CRDs (`helm install --skip-crds`). Both paths apply byte-identical YAML.
+
+## Editing
+
+Edit the chart-dir file. Then run:
+
+```bash
+make vendor-crds        # regenerates crd-*.yaml in this directory
+make check-vendored-crds # CI also runs this; fails on drift
+```
+
+`scripts/sync.sh` simply copies from the chart dir into this directory with
+an AUTO-GENERATED header injected; `scripts/check.sh` re-runs sync.sh into a
+tmp dir and diffs.
+
+See [`../README.md`](../README.md) for the broader vendoring rationale and
+the equivalent layout used for upstream-tracked subchart CRDs.

--- a/crds/flyte-v1/scripts/check.sh
+++ b/crds/flyte-v1/scripts/check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Verify the mirrored FlyteWorkflow CRD in this directory is byte-identical
+# to a fresh `sync.sh` re-run against the chart-dir source of truth at
+# charts/dataplane/crds/. Hand-editing either copy (or editing the chart
+# source without re-running `make vendor-crds`) fails the check.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRD_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${CRD_DIR}/../.." && pwd)"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+"${SCRIPT_DIR}/sync.sh" "${TMPDIR}" >/dev/null
+
+mismatch=0
+shopt -s nullglob
+for src in "${CRD_DIR}"/crd-*.yaml; do
+  base="$(basename "${src}")"
+  if [[ ! -f "${TMPDIR}/${base}" ]]; then
+    echo "drift: extra mirrored file (not produced by sync.sh): ${base}" >&2
+    mismatch=1
+    continue
+  fi
+  if ! diff -u "${src}" "${TMPDIR}/${base}" >&2; then
+    mismatch=1
+  fi
+done
+for src in "${TMPDIR}"/crd-*.yaml; do
+  base="$(basename "${src}")"
+  if [[ ! -f "${CRD_DIR}/${base}" ]]; then
+    echo "drift: missing mirrored file (would be produced by sync.sh): ${base}" >&2
+    mismatch=1
+  fi
+done
+shopt -u nullglob
+
+if (( mismatch != 0 )); then
+  cat >&2 <<EOF
+
+ERROR: vendored CRD YAML in crds/flyte-v1/ does not match the chart-dir
+source at charts/dataplane/crds/. Edit the chart-dir file (source of truth)
+then run \`make vendor-crds\` and commit the result.
+EOF
+  exit 1
+fi
+
+echo "==> flyte-v1 CRDs in sync ($(ls "${CRD_DIR}"/crd-*.yaml 2>/dev/null | wc -l | tr -d ' ') file(s))"

--- a/crds/flyte-v1/scripts/sync.sh
+++ b/crds/flyte-v1/scripts/sync.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Re-vendor the FlyteWorkflow CRD into this directory by copying it from the
+# Helm-managed source of truth at charts/dataplane/crds/. Helm's `crds/`
+# convention installs that file automatically on `helm install` (no template
+# rendering); we keep a byte-identical mirror here so a dedicated ArgoCD
+# Application can install it with SSA when the customer opts out of Helm-
+# managed CRDs (`helm install --skip-crds`).
+#
+# This is the same shape as the other crds/<name>/scripts/sync.sh scripts,
+# but with no upstream chart to pull from — the "upstream" is just the
+# chart-dir file in this repo. There is no VERSION file for the same reason.
+#
+# Usage:
+#   ./scripts/sync.sh                     # default: writes to parent dir
+#   ./scripts/sync.sh /path/to/out/dir    # writes to a custom dir (used by check.sh)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRD_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${CRD_DIR}/../.." && pwd)"
+
+SRC_DIR="${REPO_ROOT}/charts/dataplane/crds"
+OUT_DIR="${1:-${CRD_DIR}}"
+
+if [[ ! -d "${SRC_DIR}" ]]; then
+  echo "ERROR: expected source CRDs at ${SRC_DIR}; was the chart's crds/ dir moved?" >&2
+  exit 1
+fi
+
+echo "==> Mirroring flyte-v1 CRDs from ${SRC_DIR#${REPO_ROOT}/}"
+echo "    output dir: ${OUT_DIR}"
+
+mkdir -p "${OUT_DIR}"
+
+# Wipe existing vendored CRDs so removals at the source propagate.
+rm -f "${OUT_DIR}"/crd-*.yaml
+
+count=0
+shopt -s nullglob
+for src in "${SRC_DIR}"/crd-*.yaml; do
+  base="$(basename "${src}")"
+  dst="${OUT_DIR}/${base}"
+
+  {
+    echo "# AUTO-GENERATED — do not edit. Run scripts/sync.sh in this directory to regenerate."
+    echo "# Source: charts/dataplane/crds/${base}"
+    cat "${src}"
+  } > "${dst}"
+
+  count=$((count + 1))
+done
+shopt -u nullglob
+
+if (( count == 0 )); then
+  echo "ERROR: no crd-*.yaml files found at ${SRC_DIR}" >&2
+  exit 1
+fi
+
+echo "==> Wrote ${count} CRD manifest(s)"


### PR DESCRIPTION
## Summary

The dataplane chart now ships the FlyteWorkflow CRD under `charts/dataplane/crds/` so `helm install` auto-applies it (Helm 3 `crds/` convention). The existing `crds/flyte-v1/` directory becomes a byte-identical **mirror** of that chart-dir file, kept in sync by `scripts/sync.sh` + `scripts/check.sh` — the same shape used for the upstream-tracked vendored CRD dirs (`kube-prometheus-stack/`, `scylla-operator/`, `envoy-gateway/`, `knative-operator/`). `make vendor-crds` / `make check-vendored-crds` pick the new dir up automatically; no Makefile edits.

This gives customers two equally-supported install paths and lets the docs prefer the externally-managed-CRD path without having to maintain a separate, hand-edited copy:

| Path | Behavior |
|---|---|
| `helm install … --skip-crds` + `kubectl apply --server-side -f crds/flyte-v1/` (or ArgoCD pointing at `crds/flyte-v1/`) | CRDs land via SSA, full lifecycle owned by whoever runs the kubectl/Argo apply. **Recommended** for selfhosted/intra-cluster installs. |
| `helm install …` (no `--skip-crds`) | Helm installs the bundled CRD on first install. Convenient for one-shot installs. Note: Helm's `crds/` dir is **install-only** — `helm upgrade` will never modify the CRD. |

## Why the mirror, not a single location

Having a chart-dir copy alone would force every Argo-managed install to render the chart just to install the CRD; having only the standalone mirror means Helm-only users get a worse out-of-box experience. Splitting source-of-truth (`charts/dataplane/crds/`) from mirror (`crds/flyte-v1/`) and CI-gating that they're byte-identical is a well-trodden pattern (cert-manager, prometheus-operator, Argo CD, Gateway API all ship CRDs in both forms).

## Drift gate

`crds/flyte-v1/scripts/check.sh` re-runs `sync.sh` into a tmp dir and `diff -u`s against the committed mirror. Hand-editing either copy without re-running `make vendor-crds` fails CI with an actionable message pointing at the chart-dir source.

The existing `vendored-crds` GitHub Actions job iterates `crds/*/scripts/check.sh` so it picks up the new dir automatically.

## What did NOT change

- `charts/dataplane-crds/` stays in place, still marked deprecated. Customers on the legacy `helm install unionai/dataplane-crds` path are unaffected.
- The ArgoCD `Application` that points at `crds/flyte-v1/` still resolves to the same bytes; no downstream config change needed.
- Subchart-vendored CRD dirs (`kube-prometheus-stack/`, `scylla-operator/`, `envoy-gateway/`, `knative-operator/`) are untouched.

## Docs touched

- `charts/dataplane/README.md` — install steps mention both paths + the install-only caveat.
- `charts/dataplane/SELFHOSTED_INTRA_CLUSTER_AWS.md` and `…_GCP.md` — Step 1 now uses `kubectl apply --server-side -f crds/flyte-v1/` (was `helm install unionai/dataplane-crds`).
- Top-level `README.md` — dataplane install snippet updated.
- `crds/README.md` — documents the "chart-mirrored" subtype alongside the existing "upstream-tracked" one.
- `crds/flyte-v1/README.md` — points editors at the chart-dir source.

## Test plan

- [x] `make vendor-crds` populates `crds/flyte-v1/` from `charts/dataplane/crds/` (1 CRD, picked up by the existing loop).
- [x] `make check-vendored-crds` exits 0 with all five vendored dirs green.
- [x] Tampered the mirror file → `check.sh` produced an actionable diff and exit 1.
- [ ] CI: `vendored-crds` job passes on this branch.
- [ ] `helm template charts/dataplane` continues to render unchanged (the chart's `crds/` dir is not templated).