### PR TITLE
controlplane: route nginx auth-url to in-cluster flyteadmin

### DIFF
--- a/charts/controlplane/templates/common/_dataproxy-ingress.yaml
+++ b/charts/controlplane/templates/common/_dataproxy-ingress.yaml
@@ -12,11 +12,11 @@ metadata:
   {{- end}}
   {{- if .Values.ingress.enableProtectedConsoleIngress }}
   {{- with .Values.ingress.protectedIngressAnnotationsWithoutSignin }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   {{- else }}
   {{- with .Values.ingress.protectedIngressAnnotations }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   {{- end}}
 spec:

--- a/charts/controlplane/templates/common/_ingress-protected-console.yaml
+++ b/charts/controlplane/templates/common/_ingress-protected-console.yaml
@@ -115,7 +115,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end}}
   {{- with .Values.ingress.protectedConsoleIngressAnnotations }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
 spec:
   {{- with .Values.ingress.className }}

--- a/charts/controlplane/templates/common/_ingress-protected.yaml
+++ b/charts/controlplane/templates/common/_ingress-protected.yaml
@@ -1493,11 +1493,11 @@ metadata:
   {{- end}}
   {{- if .Values.ingress.enableProtectedConsoleIngress }}
   {{- with .Values.ingress.protectedIngressAnnotationsWithoutSignin }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   {{- else }}
   {{- with .Values.ingress.protectedIngressAnnotations }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   {{- end}}
 spec:

--- a/charts/controlplane/templates/common/_usage-ingress.yaml
+++ b/charts/controlplane/templates/common/_usage-ingress.yaml
@@ -104,11 +104,11 @@ metadata:
   {{- end}}
   {{- if .Values.ingress.enableProtectedConsoleIngress }}
   {{- with .Values.ingress.protectedIngressAnnotationsWithoutSignin }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   {{- else }}
   {{- with .Values.ingress.protectedIngressAnnotations }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   {{- end}}
   {{- if not .Values.services.usage.configMap.billing.enable }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -284,20 +284,27 @@ ingress:
   #   - X-User-Token: raw OIDC token forwarding for external authorization
   # Removing either will break functionality. X-User-Token enables browser-path
   # token forwarding to external authz servers for downstream token exchange.
+  #
+  # auth-url uses the in-cluster flyteadmin service so nginx's auth_request
+  # subrequest stays inside the cluster. The public-URL form (https://$host/me)
+  # exits via the load balancer and re-enters via ingress, which makes the
+  # subrequest sensitive to any transient LB/TLS/upstream hiccup and surfaces as
+  # intermittent 302 redirects to /login on otherwise valid sessions. The gRPC
+  # variant below has always used the in-cluster form; this mirrors that.
   protectedIngressAnnotations:
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
+    nginx.ingress.kubernetes.io/auth-url: "http://flyteadmin.{{ template \"flyte.namespace\" . }}.svc.cluster.local/me"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login?redirect_url=$escaped_request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
     nginx.ingress.kubernetes.io/auth-cache-key: "$http_flyte_authorization$http_cookie"
     nginx.org/websocket-services: dataproxy-service
   enableProtectedConsoleIngress: false
   protectedIngressAnnotationsWithoutSignin:
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
+    nginx.ingress.kubernetes.io/auth-url: "http://flyteadmin.{{ template \"flyte.namespace\" . }}.svc.cluster.local/me"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
     nginx.ingress.kubernetes.io/auth-cache-key: "$http_flyte_authorization$http_cookie"
     nginx.org/websocket-services: dataproxy-service
   protectedConsoleIngressAnnotations:
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
+    nginx.ingress.kubernetes.io/auth-url: "http://flyteadmin.{{ template \"flyte.namespace\" . }}.svc.cluster.local/me"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login?redirect_url=$escaped_request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
     nginx.ingress.kubernetes.io/auth-cache-key: "$http_flyte_authorization$http_cookie"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -9572,7 +9572,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -9714,7 +9714,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -9776,7 +9776,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -11674,7 +11674,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -9577,7 +9577,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -9712,7 +9712,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
@@ -9767,7 +9767,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -11665,7 +11665,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -9590,7 +9590,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -9725,7 +9725,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
@@ -9780,7 +9780,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -11678,7 +11678,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -9577,7 +9577,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -9712,7 +9712,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
@@ -9767,7 +9767,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -11665,7 +11665,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -9861,7 +9861,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -9996,7 +9996,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
@@ -10051,7 +10051,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"
@@ -11949,7 +11949,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://$host/me
+    nginx.ingress.kubernetes.io/auth-url: http://flyteadmin.union.svc.cluster.local/me
     nginx.org/websocket-services: dataproxy-service
 spec:
   ingressClassName: "controlplane"


### PR DESCRIPTION
## Summary

Three of the four protected-ingress annotation blocks in `charts/controlplane/values.yaml` defaulted to:

```
nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
```

With the public-URL form, nginx-ingress's `auth_request` subrequest leaves the cluster, traverses the load balancer, and re-enters via ingress before reaching `flyteadmin`. Any transient hiccup at any layer (stale upstream conn, TLS resumption miss, LB endpoint drain, controller pod restart) makes the subrequest return non-2xx, which nginx-ingress correctly treats as auth failure and serves the `auth-signin` 302. The user sees intermittent redirects to `/login` on otherwise valid sessions.

`protectedIngressAnnotationsGrpc` has always used the in-cluster form. This PR mirrors that on the other three annotation blocks so the auth subrequest stays inside the cluster:

| Annotation block | Before | After |
| --- | --- | --- |
| `protectedIngressAnnotations` | `https://$host/me` | `http://flyteadmin.<ns>.svc.cluster.local/me` |
| `protectedIngressAnnotationsWithoutSignin` | `https://$host/me` | `http://flyteadmin.<ns>.svc.cluster.local/me` |
| `protectedConsoleIngressAnnotations` | `https://$host/me` | `http://flyteadmin.<ns>.svc.cluster.local/me` |
| `protectedIngressAnnotationsGrpc` | (unchanged, in-cluster) | (unchanged) |

`auth-signin` is intentionally left on the public URL form (`https://$host/login...`) — that's the URL nginx redirects the browser to, not a subrequest.

### Template change

The annotation value uses a Go-template helper (`{{ template "flyte.namespace" . }}`) so the namespace resolves at chart-render time. The non-gRPC consumers were using plain `toYaml`, which would have emitted the template literal verbatim. Switched the four consumers (`_ingress-protected.yaml`, `_ingress-protected-console.yaml`, `_usage-ingress.yaml`, `_dataproxy-ingress.yaml`) from `toYaml` to `tpl (toYaml .) $`, matching the gRPC code path that has always done it that way.

### Snapshot diff

`make generate-expected` produces a minimal, targeted diff: 4 lines changed per controlplane fixture (the four Ingress objects), each toggling `auth-url` from the public form to the in-cluster form. No other rendered output changes.

## Test plan

- [x] `make generate-expected` produces only the expected snapshot delta
- [x] `make test` passes (`helm-test` + `kubeconform-test`)
- [x] Snapshot inspection confirms only the four `auth-url` annotations changed across all controlplane fixtures (`aws`, `aws.billing-enable`, `custom-oidc`, `external-authz`, `userclouds`)
- [ ] Verified on a selfhosted cluster that nginx-ingress pods can reach `http://flyteadmin.<ns>.svc.cluster.local/me` (no strict-mTLS mesh blocking) and the auth subrequest succeeds end-to-end
- [ ] End-to-end browser auth flow (`Set-Cookie`, `X-User-Subject`, `X-User-Token` propagation) with the in-cluster `auth-url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)