### PR TITLE
crds: drop dangling `properties:` null in flyteworkflows CRD

### DIFF
--- a/crds/flyte-v1/crd-flyteworkflows.yaml
+++ b/crds/flyte-v1/crd-flyteworkflows.yaml
@@ -23,4 +23,3 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
-          properties:


### PR DESCRIPTION
## Problem

\`crds/flyte-v1/crd-flyteworkflows.yaml\` ended with \`properties:\` on its own line with no body, which YAML interprets as \`properties: null\`. The Kubernetes API server drops null fields when storing the CRD, so the live resource has no \`properties\` key at all.

Any tool that compares the source manifest against the live state via server-side dry-run (e.g. \`kubectl diff\`, \`helm diff\`, GitOps controllers) flags this as a perpetual drift.

## Fix

Drop the dangling \`properties:\` line. The schema is already permissive via \`x-kubernetes-preserve-unknown-fields: true\`, so the removal is functionally a no-op and eliminates the diff.

## Test plan

- [x] \`kubectl apply --dry-run=server -f crds/flyte-v1/crd-flyteworkflows.yaml\` succeeds with no schema validation error.
- [x] \`kubectl get crd flyteworkflows.flyte.lyft.com -o yaml\` shows identical schema (the field was already absent in the stored object).
- [x] \`kubectl diff -f crds/flyte-v1/crd-flyteworkflows.yaml\` returns empty after the change (was previously non-empty).