### PR TITLE
controlplane: use pre-baked image for build-image bootstrap Job

### DIFF
--- a/charts/controlplane/templates/image-builder-bootstrap/job.yaml
+++ b/charts/controlplane/templates/image-builder-bootstrap/job.yaml
@@ -28,7 +28,7 @@ spec:
       restartPolicy: {{ .Values.imageBuilder.bootstrap.restartPolicy }}
       containers:
         - name: bootstrap
-          image: {{ .Values.imageBuilder.bootstrap.image | quote }}
+          image: "{{ tpl .Values.imageBuilder.bootstrap.image.repository . }}:{{ tpl .Values.imageBuilder.bootstrap.image.tag . }}"
           env:
             - name: APP_VERSION
               value: {{ tpl .Values.image.tag . | quote }}
@@ -40,9 +40,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install --root-user-action=ignore --quiet uv
-              uv pip install --quiet --system flyte kubernetes
-
               flyte create project \
                 --id   {{ .Values.imageBuilder.bootstrap.project | quote }} \
                 --name "Union system tasks" \

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -137,14 +137,17 @@ secrets: {}
 imageBuilder:
   bootstrap:
     # When false, the bootstrap Job + ConfigMap are not rendered (use this
-    # if the customer prefers to manage build-image registration themselves
+    # if the operator prefers to manage build-image registration themselves
     # or has an existing registration that must not be overwritten).
     enabled: true
 
-    # Container image the bootstrap Job runs in. Needs Python + a shell;
-    # no Union image currently ships `uv` + `flyte` CLI so the Job
-    # `pip install`s them at startup (~30s, idempotent on re-runs).
-    image: python:3.13-slim
+    # Container image the bootstrap Job runs in. Defaults to the Union-published
+    # `build-image-bootstrap` image (ghcr.io/flyteorg/flyte:py3.12 base with the
+    # `kubernetes` Python client pre-installed), so the Job has no runtime install
+    # step and works in restricted-network deployments where the cluster cannot reach PyPI.
+    image:
+      repository: "{{ .Values.global.IMAGE_REPOSITORY_PREFIX }}/build-image-bootstrap"
+      tag: "{{ .Chart.AppVersion }}"
 
     # Registry prefix the build-image + frontend-v2 task images are pulled
     # from. Defaults to Union's public ECR staging; override per env if

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -12150,7 +12150,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: bootstrap
-          image: "python:3.13-slim"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.5.9"
           env:
             - name: APP_VERSION
               value: "2026.5.9"
@@ -12162,9 +12162,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install --root-user-action=ignore --quiet uv
-              uv pip install --quiet --system flyte kubernetes
-
               flyte create project \
                 --id   "system" \
                 --name "Union system tasks" \

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -12141,7 +12141,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: bootstrap
-          image: "python:3.13-slim"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.5.9"
           env:
             - name: APP_VERSION
               value: "2026.5.9"
@@ -12153,9 +12153,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install --root-user-action=ignore --quiet uv
-              uv pip install --quiet --system flyte kubernetes
-
               flyte create project \
                 --id   "system" \
                 --name "Union system tasks" \

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -12154,7 +12154,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: bootstrap
-          image: "python:3.13-slim"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.5.9"
           env:
             - name: APP_VERSION
               value: "2026.5.9"
@@ -12166,9 +12166,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install --root-user-action=ignore --quiet uv
-              uv pip install --quiet --system flyte kubernetes
-
               flyte create project \
                 --id   "system" \
                 --name "Union system tasks" \

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -12141,7 +12141,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: bootstrap
-          image: "python:3.13-slim"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.5.9"
           env:
             - name: APP_VERSION
               value: "2026.5.9"
@@ -12153,9 +12153,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install --root-user-action=ignore --quiet uv
-              uv pip install --quiet --system flyte kubernetes
-
               flyte create project \
                 --id   "system" \
                 --name "Union system tasks" \

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -12425,7 +12425,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: bootstrap
-          image: "python:3.13-slim"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.5.9"
           env:
             - name: APP_VERSION
               value: "2026.5.9"
@@ -12437,9 +12437,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install --root-user-action=ignore --quiet uv
-              uv pip install --quiet --system flyte kubernetes
-
               flyte create project \
                 --id   "system" \
                 --name "Union system tasks" \


### PR DESCRIPTION
## Summary

The image-builder bootstrap Helm hook (added in #395) currently installs `flyte` + `kubernetes` from PyPI on every run via `pip install uv && uv pip install flyte kubernetes` inside a `python:3.13-slim` container. That fails in restricted-network customer environments where the cluster cannot reach PyPI from the bootstrap Job pod.

This PR switches the default `imageBuilder.bootstrap.image` to a Union-published pre-baked image (`{IMAGE_REPOSITORY_PREFIX}/build-image-bootstrap`, tagged with the chart's `appVersion`), and drops the install lines from the Job command. The image is `ghcr.io/flyteorg/flyte:py3.12` (provides the `flyte` CLI) with the `kubernetes` Python client layered on via uv as an intermediate build stage so the final image is minimal.

## Breaking change

`imageBuilder.bootstrap.image` schema changed from `string` to `{repository, tag}` to match every other image block in the chart (`services`, `console`, etc.). Anyone overriding it as a string must update to the object form:

```yaml
# Before
imageBuilder:
  bootstrap:
    image: my-registry/my-image:tag

# After
imageBuilder:
  bootstrap:
    image:
      repository: my-registry/my-image
      tag: tag
```

\#395 only landed in 2026.5.8 so few overrides are expected in the wild.

## Test plan

- [x] `make generate-expected` — 5 controlplane snapshots regenerated
- [x] `make test` — passes
- [x] Inspected rendered Job: `image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.5.9"`, install lines removed from `command`
- [ ] End-to-end: deploy this chart change against a cluster once the corresponding Union-published `build-image-bootstrap:<chart-tag>` exists, confirm the Job pulls the image and runs `flyte create project` + `flyte deploy` to completion without the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - **controlplane: use pre-baked image for build-image bootstrap Job** :point\_left:
    - \#410
