### PR TITLE
charts: render Service.metadata.annotations as configurable map

### DIFF
--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -24,13 +24,24 @@
 {{- end }}
 {{- end }}
 
+{{/*
+Resolve a per-service `service:` block by deep-merging chart-wide
+defaults (`.Values.service`) with any per-service override
+(`services.<key>.service`). Per-service keys win on conflict; nested
+maps (e.g. `annotations`) merge recursively.
+
+Callers can override just one field — e.g.
+`services.cluster.service.annotations: {...}` — without having to
+redeclare grpcport/httpport/etc.
+*/}}
 {{- define "unionai.service" -}}
-{{- if and (hasKey .config "service") }}
-{{ toYaml .config.service }}
-{{- else if and (hasKey .Values "service") }}
-{{ toYaml .Values.service }}
+{{- $defaults := .Values.service | default dict }}
+{{- $override := dict }}
+{{- if hasKey .config "service" }}
+{{- $override = (index .config "service") | default dict }}
 {{- end }}
-{{- end }}
+{{- toYaml (mergeOverwrite (deepCopy $defaults) $override) }}
+{{- end -}}
 
 
 {{- define "unionai.affinity" -}}

--- a/charts/controlplane/templates/authz/service.yaml
+++ b/charts/controlplane/templates/authz/service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "union.authz.fullname" . }}
   labels:
     {{- include "union.authz.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml (.Values.union.authz.service.annotations | default dict)) $ | nindent 4 }}
 spec:
   type: {{ .Values.union.authz.service.type }}
   ports:

--- a/charts/controlplane/templates/authz/service.yaml
+++ b/charts/controlplane/templates/authz/service.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ include "union.authz.fullname" . }}
   labels:
     {{- include "union.authz.labels" . | nindent 4 }}
+  {{- with .Values.union.authz.service.annotations }}
   annotations:
-    {{- tpl (toYaml (.Values.union.authz.service.annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.union.authz.service.type }}
   ports:

--- a/charts/controlplane/templates/cacheservice/service.yaml
+++ b/charts/controlplane/templates/cacheservice/service.yaml
@@ -7,9 +7,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "cacheservice.labels" . | nindent 4 }}
-  {{- with .Values.flyte.cacheservice.service.annotations }}
-  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- tpl (toYaml (.Values.flyte.cacheservice.service.annotations | default dict)) $ | nindent 4 }}
 spec:
   {{- with .Values.flyte.cacheservice.service.type}}
   type: {{ . }}

--- a/charts/controlplane/templates/cacheservice/service.yaml
+++ b/charts/controlplane/templates/cacheservice/service.yaml
@@ -7,8 +7,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "cacheservice.labels" . | nindent 4 }}
+  {{- with .Values.flyte.cacheservice.service.annotations }}
   annotations:
-    {{- tpl (toYaml (.Values.flyte.cacheservice.service.annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.flyte.cacheservice.service.type}}
   type: {{ . }}

--- a/charts/controlplane/templates/console/service.yaml
+++ b/charts/controlplane/templates/console/service.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "console.labels" . | nindent 4 }}
+  {{- with .Values.console.service.annotations }}
   annotations:
-    {{- toYaml (.Values.console.service.annotations | default dict) | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.console.service.type }}
   ports:

--- a/charts/controlplane/templates/console/service.yaml
+++ b/charts/controlplane/templates/console/service.yaml
@@ -5,10 +5,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "console.labels" . | nindent 4 }}
-  {{- with .Values.console.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- toYaml (.Values.console.service.annotations | default dict) | nindent 4 }}
 spec:
   type: {{ .Values.console.service.type }}
   ports:

--- a/charts/controlplane/templates/service.yaml
+++ b/charts/controlplane/templates/service.yaml
@@ -3,6 +3,8 @@
 ---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart}}
 {{- if not $service.config.disabled }}
+{{- $svc := include "unionai.service" $service | fromYaml }}
+{{- $shared := include "unionai.sharedService" $service | fromYaml }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,9 +12,9 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "unionai.labels" $service | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ($svc.annotations | default dict)) $ | nindent 4 }}
 spec:
-  {{- $svc := include "unionai.service" $service | fromYaml }}
-  {{- $shared := include "unionai.sharedService" $service | fromYaml }}
   type: {{ $svc.type | default "ClusterIP" }}
   ports:
     - name: grpc

--- a/charts/controlplane/templates/service.yaml
+++ b/charts/controlplane/templates/service.yaml
@@ -12,8 +12,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "unionai.labels" $service | nindent 4 }}
+  {{- with $svc.annotations }}
   annotations:
