### PR TITLE
controlplane: add ingress.extraHosts and drop default TLS secret reference

### DIFF
--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -1,3 +1,47 @@
+{{/*
+controlPlaneLibrary.ingressRules emits the `rules:` body for a controlplane
+Ingress. It produces one rule per hostname — first the primary
+`.Values.ingress.host`, then one rule per entry in `.Values.ingress.extraHosts`
+— each carrying the same `http.paths` block.
+
+Arguments (dict):
+  context   — the calling template's root context (so $.Values, $.Release,
+              and `tpl` continue to resolve against the chart, not the dict).
+  pathsTpls — list of named templates to include under `http.paths` (e.g.
+              `(list "protectedHttpRoutes")` or
+              `(list "protectedGrpcRoutes" "appsProtectedConnectRoutes")`).
+
+Usage:
+  rules:
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "protectedHttpRoutes")) | nindent 4 }}
+
+Notes:
+  - When `.Values.ingress.host` is empty, the primary rule emits as a hostless
+    catch-all (same behavior as the prior inline template).
+  - `.Values.ingress.extraHosts` defaults to `[]`, so when unset this helper
+    produces a single rule equivalent to the pre-extraHosts template output.
+*/}}
+{{- define "controlPlaneLibrary.ingressRules" -}}
+{{- $ctx := .context -}}
+{{- $pathsTpls := .pathsTpls -}}
+- {{ with $ctx.Values.ingress.host -}}
+  host: {{ tpl . $ctx }}
+  {{ end -}}
+  http:
+    paths:
+      {{- range $tpl := $pathsTpls }}
+      {{- include $tpl $ctx | nindent 6 }}
+      {{- end }}
+{{- range $extraHost := $ctx.Values.ingress.extraHosts }}
+- host: {{ tpl $extraHost $ctx }}
+  http:
+    paths:
+      {{- range $tpl := $pathsTpls }}
+      {{- include $tpl $ctx | nindent 6 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "unionai.imagePullSecrets" -}}
 {{- if and (hasKey .config "imagePullSecrets") }}
 {{ toYaml .config.imagePullSecrets }}