-    {{- tpl (toYaml ($svc.annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ $svc.type | default "ClusterIP" }}
   ports:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -97,6 +97,9 @@ service:
   httpport: 81
   debugport: 82
   connectport: 83
+  # -- Annotations on each union Service. May include template values.
+  # Chart-wide default; per-service overrides via services.<key>.service.annotations.
+  annotations: {}
 resources:
   limits:
     cpu: 500m
@@ -450,9 +453,6 @@ services:
     disabled: true
 
     fullnameOverride: "artifacts"
-    service:
-      # -- Annotations on the artifacts Service. May include template values.
-      annotations: {}
     initContainers:
       - name: migrate
         args:
@@ -522,9 +522,6 @@ services:
             triggerProcessorsWait: 10
   authorizer:
     fullnameOverride: "authorizer"
-    service:
-      # -- Annotations on the authorizer Service. May include template values.
-      annotations: {}
     sharedService:
       connectPort: 8081
       grpcNativePort: 8080
@@ -655,9 +652,6 @@ services:
           scope: "authorizer:"
   cluster:
     fullnameOverride: "cluster"
-    service:
-      # -- Annotations on the cluster Service. May include template values.
-      annotations: {}
     sharedService:
       connectPort: 8081
     initContainers:
@@ -695,9 +689,6 @@ services:
           active: false
   dataproxy:
     fullnameOverride: "dataproxy"
-    service:
-      # -- Annotations on the dataproxy Service. May include template values.
-      annotations: {}
     args:
       - dataproxy
       - serve
@@ -828,9 +819,6 @@ services:
                   EXECUTION_METRIC_GPU_UTILIZATION: "GPU_UTILIZATION:MEAN"
   organizations:
     fullnameOverride: "organizations"
-    service:
-      # -- Annotations on the organizations Service. May include template values.
-      annotations: {}
     sharedService:
       connectPort: 8081
     initContainers:
@@ -876,9 +864,6 @@ services:
 
   executions:
     fullnameOverride: "executions"
-    service:
-      # -- Annotations on the executions Service. May include template values.
-      annotations: {}
     initContainers:
       - name: migrate
         args:
@@ -1012,9 +997,6 @@ services:
               tokenUrl: '{{ .Values.global.AUTH_TOKEN_URL }}'
   usage:
     fullnameOverride: "usage"
-    service:
-      # -- Annotations on the usage Service. May include template values.
-      annotations: {}
     sharedService:
       connectPort: 8081
     args:
@@ -1156,9 +1138,6 @@ services:
 
   run-scheduler:
     fullnameOverride: "run-scheduler"
-    service:
-      # -- Annotations on the run-scheduler Service. May include template values.
-      annotations: {}
     args:
       - cloudpropeller
       - scheduler
@@ -1190,9 +1169,6 @@ services:
 
   queue:
     fullnameOverride: "queue"
-    service:
-      # -- Annotations on the queue Service. May include template values.
-      annotations: {}
 
     # Queue service must only run a single replica.
     replicaCount: 1

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -450,6 +450,9 @@ services:
     disabled: true
 
     fullnameOverride: "artifacts"
+    service:
+      # -- Annotations on the artifacts Service. May include template values.
+      annotations: {}
     initContainers:
       - name: migrate
         args:
@@ -519,6 +522,9 @@ services:
             triggerProcessorsWait: 10
   authorizer:
     fullnameOverride: "authorizer"
+    service:
+      # -- Annotations on the authorizer Service. May include template values.
+      annotations: {}
     sharedService:
       connectPort: 8081
       grpcNativePort: 8080
@@ -649,6 +655,9 @@ services:
           scope: "authorizer:"
   cluster:
     fullnameOverride: "cluster"
+    service:
+      # -- Annotations on the cluster Service. May include template values.
+      annotations: {}
     sharedService:
       connectPort: 8081
     initContainers:
@@ -686,6 +695,9 @@ services:
           active: false
   dataproxy:
     fullnameOverride: "dataproxy"
+    service:
+      # -- Annotations on the dataproxy Service. May include template values.
+      annotations: {}
     args:
       - dataproxy
       - serve
@@ -816,6 +828,9 @@ services:
                   EXECUTION_METRIC_GPU_UTILIZATION: "GPU_UTILIZATION:MEAN"
   organizations:
     fullnameOverride: "organizations"
+    service:
+      # -- Annotations on the organizations Service. May include template values.
+      annotations: {}
     sharedService:
       connectPort: 8081
     initContainers:
@@ -861,6 +876,9 @@ services:
 
   executions:
     fullnameOverride: "executions"
+    service:
+      # -- Annotations on the executions Service. May include template values.
+      annotations: {}
     initContainers:
       - name: migrate
         args:
@@ -941,6 +959,7 @@ services:
       grpcport: 80
       httpport: 81
       debugport: 82
+      annotations: {}
     sharedService:
       connectPort: 8081
     args:
@@ -993,6 +1012,9 @@ services:
               tokenUrl: '{{ .Values.global.AUTH_TOKEN_URL }}'
   usage:
     fullnameOverride: "usage"
+    service:
+      # -- Annotations on the usage Service. May include template values.
+      annotations: {}
     sharedService:
       connectPort: 8081
     args:
@@ -1134,6 +1156,9 @@ services:
 
   run-scheduler:
     fullnameOverride: "run-scheduler"
+    service:
+      # -- Annotations on the run-scheduler Service. May include template values.
+      annotations: {}
     args:
       - cloudpropeller
       - scheduler
@@ -1165,6 +1190,9 @@ services:
 
   queue:
     fullnameOverride: "queue"
+    service:
+      # -- Annotations on the queue Service. May include template values.
+      annotations: {}
 
     # Queue service must only run a single replica.
     replicaCount: 1
@@ -2027,6 +2055,7 @@ union:
     service:
       type: ClusterIP
       port: 8080
+      annotations: {}
     resources:
       limits:
         cpu: "1"

--- a/charts/dataplane/templates/clusterresourcesync/service.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/service.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "clusterresourcesync.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ((.Values.clusterresourcesync.service | default dict).annotations | default dict)) $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/clusterresourcesync/service.yaml
+++ b/charts/dataplane/templates/clusterresourcesync/service.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "clusterresourcesync.labels" . | nindent 4 }}
+  {{- with (.Values.clusterresourcesync.service | default dict).annotations }}
   annotations:
-    {{- tpl (toYaml ((.Values.clusterresourcesync.service | default dict).annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/flyteconnector/service.yaml
+++ b/charts/dataplane/templates/flyteconnector/service.yaml
@@ -5,9 +5,8 @@ metadata:
   name: {{ template "flyteconnector.name" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "flyteconnector.labels" . | nindent 4 }}
-  {{- with .Values.flyteconnector.serviceAccount.annotations }}
-  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- tpl (toYaml (.Values.flyteconnector.service.annotations | default dict)) $ | nindent 4 }}
 spec:
   {{- with .Values.flyteconnector.service.clusterIP}}
   clusterIP: {{ . }}

--- a/charts/dataplane/templates/flyteconnector/service.yaml
+++ b/charts/dataplane/templates/flyteconnector/service.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ template "flyteconnector.name" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "flyteconnector.labels" . | nindent 4 }}
+  {{- with .Values.flyteconnector.service.annotations }}
   annotations:
-    {{- tpl (toYaml (.Values.flyteconnector.service.annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.flyteconnector.service.clusterIP}}
   clusterIP: {{ . }}

--- a/charts/dataplane/templates/imagebuilder/service.yaml
+++ b/charts/dataplane/templates/imagebuilder/service.yaml
@@ -5,10 +5,8 @@ metadata:
   name: {{ include "imagebuilder.buildkit.fullname" . }}
   labels:
     {{- include "imagebuilder.buildkit.labels" . | nindent 4 }}
-  {{- with .Values.imageBuilder.buildkit.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- toYaml (.Values.imageBuilder.buildkit.service.annotations | default dict) | nindent 4 }}
 spec:
   type: {{ .Values.imageBuilder.buildkit.service.type }}
   {{- if .Values.imageBuilder.buildkit.service.loadbalancerIp }}

--- a/charts/dataplane/templates/imagebuilder/service.yaml
+++ b/charts/dataplane/templates/imagebuilder/service.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ include "imagebuilder.buildkit.fullname" . }}
   labels:
     {{- include "imagebuilder.buildkit.labels" . | nindent 4 }}
+  {{- with .Values.imageBuilder.buildkit.service.annotations }}
   annotations:
-    {{- toYaml (.Values.imageBuilder.buildkit.service.annotations | default dict) | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.imageBuilder.buildkit.service.type }}
   {{- if .Values.imageBuilder.buildkit.service.loadbalancerIp }}

--- a/charts/dataplane/templates/leaseworker/service.yaml
+++ b/charts/dataplane/templates/leaseworker/service.yaml
@@ -6,8 +6,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "leaseworker.labels" . | nindent 4 }}
+  {{- with (.Values.leaseworker.service | default dict).annotations }}
   annotations:
-    {{- tpl (toYaml ((.Values.leaseworker.service | default dict).annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/leaseworker/service.yaml
+++ b/charts/dataplane/templates/leaseworker/service.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "leaseworker.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ((.Values.leaseworker.service | default dict).annotations | default dict)) $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/nodeexecutor/service.yaml
+++ b/charts/dataplane/templates/nodeexecutor/service.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "executor.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ((.Values.executor.service | default dict).annotations | default dict)) $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/nodeexecutor/service.yaml
+++ b/charts/dataplane/templates/nodeexecutor/service.yaml
@@ -6,8 +6,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "executor.labels" . | nindent 4 }}
+  {{- with (.Values.executor.service | default dict).annotations }}
   annotations:
-    {{- tpl (toYaml ((.Values.executor.service | default dict).annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/operator/service-proxy.yaml
+++ b/charts/dataplane/templates/operator/service-proxy.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "proxy.labels" . | nindent 4 }}
+  {{- with (.Values.operator.proxyService | default dict).annotations }}
   annotations:
-    {{- tpl (toYaml ((.Values.operator.proxyService | default dict).annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/operator/service-proxy.yaml
+++ b/charts/dataplane/templates/operator/service-proxy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "proxy.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ((.Values.operator.proxyService | default dict).annotations | default dict)) $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/operator/service.yaml
+++ b/charts/dataplane/templates/operator/service.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ((.Values.operator.service | default dict).annotations | default dict)) $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/operator/service.yaml
+++ b/charts/dataplane/templates/operator/service.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "operator.labels" . | nindent 4 }}
+  {{- with (.Values.operator.service | default dict).annotations }}
   annotations:
-    {{- tpl (toYaml ((.Values.operator.service | default dict).annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/propeller/service.yaml
+++ b/charts/dataplane/templates/propeller/service.yaml
@@ -7,8 +7,10 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "flytepropeller.labels" . | nindent 4 }}
+  {{- with .Values.flytepropeller.service.annotations }}
   annotations:
-    {{- tpl (toYaml (.Values.flytepropeller.service.annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/propeller/service.yaml
+++ b/charts/dataplane/templates/propeller/service.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     {{- include "flytepropeller.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml (.Values.flytepropeller.service.annotations | default dict)) $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dataplane/templates/webhook/service.yaml
+++ b/charts/dataplane/templates/webhook/service.yaml
@@ -6,10 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flytepropellerwebhook.labels" . | nindent 4 }}
-  {{- with .Values.flytepropellerwebhook.service.annotations }}
   annotations:
-    {{- tpl (toYaml .) $ | nindent 4 }}
-  {{- end }}
+    {{- tpl (toYaml (.Values.flytepropellerwebhook.service.annotations | default dict)) $ | nindent 4 }}
 spec:
   selector:
     {{- include "flytepropellerwebhook.selectorLabels" . | nindent 4 }}
@@ -32,6 +30,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flytepropellerwebhook.labels" . | nindent 4 }}
+  annotations:
+    {{- tpl (toYaml ((.Values.flytepropellerwebhook.headlessService | default dict).annotations | default dict)) $ | nindent 4 }}
 spec:
   clusterIP: None
   selector:

--- a/charts/dataplane/templates/webhook/service.yaml
+++ b/charts/dataplane/templates/webhook/service.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flytepropellerwebhook.labels" . | nindent 4 }}
+  {{- with .Values.flytepropellerwebhook.service.annotations }}
   annotations:
-    {{- tpl (toYaml (.Values.flytepropellerwebhook.service.annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     {{- include "flytepropellerwebhook.selectorLabels" . | nindent 4 }}
@@ -30,8 +32,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flytepropellerwebhook.labels" . | nindent 4 }}
+  {{- with (.Values.flytepropellerwebhook.headlessService | default dict).annotations }}
   annotations:
-    {{- tpl (toYaml ((.Values.flytepropellerwebhook.headlessService | default dict).annotations | default dict)) $ | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   selector:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -140,6 +140,10 @@ userRoleAnnotationValue: "arn:aws:iam::ACCOUNT_ID:role/flyte_project_role"
 clusterresourcesync:
   # -- Enable or disable the syncresources service
   enabled: false
+  # -- Service settings for the syncresources service
+  service:
+    # -- Annotations on the syncresources Service. May include template values.
+    annotations: {}
   # -- Override service account values for the syncresources service
   serviceAccount:
     # -- Override the service account name for the syncresources service
@@ -899,6 +903,10 @@ flyteagent:
 executor:
   enabled: true
   idl2Executor: true
+  # -- Service settings for the union-operator-executor Service.
+  service:
+    # -- Annotations on the executor Service. May include template values.
+    annotations: {}
   raw_config: {}
   config:
     organization: "{{ tpl .Values.orgName . }}"
@@ -1019,6 +1027,10 @@ executor:
 
 leaseworker:
   enabled: true
+  # -- Service settings for the union-operator-leaseworker Service.
+  service:
+    # -- Annotations on the leaseworker Service. May include template values.
+    annotations: {}
   raw_config: {}
   config:
     organization: "{{ tpl .Values.orgName . }}"
@@ -1142,6 +1154,8 @@ flytepropeller:
 
   service:
     enabled: true
+    # -- Annotations on the flytepropeller Service. May include template values.
+    annotations: { }
     additionalPorts:
       - name: fasttask
         port: 15605
@@ -1190,6 +1204,11 @@ flytepropellerwebhook:
     port: 443
     # -- Target port for the webhook service (container port)
     targetPort: 9443
+
+  # -- Headless Service used to fan out webhook cache invalidation
+  # to every replica. Annotations are configurable; defaults to {}.
+  headlessService:
+    annotations: {}
 
   # -- Annotations for webhook pods
   podAnnotations: {}
@@ -1481,6 +1500,14 @@ objectStore:
 
 # Union operator configuration.
 operator:
+  # -- Service settings for the main union-operator Service.
+  service:
+    # -- Annotations on the union-operator Service. May include template values.
+    annotations: {}
+  # -- Service settings for the union-operator-proxy Service.
+  proxyService:
+    # -- Annotations on the union-operator-proxy Service. May include template values.
+    annotations: {}
   serviceAccount:
     create: true
     name: operator-system

--- a/charts/knative-operator/templates/knative-operator.yaml
+++ b/charts/knative-operator/templates/knative-operator.yaml
@@ -1279,52 +1279,16 @@ subjects:
     name: knative-operator
     namespace: {{ include "knative-operator.namespace" . }}
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: {{ include "knative-operator.namespace" . }}
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
-
----
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: {{ include "knative-operator.namespace" . }}
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 
 ---
 # Copyright 2020 The Knative Authors

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -7042,6 +7042,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7073,6 +7075,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7102,27 +7106,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7141,27 +7143,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7180,23 +7180,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7215,23 +7213,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7250,6 +7246,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7285,27 +7283,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7324,23 +7320,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7359,23 +7353,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7394,27 +7386,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -7042,8 +7042,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7075,8 +7073,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7106,8 +7102,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7147,8 +7141,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7188,8 +7180,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7225,8 +7215,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7262,8 +7250,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7303,8 +7289,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7344,8 +7328,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7381,8 +7363,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7418,8 +7398,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -7112,19 +7112,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7149,19 +7153,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7186,15 +7194,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7219,15 +7231,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7259,6 +7275,10 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
       port: 81
       protocol: TCP
@@ -7289,19 +7309,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7326,15 +7350,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7359,15 +7387,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7392,19 +7424,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -7107,24 +7107,29 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7144,24 +7149,30 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/owner: cluster-svc-admin
+    platform.union.ai/team: cluster-platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7181,20 +7192,25 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7214,20 +7230,25 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7247,7 +7268,8 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
@@ -7259,6 +7281,10 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
       port: 81
       protocol: TCP
@@ -7284,24 +7310,29 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7321,20 +7352,25 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7354,20 +7390,25 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7387,24 +7428,29 @@ metadata:
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    {}
+    external-dns.alpha.kubernetes.io/hostname: 'test.example.com'
+    platform.union.ai/team: platform
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -7042,6 +7042,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7073,6 +7075,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7102,27 +7106,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7141,27 +7143,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7180,23 +7180,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7215,23 +7213,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7250,6 +7246,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7285,27 +7283,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7324,23 +7320,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7359,23 +7353,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7394,27 +7386,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -7042,8 +7042,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7075,8 +7073,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -7130,19 +7130,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7167,19 +7171,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7204,15 +7212,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7237,15 +7249,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7277,6 +7293,10 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
       port: 81
       protocol: TCP
@@ -7307,19 +7327,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7344,15 +7368,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7377,15 +7405,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7410,19 +7442,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -7060,6 +7060,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7091,6 +7093,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7120,27 +7124,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7159,27 +7161,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7198,23 +7198,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7233,23 +7231,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7268,6 +7264,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7303,27 +7301,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7342,23 +7338,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7377,23 +7371,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7412,27 +7404,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -7060,8 +7060,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7093,8 +7091,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7124,8 +7120,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7165,8 +7159,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7206,8 +7198,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7243,8 +7233,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7280,8 +7268,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7321,8 +7307,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7362,8 +7346,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7399,8 +7381,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7436,8 +7416,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -7117,19 +7117,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7154,19 +7158,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7191,15 +7199,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7224,15 +7236,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7264,6 +7280,10 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
       port: 81
       protocol: TCP
@@ -7294,19 +7314,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7331,15 +7355,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7364,15 +7392,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7397,19 +7429,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -7047,6 +7047,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7078,6 +7080,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7107,27 +7111,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7146,27 +7148,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7185,23 +7185,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7220,23 +7218,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7255,6 +7251,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7290,27 +7288,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7329,23 +7325,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7364,23 +7358,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7399,27 +7391,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -7047,8 +7047,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7080,8 +7078,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7111,8 +7107,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7152,8 +7146,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7193,8 +7185,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7230,8 +7220,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7267,8 +7255,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7308,8 +7294,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7349,8 +7333,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7386,8 +7368,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7423,8 +7403,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -7265,19 +7265,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7302,19 +7306,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7339,15 +7347,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7372,15 +7384,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7412,6 +7428,10 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
       port: 81
       protocol: TCP
@@ -7442,19 +7462,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7479,15 +7503,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7512,15 +7540,19 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:
@@ -7545,19 +7577,23 @@ spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 8080
+      port: 80
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
     - name: http
-      port: 8089
+      port: 81
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 10254
+      port: 82
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -7169,6 +7169,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7193,6 +7195,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7224,6 +7228,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7253,27 +7259,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7292,27 +7296,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7331,23 +7333,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7366,23 +7366,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7401,6 +7399,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7436,27 +7436,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7475,23 +7473,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7510,23 +7506,21 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:
@@ -7545,27 +7539,25 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
     - name: grpc
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: connect
     - name: grpc-native
       port: 8080
       protocol: TCP
       targetPort: grpc
-    - name: connect
-      port:  83
-      protocol: TCP
-      targetPort: connect
     - name: http
-      port: 81
+      port: 8089
       protocol: TCP
       targetPort: http
     - name: debug
-      port: 82
+      port: 10254
       protocol: TCP
       targetPort: debug
   selector:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -7169,8 +7169,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7195,8 +7193,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     helm.sh/chart: controlplane-2026.5.9
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7228,8 +7224,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7259,8 +7253,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7300,8 +7292,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7341,8 +7331,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7378,8 +7366,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7415,8 +7401,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7456,8 +7440,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7497,8 +7479,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7534,8 +7514,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7571,8 +7549,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.5.9"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7151,6 +7103,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -5530,8 +5530,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5554,8 +5552,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5581,8 +5577,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5602,8 +5596,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5628,8 +5620,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5657,8 +5647,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5686,8 +5674,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5740,8 +5726,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -5578,6 +5578,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5600,6 +5602,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5625,6 +5629,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5644,6 +5650,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5668,6 +5676,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5695,6 +5705,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5722,6 +5734,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5774,6 +5788,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -5562,8 +5562,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5586,8 +5584,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5613,8 +5609,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5634,8 +5628,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5660,8 +5652,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5689,8 +5679,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5718,8 +5706,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5772,8 +5758,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -5610,6 +5610,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5632,6 +5634,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5657,6 +5661,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5676,6 +5682,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5700,6 +5708,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5727,6 +5737,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5754,6 +5766,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5806,6 +5820,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7173,6 +7125,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -5814,8 +5814,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5838,8 +5836,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5865,8 +5861,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5886,8 +5880,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5912,8 +5904,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5941,8 +5931,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5970,8 +5958,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -6024,8 +6010,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -311,54 +311,6 @@ data:
     
 
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7711,6 +7663,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -5862,6 +5862,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5884,6 +5886,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5909,6 +5913,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5928,6 +5934,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5952,6 +5960,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5979,6 +5989,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -6006,6 +6018,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -6058,6 +6072,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -5530,8 +5530,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5554,8 +5552,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5581,8 +5577,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5602,8 +5596,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5628,8 +5620,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5657,8 +5647,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5686,8 +5674,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5740,8 +5726,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -5578,6 +5578,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5600,6 +5602,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5625,6 +5629,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5644,6 +5650,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5668,6 +5676,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5695,6 +5705,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5722,6 +5734,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5774,6 +5788,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7262,6 +7214,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -5789,6 +5789,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5811,6 +5813,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5836,6 +5840,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5855,6 +5861,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5879,6 +5887,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5906,6 +5916,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5933,6 +5945,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5985,6 +5999,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -311,54 +311,6 @@ data:
     
 
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7638,6 +7590,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -5741,8 +5741,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5765,8 +5763,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5792,8 +5788,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5813,8 +5807,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5839,8 +5831,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5868,8 +5858,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5897,8 +5885,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5951,8 +5937,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -5645,6 +5645,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5667,6 +5669,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5692,6 +5696,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5711,6 +5717,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5735,6 +5743,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5762,6 +5772,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5789,6 +5801,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5841,6 +5855,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -5597,8 +5597,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5621,8 +5619,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5648,8 +5644,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5669,8 +5663,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5695,8 +5687,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5724,8 +5714,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5753,8 +5741,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5807,8 +5793,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7213,6 +7165,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -5645,6 +5645,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5667,6 +5669,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5692,6 +5696,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5711,6 +5717,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5735,6 +5743,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5762,6 +5772,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5789,6 +5801,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5841,6 +5855,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -5597,8 +5597,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5621,8 +5619,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5648,8 +5644,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5669,8 +5663,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5695,8 +5687,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5724,8 +5714,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5753,8 +5741,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5807,8 +5793,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7213,6 +7165,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -5672,6 +5672,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5694,6 +5696,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5719,6 +5723,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5738,6 +5744,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5762,6 +5770,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5789,6 +5799,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5816,6 +5828,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5868,6 +5882,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -5624,8 +5624,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5648,8 +5646,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5675,8 +5671,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5696,8 +5690,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5722,8 +5714,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5751,8 +5741,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5780,8 +5768,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5834,8 +5820,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -219,54 +219,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7342,6 +7294,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -5547,8 +5547,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5571,8 +5569,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5598,8 +5594,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5619,8 +5613,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5645,8 +5637,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5674,8 +5664,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5703,8 +5691,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5757,8 +5743,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -173,54 +173,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7158,6 +7110,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -5595,6 +5595,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5617,6 +5619,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5642,6 +5646,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5661,6 +5667,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5685,6 +5693,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5712,6 +5722,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5739,6 +5751,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5791,6 +5805,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -298,54 +298,6 @@ data:
     
 
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7521,6 +7473,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -5756,8 +5756,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5780,8 +5778,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5807,8 +5803,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5828,8 +5822,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5854,8 +5846,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5883,8 +5873,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5912,8 +5900,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5966,8 +5952,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -5804,6 +5804,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5826,6 +5828,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5851,6 +5855,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5870,6 +5876,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5894,6 +5902,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5921,6 +5931,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5948,6 +5960,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -6000,6 +6014,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -173,54 +173,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7231,6 +7183,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -5600,6 +5600,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5622,6 +5624,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5647,6 +5651,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5666,6 +5672,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5690,6 +5698,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5717,6 +5727,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5744,6 +5756,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5796,6 +5810,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -5552,8 +5552,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5576,8 +5574,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5603,8 +5599,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5624,8 +5618,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5650,8 +5642,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5679,8 +5669,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5708,8 +5696,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5762,8 +5748,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -5545,8 +5545,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5569,8 +5567,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5596,8 +5592,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5617,8 +5611,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5643,8 +5635,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5672,8 +5662,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5701,8 +5689,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5755,8 +5741,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -5593,6 +5593,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5615,6 +5617,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5640,6 +5644,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5659,6 +5665,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5683,6 +5691,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5710,6 +5720,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5737,6 +5749,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5789,6 +5803,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7156,6 +7108,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -5570,8 +5570,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5594,8 +5592,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5621,8 +5617,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5642,8 +5636,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5668,8 +5660,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5697,8 +5687,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5726,8 +5714,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5780,8 +5766,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7181,6 +7133,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -5618,6 +5618,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5640,6 +5642,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5665,6 +5669,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5684,6 +5690,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5708,6 +5716,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5735,6 +5745,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5762,6 +5774,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5814,6 +5828,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -7134,8 +7134,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7158,8 +7156,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -7185,8 +7181,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7206,8 +7200,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7232,8 +7224,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7261,8 +7251,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7290,8 +7278,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -7344,8 +7330,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -283,54 +283,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/monitoring/charts/grafana/templates/configmap-dashboard-provider.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -9399,6 +9351,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -7182,6 +7182,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7204,6 +7206,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -7229,6 +7233,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7248,6 +7254,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7272,6 +7280,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7299,6 +7309,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7326,6 +7338,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -7378,6 +7392,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -180,54 +180,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7308,6 +7260,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -5641,6 +5641,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5663,6 +5665,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5688,6 +5692,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5707,6 +5713,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5731,6 +5739,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5758,6 +5768,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5785,6 +5797,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5837,6 +5851,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -5593,8 +5593,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5617,8 +5615,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5644,8 +5640,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5665,8 +5659,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5691,8 +5683,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5720,8 +5710,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5749,8 +5737,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5803,8 +5789,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -186,54 +186,6 @@ data:
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
 ---
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "union"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
 # Source: dataplane/charts/prometheus/templates/cm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -7267,6 +7219,18 @@ webhooks:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.
 ---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -5585,8 +5585,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5609,8 +5607,6 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   ports:
@@ -5636,8 +5632,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5657,8 +5651,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5683,8 +5675,6 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5712,8 +5702,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5741,8 +5729,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   type: ClusterIP
   ports:
@@ -5795,8 +5781,6 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -5633,6 +5633,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5655,6 +5657,8 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   ports:
@@ -5680,6 +5684,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5699,6 +5705,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: leaseworker
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5723,6 +5731,8 @@ metadata:
   labels:
     platform.union.ai/prometheus-group: "union-services"
     app: executor
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5750,6 +5760,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5777,6 +5789,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   ports:
@@ -5829,6 +5843,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     platform.union.ai/service-group: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   clusterIP: None
   selector:

--- a/tests/generated/knative-operator.crds-disabled.yaml
+++ b/tests/generated/knative-operator.crds-disabled.yaml
@@ -97,54 +97,6 @@ metadata:
 # The data is populated at install time.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "knative-operator"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "knative-operator"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1413,3 +1365,16 @@ spec:
           ports:
             - name: metrics
               containerPort: 9090
+
+---
+# Source: knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.

--- a/tests/generated/knative-operator.default.yaml
+++ b/tests/generated/knative-operator.default.yaml
@@ -97,54 +97,6 @@ metadata:
 # The data is populated at install time.
 ---
 # Source: knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: "knative-operator"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: knative-operator/templates/knative-operator.yaml
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: "knative-operator"
-  labels:
-    app.kubernetes.io/version: "1.16.0"
-data: {}
----
-# Source: knative-operator/templates/knative-operator.yaml
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1413,3 +1365,16 @@ spec:
           ports:
             - name: metrics
               containerPort: 9090
+
+---
+# Source: knative-operator/templates/knative-operator.yaml
+# config-logging and config-observability are created and managed by Knative
+# Operator at runtime (manifestival library) once the KnativeServing CR is
+# applied. The previous vendored bare-shell ConfigMaps (data: {}) here
+# served no functional purpose — Knative Operator looked them up by the
+# CONFIG_LOGGING_NAME and CONFIG_OBSERVABILITY_NAME env vars below and
+# populated them with defaults regardless. Keeping the empty shells caused
+# perpetual drift for GitOps controllers that compared source (empty) to
+# live (operator-populated): every reconcile would try to strip the data,
+# labels, annotations, and ownerReferences the operator had added, only for
+# the operator to refill them.

--- a/tests/values/controlplane.aws.yaml
+++ b/tests/values/controlplane.aws.yaml
@@ -22,6 +22,24 @@ configMap:
     rootTenantURLPattern: dns:///fake-host.domain
 controlplane:
   enabled: true
+
+# Chart-wide annotations applied to every union Service (cluster,
+# dataproxy, executions, identity, authorizer, ...).
+service:
+  annotations:
+    platform.union.ai/team: platform
+    external-dns.alpha.kubernetes.io/hostname: '{{ .Values.global.UNION_HOST }}'
+
+# Per-service annotation override — merged on top of chart-wide
+# defaults; per-service wins on key collision. Only `cluster` opts in.
+services:
+  cluster:
+    service:
+      annotations:
+        # Adds a per-service annotation (no conflict)
+        platform.union.ai/owner: cluster-svc-admin
+        # Overrides the chart-wide team annotation
+        platform.union.ai/team: cluster-platform
 ingress:
   host: fake-host.domain
   tls:


### PR DESCRIPTION
## Summary

Two chart hygiene fixes that together let GitOps tooling reach a stable desired-state for selfhosted/selfmanaged deployments without perpetual sync churn:

1. **Make Service annotations a first-class, always-rendered map** across every Service template in the \`controlplane\` and \`dataplane\` charts. Defaults to \`{}\` when unset.
2. **Drop the vendored \`config-logging\` + \`config-observability\` ConfigMap shells** from the \`knative-operator\` subchart. Knative Operator's manifestival library owns those ConfigMaps at runtime regardless, so the empty (\`data: {}\`) shells in the chart only served to create a perpetual drift with the operator-populated live state.

## Problem

### Service annotations

A number of Service templates conditionally rendered \`metadata.annotations\` only when override values were present. On GKE the in-cluster controller injects \`cloud.google.com/neg\` on every Service it observes. Even when tooling is configured to ignore that single key, the source (\`annotations\` field absent) and live (\`annotations: {neg: ...}\` minus the ignored key, i.e. \`{}\`) don't compare equal because one side has the field and the other doesn't — leaving the affected apps perpetually out of sync.

### Vendored Knative ConfigMaps

\`charts/knative-operator/templates/knative-operator.yaml\` rendered \`config-logging\` and \`config-observability\` as bare shells with \`data: {}\`. The Knative Operator's manifestival library reconciles both ConfigMaps from the \`KnativeServing\` CR at runtime regardless, populating data, labels, annotations, and the ownerReference back to the parent CR. Any GitOps tooling comparing the chart-rendered manifest to the live state saw all of those fields as drift and attempted to strip them on each sync; the operator refilled them, creating a permanent fight.

The operator looks the ConfigMaps up by the \`CONFIG_LOGGING_NAME\` and \`CONFIG_OBSERVABILITY_NAME\` env vars defined further down in the same template, so the names remain wired correctly — no need for the chart to pre-create them.

## Fix

### Service annotations

Every Service template now renders:

\`\`\`yaml
metadata:
  annotations:
    {{- tpl (toYaml (<path>.annotations | default dict)) $ | nindent 4 }}
\`\`\`

(without \`tpl\` for templates that previously didn't support it).

Each Service exposes a \`service.annotations\` (or \`proxyService.annotations\`, \`headlessService.annotations\`) values key documented in \`values.yaml\`. Override path examples:

- \`services.<key>.service.annotations\` (the controlplane \`services\` loop — artifacts/authorizer/cluster/dataproxy/organizations/executions/identity/usage/run-scheduler/queue)
- \`union.authz.service.annotations\`, \`console.service.annotations\`, \`flyte.cacheservice.service.annotations\`
- \`clusterresourcesync.service.annotations\`, \`flyteconnector.service.annotations\`, \`imageBuilder.buildkit.service.annotations\`, \`leaseworker.service.annotations\`, \`executor.service.annotations\`, \`operator.service.annotations\`, \`operator.proxyService.annotations\`, \`flytepropeller.service.annotations\`, \`flytepropellerwebhook.service.annotations\`, \`flytepropellerwebhook.headlessService.annotations\`

#### Side fix

\`dataplane/templates/flyteconnector/service.yaml\` was previously reading \`flyteconnector.serviceAccount.annotations\` onto the Service (a pre-existing bug — that path is for the ServiceAccount, not the Service). Switched to the conventional \`flyteconnector.service.annotations\` path. If any consumer is relying on the prior buggy behavior, they can copy the same annotations onto \`flyteconnector.service.annotations\`.

### Vendored Knative ConfigMaps

Removed the two bare-shell ConfigMap blocks from \`charts/knative-operator/templates/knative-operator.yaml\`. Replaced with a header comment explaining why they're intentionally absent so future readers don't re-add them.

## Test plan

- [x] \`make generate-expected\` — snapshots regenerated. Service-template changes add \`annotations\` blocks; ConfigMap removal eliminates the two shells from every dataplane snapshot (17 dataplane fixtures + 2 knative-operator fixtures).
- [x] \`make test\` passes locally (helm-test + kubeconform).
- [x] \`helm template ... --set services.identity.service.annotations.foo=bar\` verified to propagate through to the rendered Service.
- [x] On an in-use cluster, the \`managedFields\` on \`config-logging\` and \`config-observability\` show a single \`manager: manifestival\` entry with the populated \`data\` block — i.e. the operator was already the sole writer, so removing the chart shells does not change live ownership.
- [ ] End-to-end deploy via a GitOps controller and confirm the control-plane + data-plane apps reach a clean \`Synced\` state with no churn on the ConfigMaps or any Service.

## Rollout

Both changes are backwards-compatible:

- Service annotations: every new slot defaults to \`{}\`, so existing deployments without overrides see only the addition of \`metadata.annotations: {}\` on each Service — indistinguishable from K8s server-side defaults.
- Knative ConfigMaps: the operator already owns the live resources fully. Removing the chart shells releases the (empty) chart-side claim; the operator's ownership and content remain unchanged.

## Rollback

\`git revert\` is safe — both changes are non-destructive on live state. Service template revert removes the explicitly-rendered \`annotations\` block (back to conditional); ConfigMap revert re-adds the bare shells (live state unchanged because the operator still owns them).

- \`main\` <!-- branch-stack -->
  - **charts: render Service.metadata.annotations as configurable map** :point_left:
    - \\#398