--- a/charts/controlplane/templates/common/_dataproxy-ingress.yaml
+++ b/charts/controlplane/templates/common/_dataproxy-ingress.yaml
@@ -1,3 +1,20 @@
+{{- define "dataproxyIngressPaths" -}}
+- path: /data/*
+  pathType: ImplementationSpecific
+  backend:
+    service:
+      name: dataproxy
+      port:
+        name: grpc
+- path: /data
+  pathType: Prefix
+  backend:
+    service:
+      name: dataproxy
+      port:
+        name: grpc
+{{- end }}
+
 {{- define "control-plane-library.dataproxy-ingress" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -28,23 +45,5 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end}}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          - path: /data/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: dataproxy
-                port:
-                  name: grpc
-          - path: /data
-            pathType: Prefix
-            backend:
-              service:
-                name: dataproxy
-                port:
-                  name: grpc
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "dataproxyIngressPaths")) | nindent 4 }}
 {{- end }}

--- a/charts/controlplane/templates/common/_grpcroute-protected.yaml
+++ b/charts/controlplane/templates/common/_grpcroute-protected.yaml
@@ -18,6 +18,9 @@ spec:
     - {{ . | quote }}
     {{- end }}
     {{- end }}
+    {{- range $extraHost := .Values.ingress.extraHosts }}
+    - {{ tpl $extraHost $ | quote }}
+    {{- end }}
   rules:
     # flyteadmin — protected gRPC (AdminService, ProjectService, IdentityService, etc.)
     - matches:

--- a/charts/controlplane/templates/common/_grpcroute-unprotected.yaml
+++ b/charts/controlplane/templates/common/_grpcroute-unprotected.yaml
@@ -20,6 +20,9 @@ spec:
     - {{ . | quote }}
     {{- end }}
     {{- end }}
+    {{- range $extraHost := .Values.ingress.extraHosts }}
+    - {{ tpl $extraHost $ | quote }}
+    {{- end }}
   rules:
     - matches:
         - method:

--- a/charts/controlplane/templates/common/_httproute-protected.yaml
+++ b/charts/controlplane/templates/common/_httproute-protected.yaml
@@ -13,6 +13,9 @@ spec:
       namespace: {{ template "flyte.namespace" . }}
   hostnames:
     - {{ .Values.global.UNION_HOST | quote }}
+    {{- range $extraHost := .Values.ingress.extraHosts }}
+    - {{ tpl $extraHost $ | quote }}
+    {{- end }}
   rules:
     # Flyte REST API
     - matches:

--- a/charts/controlplane/templates/common/_httproute-unprotected.yaml
+++ b/charts/controlplane/templates/common/_httproute-unprotected.yaml
@@ -15,6 +15,9 @@ spec:
     {{- if .Values.flyte.common.ingress.isServerless }}
     - {{ .Values.flyte.common.ingress.serverlessVanityHost | quote }}
     {{- end }}
+    {{- range $extraHost := .Values.ingress.extraHosts }}
+    - {{ tpl $extraHost $ | quote }}
+    {{- end }}
   rules:
     # Auth / identity endpoints — publicly required for OIDC flows
     - matches:

--- a/charts/controlplane/templates/common/_ingress-protected-console.yaml
+++ b/charts/controlplane/templates/common/_ingress-protected-console.yaml
@@ -126,9 +126,5 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths: {{- include "protectedConsoleHttpRoutes" . | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "protectedConsoleHttpRoutes")) | nindent 4 }}
 {{- end}} # end of define control-plane-library.console-protected-ingress # end of if .Values.ingress.enableProtectedConsoleIngress

--- a/charts/controlplane/templates/common/_ingress-protected.yaml
+++ b/charts/controlplane/templates/common/_ingress-protected.yaml
@@ -1509,12 +1509,7 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "protectedHttpRoutes" . | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "protectedHttpRoutes")) | nindent 4 }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -1544,13 +1539,7 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "protectedGrpcRoutes" . | nindent 10 }}
-          {{- include "appsProtectedConnectRoutes" . | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "protectedGrpcRoutes" "appsProtectedConnectRoutes")) | nindent 4 }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -1580,11 +1569,5 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "protectedGrpcStreamingRoutes" . | nindent 10 }}
-          {{- include "appsProtectedStreamingRoutes" . | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "protectedGrpcStreamingRoutes" "appsProtectedStreamingRoutes")) | nindent 4 }}
 {{- end }}

--- a/charts/controlplane/templates/common/_ingress-unprotected.yaml
+++ b/charts/controlplane/templates/common/_ingress-unprotected.yaml
@@ -244,12 +244,7 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "httpRoutes" $ | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "httpRoutes")) | nindent 4 }}
 ---
 # Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
 # enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
@@ -277,12 +272,7 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "grpcRoutes" $ | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "grpcRoutes")) | nindent 4 }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -308,10 +298,5 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "grpcStreamingRoutes" $ | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "grpcStreamingRoutes")) | nindent 4 }}
 {{- end }}

--- a/charts/controlplane/templates/common/_usage-ingress.yaml
+++ b/charts/controlplane/templates/common/_usage-ingress.yaml
@@ -84,12 +84,7 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "usageGrpcRoutes" . | nindent 10 }}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "usageGrpcRoutes")) | nindent 4 }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -123,11 +118,6 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - {{ with .Values.ingress.host -}}
-      host: {{ tpl . $ }}
-      {{ end -}}
-      http:
-        paths:
-          {{- include "usageHttpRoutes" . | nindent 10 -}}
+    {{- include "controlPlaneLibrary.ingressRules" (dict "context" . "pathsTpls" (list "usageHttpRoutes")) | nindent 4 }}
 {{- end }}
 

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -259,6 +259,15 @@ ingress:
   # to the public LB, prefer the `nginx.ingress.kubernetes.io/server-alias`
   # annotation below — it's controller-private and doesn't trip cert-manager
   # / external-dns into managing a hostname they can't address.
+  #
+  # When OIDC auth is enabled, each extra host must ALSO be added to:
+  #   - `flyte.configmap.adminServer.auth.authorizedUris` (so flyteadmin
+  #     trusts the host for OAuth redirect URL construction)
+  #   - `flyte.configmap.adminServer.auth.appAuth.externalAuthServer.allowedAudience`
+  #     (so tokens with aud=<extra-host> validate)
+  #   - the IdP application's redirect URI list (`https://<host>/callback`)
+  # Missing any of these will cause login on the alias host to fail —
+  # flyteadmin falls back to the internal service URL and the IdP rejects it.
   extraHosts: []
 
   # Whether to create separate ingress objects for gRPC and HTTP traffic.
@@ -1662,10 +1671,17 @@ flyte:
       auth:
         httpAuthorizationHeader: "flyte-authorization"
         grpcAuthorizationHeader: "flyte-authorization"
+        # Hosts flyteadmin trusts for OAuth redirect URL construction. When a
+        # request arrives, flyteadmin matches the Host header against this
+        # list to build `redirect_uri`; unmatched hosts fall back to the
+        # internal service URL and the IdP will reject the resulting
+        # /authorize request. Must include every public hostname listed in
+        # `ingress.host` and `ingress.extraHosts`.
         authorizedUris:
           - "http://flyteadmin:80"
           - 'http://flyteadmin.{{ .Release.Namespace }}.svc.cluster.local:80'
           - 'https://{{ .Values.global.UNION_HOST }}'
+          # - 'https://<each ingress.extraHosts entry>'
 
         appAuth:
           authServerType: "External"
@@ -1681,8 +1697,12 @@ flyte:
             # Allowed JWT audiences for access token validation.
             # Default: ["https://{UNION_HOST}"].
             # Entra ID example: ["api://my-app-name", "f0b2667d-..."]
+            # Must include every public hostname listed in `ingress.host` and
+            # `ingress.extraHosts` (each as `https://<host>`), or tokens issued
+            # for an extra host's audience will be rejected.
             allowedAudience:
               - 'https://{{ .Values.global.UNION_HOST }}'
+              # - 'https://<each ingress.extraHosts entry>'
 
           # --- Subject claim resolution (FAB-205) ---
           # Ordered list of JWT claims to try for caller identity.

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -141,10 +141,13 @@ imageBuilder:
     # or has an existing registration that must not be overwritten).
     enabled: true
 
-    # Container image the bootstrap Job runs in. Defaults to the Union-published
-    # `build-image-bootstrap` image (ghcr.io/flyteorg/flyte:py3.12 base with the
-    # `kubernetes` Python client pre-installed), so the Job has no runtime install
-    # step and works in restricted-network deployments where the cluster cannot reach PyPI.
+    # Container image the bootstrap Job runs in. Must provide `flyte` (Python
+    # SDK CLI) and the `kubernetes` Python client on PATH. Defaults to the
+    # Union-published `build-image-bootstrap` image, which bakes both in so the
+    # Job has no runtime install step and works in restricted-network
+    # deployments where the cluster cannot reach PyPI. Override `repository`
+    # to use a private mirror or a custom image that satisfies the same
+    # contract.
     image:
       repository: "{{ .Values.global.IMAGE_REPOSITORY_PREFIX }}/build-image-bootstrap"
       tag: "{{ .Chart.AppVersion }}"

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -225,15 +225,38 @@ ingress:
   # Default to the ingress class being created in nginx-ingress chart.
   className: "controlplane"
 
-  # TLS configuration for intra-cluster HTTPS.
-  tls:
-    - hosts:
-        - '{{ .Values.global.UNION_HOST }}'
-        - 'controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local'
-      secretName: 'controlplane-selfsigned-tls-secret'
+  # TLS configuration for the controlplane Ingresses.
+  #
+  # No TLS is configured by default. To enable HTTPS, set `tls` to a list of
+  # `{hosts, secretName}` entries. The secret must already exist in the chart's
+  # namespace (typically provisioned by cert-manager via extraObjects, or by
+  # an external-secrets ExternalSecret in your environment overlay).
+  #
+  # Example — one secret covering the public host and the in-cluster alias:
+  # tls:
+  #   - hosts:
+  #       - '{{ .Values.global.UNION_HOST }}'
+  #       - 'controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local'
+  #     secretName: my-controlplane-tls-secret
+  tls: []
 
   # Host to use for all ingress objects.
   host:  "" # Set the DNS name of the ingress host used by you control plane
+
+  # Additional hostnames to expose every controlplane Ingress (and Envoy
+  # GRPCRoute/HTTPRoute) on. Each entry is added as a separate rules[].host
+  # entry (and hostnames[] entry on Gateway-API routes), so all routes are
+  # reachable on both the primary `host` and each additional hostname.
+  #
+  # TLS coverage is independent — add the hostname to an existing `tls[].hosts`
+  # entry if it's covered by the same secret, add a new `tls[]` entry with its
+  # own secretName for per-host certs, or leave it out for HTTP-only access.
+  #
+  # For an in-cluster alias used only to avoid hairpinning DP→CP traffic out
+  # to the public LB, prefer the `nginx.ingress.kubernetes.io/server-alias`
+  # annotation below — it's controller-private and doesn't trip cert-manager
+  # / external-dns into managing a hostname they can't address.
+  extraHosts: []
 
   # Whether to create separate ingress objects for gRPC and HTTP traffic.
   separateGrpcIngress: true
@@ -241,9 +264,14 @@ ingress:
   # Universal ingress annotations.
   # Currently biased toward nginx-ingress controller
   annotations:
-    # Allow DP→CP traffic via intra-cluster DNS to match ingress rules.
-    # Without this, requests from the dataplane to the controlplane nginx
-    # controller service DNS name won't match the ingress host.
+    # Intra-cluster routing alias — configured by default so controlplane
+    # services (DP→CP, CP→CP auth subrequests) can reach the ingress via the
+    # in-cluster DNS name `controlplane-nginx-controller.<ns>.svc.cluster.local`
+    # without hairpinning out to the public LB. The alias is matched at the
+    # nginx server_name level; the same TLS listener and Ingress rules apply
+    # to it, so no cert SAN, external-dns record, or extra `rules[].host`
+    # entry is needed (and the alias is intentionally not first-classed via
+    # `ingress.extraHosts` because no other controller needs to know about it).
     nginx.ingress.kubernetes.io/server-alias: 'controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local'
 
     # You can switch to v1 if needed using /console instead of /v2 which defaults to v2 unionconsole

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -9584,9 +9584,47 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /data/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /data
+            pathType: Prefix
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /data/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /data
+            pathType: Prefix
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /data/*
@@ -9665,9 +9703,33 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /cloudidl.usage.UsageService(/(?!GetCustomMeasuresNames|GetMeasureGroup|GetMeasureGroups|GetBillableMeasures|GetBillingInfo|ReportBillableUsage|ReportServerlessBillableUsage|CreateCustomer|AttachBillingPlanToCustomer|GetCustomerCredits|EnqueueMetronomeRequest|EnqueueStripeRequest|GetOrgCheckoutSession).*|$)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /cloudidl.usage.UsageService(/(?!GetCustomMeasuresNames|GetMeasureGroup|GetMeasureGroups|GetBillableMeasures|GetBillingInfo|ReportBillableUsage|ReportServerlessBillableUsage|CreateCustomer|AttachBillingPlanToCustomer|GetCustomerCredits|EnqueueMetronomeRequest|EnqueueStripeRequest|GetOrgCheckoutSession).*|$)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /cloudidl.usage.UsageService(/(?!GetCustomMeasuresNames|GetMeasureGroup|GetMeasureGroups|GetBillableMeasures|GetBillingInfo|ReportBillableUsage|ReportServerlessBillableUsage|CreateCustomer|AttachBillingPlanToCustomer|GetCustomerCredits|EnqueueMetronomeRequest|EnqueueStripeRequest|GetOrgCheckoutSession).*|$)
@@ -9720,9 +9782,33 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /usage/api/v1(/(?!custom_measures_names|measure_group|measure_groups|billable_measures|billing_info|report_billable_usage|customer_credits|checkout_session).*|$)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /usage/api/v1(/(?!custom_measures_names|measure_group|measure_groups|billable_measures|billing_info|report_billable_usage|customer_credits|checkout_session).*|$)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /usage/api/v1(/(?!custom_measures_names|measure_group|measure_groups|billable_measures|billing_info|report_billable_usage|customer_credits|checkout_session).*|$)
@@ -9774,9 +9860,761 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /api
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /api/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /cloudadmin
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /cloudadmin/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /actor
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /actor/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /agent
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /agent/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /dataplane
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /dataplane/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /spark-history-server
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /spark-history-server/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /api/v1/dataproxy
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /api/v1/dataproxy/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /app
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /app/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /apps
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /apps/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /cluster
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /cluster/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterpool
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterpool/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterconfig
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterconfig/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /org
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: http
+          - path: /org/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: http
+          - path: /managed_cluster
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /managed_cluster/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /authorizer
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: http
+          - path: /authorizer/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: http
+          - path: /oauth_app
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /oauth_app/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /users
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /users/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /members
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /members/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /roles
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /roles/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /policies
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /policies/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /identities
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /identities/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /echo
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /echo/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /execution
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /execution/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_registry
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_registry/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_instance
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_instance/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /usage
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /usage/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /api
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /api/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /cloudadmin
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /cloudadmin/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /actor
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /actor/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /agent
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /agent/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /dataplane
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /dataplane/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /spark-history-server
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /spark-history-server/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /api/v1/dataproxy
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /api/v1/dataproxy/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /app
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /app/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /apps
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /apps/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /cluster
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /cluster/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterpool
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterpool/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterconfig
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterconfig/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /org
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: http
+          - path: /org/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: http
+          - path: /managed_cluster
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /managed_cluster/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /authorizer
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: http
+          - path: /authorizer/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: http
+          - path: /oauth_app
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /oauth_app/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /users
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /users/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /members
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /members/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /roles
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /roles/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /policies
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /policies/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /identities
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /identities/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /echo
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /echo/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /execution
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /execution/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_registry
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_registry/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_instance
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_instance/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /usage
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /usage/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /api
@@ -10211,9 +11049,1407 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /cloudidl.execution.ExecutionService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.execution.ExecutionService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterNodepoolService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterNodepoolService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.apikey.APIKeyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.apikey.APIKeyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.AppsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.AppsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.org.OrgService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: grpc
+          - path: /cloudidl.org.OrgService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudaccounts.CloudAccountsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudaccounts.CloudAccountsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: grpc
+          - path: /cloudidl.cluster.ManagedClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ManagedClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.identity.UserService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.UserService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.MemberService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.MemberService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.RoleService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.RoleService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.PolicyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.PolicyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.SelfServe/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.SelfServe
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.clusterpool.ClusterPoolService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterpool.ClusterPoolService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterconfig.ClusterConfigService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterconfig.ClusterConfigService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.authorizer.AuthorizerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: connect
+          - path: /cloudidl.authorizer.AuthorizerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: connect
+          - path: /cloudidl.usage.UsageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+          - path: /cloudidl.usage.UsageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+          - path: /datacatalog.DataCatalog/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: datacatalog
+                port:
+                  name: grpc
+          - path: /datacatalog.DataCatalog
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: datacatalog
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.CacheService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.CacheService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.v2.CacheService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.v2.CacheService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.agent.AgentService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.agent.AgentService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.secret.SecretService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.secret.SecretService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.secret.SecretService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.secret.SecretService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.support.SupportService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.clouddataproxy.CloudDataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.clouddataproxy.CloudDataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.dataproxy.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.dataproxy.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceRegistryService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceRegistryService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TriggerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TriggerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          
+          - path: /flyteidl2.workflow.RunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.RunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.TranslatorService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.TranslatorService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.trigger.TriggerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.trigger.TriggerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.imagebuilder.ImageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.imagebuilder.ImageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.imagebuilder.ImageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.imagebuilder.ImageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppLogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.ReplicaService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppLogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.ReplicaService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /cloudidl.execution.ExecutionService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.execution.ExecutionService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterNodepoolService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterNodepoolService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.apikey.APIKeyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.apikey.APIKeyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.AppsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.AppsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.org.OrgService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: grpc
+          - path: /cloudidl.org.OrgService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudaccounts.CloudAccountsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudaccounts.CloudAccountsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: grpc
+          - path: /cloudidl.cluster.ManagedClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ManagedClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.identity.UserService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.UserService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.MemberService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.MemberService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.RoleService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.RoleService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.PolicyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.PolicyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.SelfServe/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.SelfServe
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.clusterpool.ClusterPoolService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterpool.ClusterPoolService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterconfig.ClusterConfigService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterconfig.ClusterConfigService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.authorizer.AuthorizerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: connect
+          - path: /cloudidl.authorizer.AuthorizerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: connect
+          - path: /cloudidl.usage.UsageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+          - path: /cloudidl.usage.UsageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+          - path: /datacatalog.DataCatalog/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: datacatalog
+                port:
+                  name: grpc
+          - path: /datacatalog.DataCatalog
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: datacatalog
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.CacheService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.CacheService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.v2.CacheService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.v2.CacheService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.agent.AgentService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.agent.AgentService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.secret.SecretService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.secret.SecretService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.secret.SecretService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.secret.SecretService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.support.SupportService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.clouddataproxy.CloudDataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.clouddataproxy.CloudDataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.dataproxy.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.dataproxy.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceRegistryService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceRegistryService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TriggerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TriggerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          
+          - path: /flyteidl2.workflow.RunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.RunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.TranslatorService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.TranslatorService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.trigger.TriggerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.trigger.TriggerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.imagebuilder.ImageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.imagebuilder.ImageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.imagebuilder.ImageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.imagebuilder.ImageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppLogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.ReplicaService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppLogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.ReplicaService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /cloudidl.execution.ExecutionService/*
@@ -10971,9 +13207,641 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /flyteidl2.auth.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.project.ProjectService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.project.ProjectService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AdminService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AdminService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          
+          - path: /flyteidl.service.WatchService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          
+          - path: /flyteidl.service.WatchService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudadmin.CloudAdminService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudadmin.CloudAdminService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.echo.EchoService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.echo.EchoService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService/Stream*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.execution.ExecutionService/GetExecutionOperation
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/Record*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/Update*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.LeaseService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.LeaseService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          
+          - path: /flyteidl2.workflow.RunLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.RunService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService/TailTaskExecutionLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService/WatchWorkspaceInstances
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/Watch
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/Lease
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.ReplicaService/WatchReplicas
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/Watch
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/Lease
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.ReplicaService/WatchReplicas
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /flyteidl2.auth.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.project.ProjectService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.project.ProjectService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AdminService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AdminService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          
+          - path: /flyteidl.service.WatchService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          
+          - path: /flyteidl.service.WatchService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudadmin.CloudAdminService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudadmin.CloudAdminService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.echo.EchoService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.echo.EchoService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService/Stream*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.execution.ExecutionService/GetExecutionOperation
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/Record*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/Update*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.LeaseService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.LeaseService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          
+          - path: /flyteidl2.workflow.RunLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.RunService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService/TailTaskExecutionLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService/WatchWorkspaceInstances
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/Watch
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/Lease
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.ReplicaService/WatchReplicas
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/Watch
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/Lease
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.ReplicaService/WatchReplicas
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /flyteidl2.auth.IdentityService
@@ -11324,9 +14192,345 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          # Port 87 in FlyteAdmin maps to the redoc container.
+          - path: /openapi
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: redoc
+          - path: /healthcheck
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /healthz
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /me
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          # Port 87 in FlyteAdmin maps to the redoc container.
+          - path: /openapi/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: redoc
+          - path: /.well-known
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /.well-known/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /login
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /login/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /logout
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /logout/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /callback
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /callback/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /config
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /config/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /oauth2
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /oauth2/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /auth
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /auth/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /enqueue_metronome_request/v1
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_metronome_request/v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_stripe_request/v1
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_stripe_request/v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+    - host: alt-shared.example.com
+      http:
+        paths:
+          # Port 87 in FlyteAdmin maps to the redoc container.
+          - path: /openapi
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: redoc
+          - path: /healthcheck
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /healthz
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /me
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          # Port 87 in FlyteAdmin maps to the redoc container.
+          - path: /openapi/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: redoc
+          - path: /.well-known
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /.well-known/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /login
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /login/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /logout
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /logout/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /callback
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /callback/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /config
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /config/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /oauth2
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /oauth2/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /auth
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /auth/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /enqueue_metronome_request/v1
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_metronome_request/v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_stripe_request/v1
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_stripe_request/v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+    - host: alt-own-cert.example.com
       http:
         paths:
           # Port 87 in FlyteAdmin maps to the redoc container.
@@ -11532,9 +14736,105 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
+          - path: /flyteidl.service.HealthService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.HealthService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AuthMetadataService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AuthMetadataService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.AuthMetadataService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.AuthMetadataService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+    - host: alt-shared.example.com
+      http:
+        paths:
+          # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
+          - path: /flyteidl.service.HealthService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.HealthService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AuthMetadataService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AuthMetadataService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.AuthMetadataService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.AuthMetadataService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+    - host: alt-own-cert.example.com
       http:
         paths:
           # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
@@ -11618,9 +14918,33 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /flyteidl.service.WatchService/WatchExecutionStatusUpdates
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /flyteidl.service.WatchService/WatchExecutionStatusUpdates
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /flyteidl.service.WatchService/WatchExecutionStatusUpdates
@@ -11672,9 +14996,203 @@ spec:
   tls:
     - hosts:
       - fake-host.domain
+      - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+      - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
   rules:
     - host: fake-host.domain
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
+          - path: /console
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /console/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /dashboard
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /dashboard/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /resources
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /resources/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /cost
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /cost/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /loading
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /loading/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /v2
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unionconsole
+                port:
+                  name: http
+          - path: /v2/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unionconsole
+                port:
+                  name: http
+    - host: alt-shared.example.com
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
+          - path: /console
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /console/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /dashboard
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /dashboard/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /resources
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /resources/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /cost
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /cost/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /loading
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /loading/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /v2
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unionconsole
+                port:
+                  name: http
+          - path: /v2/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unionconsole
+                port:
+                  name: http
+    - host: alt-own-cert.example.com
       http:
         paths:
           - path: /

--- a/tests/values/controlplane.aws.billing-enable.yaml
+++ b/tests/values/controlplane.aws.billing-enable.yaml
@@ -22,6 +22,13 @@ configMap:
     rootTenantURLPattern: dns:///fake-host.domain
 controlplane:
   enabled: true
+ingress:
+  tls:
+    - hosts:
+        - '{{ .Values.global.UNION_HOST }}'
+        - 'controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local'
+      secretName: controlplane-selfsigned-tls-secret
+
 flyte:
   common:
     ingress:

--- a/tests/values/controlplane.aws.yaml
+++ b/tests/values/controlplane.aws.yaml
@@ -24,10 +24,19 @@ controlplane:
   enabled: true
 ingress:
   host: fake-host.domain
+  # extraHosts: alt-shared reuses the primary cert (SAN); alt-own-cert has its
+  # own tls[] entry with a different secret (SNI selection).
+  extraHosts:
+    - alt-shared.example.com
+    - alt-own-cert.example.com
   tls:
     - hosts:
         - fake-host.domain
+        - alt-shared.example.com
       secretName: fake-host-tls-secret
+    - hosts:
+        - alt-own-cert.example.com
+      secretName: alt-own-cert-tls-secret
 flyte:
   common:
     ingress:


### PR DESCRIPTION
## Summary

- Add `ingress.extraHosts` (default `[]`) — appends additional hostnames to every controlplane Ingress and Envoy GRPCRoute/HTTPRoute via a new `controlPlaneLibrary.ingressRules` helper that defines the host+paths plumbing once instead of duplicating it across nine templates.
- Default `ingress.tls` is now `[]` (was hardcoded to `controlplane-selfsigned-tls-secret` — a secret the chart cannot provision). Operators opt in via their env overlay.
- Document the auth coupling: each `extraHosts` entry on an OIDC-protected deployment must also be added to `auth.authorizedUris`, `auth.appAuth.externalAuthServer.allowedAudience`, and the IdP application's redirect URI list. Without these, login on the alias host fails because flyteadmin falls back to its internal service URL as the OAuth `redirect_uri`.
- Expand the `server-alias` annotation comment to make the intra-cluster routing intent explicit, and simplify the bootstrap image documentation to a contract description ("must provide `flyte` + `kubernetes` on PATH").

## Migration (potentially breaking)

Deployments that relied on the chart-default `ingress.tls` will render without a `tls:` block. Set `ingress.tls` explicitly in your env overlay:

```yaml
ingress:
  tls:
    - hosts:
        - '{{ .Values.global.UNION_HOST }}'
        - 'controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local'
      secretName: <your-controlplane-tls-secret>
```

## Why `extraHosts` and not just `server-alias`

- `server-alias` is nginx-only and invisible to cert-manager / external-dns / Envoy.
- For an *external* alias (vanity domain, region cutover) you want a first-class K8s hostname so cert-manager extends the cert SAN and external-dns publishes a record. `extraHosts` provides that across both nginx and Envoy.
- For an *intra-cluster* alias used only to avoid DP→CP hairpinning, `server-alias` stays the right tool — the in-cluster `*.svc.cluster.local` name shares the public host's TLS listener without forcing a SAN entry that a publicly-issued cert can't cover.

## Test plan

- `make generate-expected` + `make test` pass; default render is unchanged when `extraHosts` is empty.
- End-to-end validated on a staging selfmanaged AWS env via the `internal-selfmanaged-staging-sync` pipeline ([build #817](https://buildkite.com/unionai/internal-selfmanaged-staging-sync/builds/817)). Verified: Ingress rules + Envoy hostnames carry both primary and alias hosts; cert-manager reissued the LE cert with the alias SAN; external-dns published the Route53 record; flyteadmin's `authorizedUris` includes the alias so the OAuth `redirect_uri` is built correctly; login flow completes against the alias host.