### PR TITLE
controlplane: extend build-image bootstrap Job with imagePullSecrets, annotations, extra env/volumes

### DIFF
--- a/charts/controlplane/templates/image-builder-bootstrap/job.yaml
+++ b/charts/controlplane/templates/image-builder-bootstrap/job.yaml
@@ -9,6 +9,9 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.imageBuilder.bootstrap.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   backoffLimit: {{ .Values.imageBuilder.bootstrap.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.imageBuilder.bootstrap.ttlSecondsAfterFinished }}
@@ -26,6 +29,10 @@ spec:
     {{- end }}
     spec:
       restartPolicy: {{ .Values.imageBuilder.bootstrap.restartPolicy }}
+      {{- with (include "unionai.imagePullSecrets" (dict "config" .Values.imageBuilder.bootstrap "Values" .Values) | fromYamlArray) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: bootstrap
           image: "{{ tpl .Values.imageBuilder.bootstrap.image.repository . }}:{{ tpl .Values.imageBuilder.bootstrap.image.tag . }}"
@@ -36,6 +43,9 @@ spec:
               value: {{ .Values.imageBuilder.bootstrap.unionImageNamePrefix | quote }}
             - name: FLYTECTL_CONFIG
               value: /etc/flyte/config.yaml
+            {{- with .Values.imageBuilder.bootstrap.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           command:
             - /bin/sh
             - -ec
@@ -61,6 +71,9 @@ spec:
             - name: client-secret
               mountPath: /etc/secrets/union
               readOnly: true
+            {{- with .Values.imageBuilder.bootstrap.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: bootstrap
           configMap:
@@ -81,4 +94,7 @@ spec:
             # chart-wide defaults.secretName convention so per-env overrides
             # of that value flow through automatically.
             secretName: {{ tpl .Values.defaults.secretName . | quote }}
+        {{- with .Values.imageBuilder.bootstrap.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -162,12 +162,54 @@ imageBuilder:
     project: system
     domain: production
 
+    # Annotations on the Job object itself (merged with the chart-managed
+    # helm.sh/hook* annotations). Useful for ArgoCD sync hints
+    # (argocd.argoproj.io/sync-options, argocd.argoproj.io/hook), tooling
+    # that targets Jobs by annotation, or arbitrary metadata.
+    # For pod-template annotations, use `podAnnotations` below.
+    annotations: {}
+
     # Annotations + labels added to the Job's pod template. Useful for
     # service-mesh sidecar control (e.g. linkerd.io/inject: disabled to
     # keep the one-shot Job from getting a sidecar that never exits),
     # Prometheus scrape opt-in/out, cost-attribution labels, etc.
     podAnnotations: {}
     podLabels: {}
+
+    # imagePullSecrets attached to the bootstrap Job's pod. If unset,
+    # falls back to the chart-wide `.Values.imagePullSecrets` — which is
+    # the right default since the bootstrap image lives under the same
+    # `global.IMAGE_REPOSITORY_PREFIX` as the rest of the chart's images.
+    # Override here (e.g. to a different secret, or to `[]` to disable)
+    # only if the bootstrap image is mirrored to a separate registry.
+    # imagePullSecrets: []
+
+    # Extra env vars appended to the bootstrap container's env. The Job
+    # talks to the public flyteadmin ingress over TLS, so the most common
+    # use is to inject corp-proxy / CA-bundle settings in restricted
+    # networks (e.g. HTTPS_PROXY, NO_PROXY, SSL_CERT_FILE pointing at a
+    # CA bundle mounted via extraVolumes).
+    extraEnv: []
+    # extraEnv:
+    #   - name: HTTPS_PROXY
+    #     value: http://proxy.corp.example:3128
+    #   - name: SSL_CERT_FILE
+    #     value: /etc/ssl/corp/ca-bundle.crt
+
+    # Extra volumes + volumeMounts appended to the Job's pod spec and
+    # container respectively. Use this to mount a corp CA bundle, swap
+    # the client-secret source for an alternate Secret, or attach any
+    # other config/data the Job needs at registration time.
+    extraVolumes: []
+    extraVolumeMounts: []
+    # extraVolumes:
+    #   - name: corp-ca
+    #     configMap:
+    #       name: corp-ca-bundle
+    # extraVolumeMounts:
+    #   - name: corp-ca
+    #     mountPath: /etc/ssl/corp
+    #     readOnly: true
 
     # Job-spec tunables. Defaults are conservative for a one-shot
     # post-install hook; override for stricter retry / cleanup policies.

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -163,9 +163,8 @@ imageBuilder:
     domain: production
 
     # Annotations on the Job object itself (merged with the chart-managed
-    # helm.sh/hook* annotations). Useful for ArgoCD sync hints
-    # (argocd.argoproj.io/sync-options, argocd.argoproj.io/hook), tooling
-    # that targets Jobs by annotation, or arbitrary metadata.
+    # helm.sh/hook* annotations). Useful for GitOps controllers, operator
+    # tooling that targets Jobs by annotation, or arbitrary metadata.
     # For pod-template annotations, use `podAnnotations` below.
     annotations: {}
 
@@ -186,29 +185,29 @@ imageBuilder:
 
     # Extra env vars appended to the bootstrap container's env. The Job
     # talks to the public flyteadmin ingress over TLS, so the most common
-    # use is to inject corp-proxy / CA-bundle settings in restricted
-    # networks (e.g. HTTPS_PROXY, NO_PROXY, SSL_CERT_FILE pointing at a
-    # CA bundle mounted via extraVolumes).
+    # use is to inject proxy / CA-bundle settings in restricted networks
+    # (e.g. HTTPS_PROXY, NO_PROXY, SSL_CERT_FILE pointing at a private CA
+    # bundle mounted via extraVolumes).
     extraEnv: []
     # extraEnv:
     #   - name: HTTPS_PROXY
-    #     value: http://proxy.corp.example:3128
+    #     value: http://proxy.internal.example:3128
     #   - name: SSL_CERT_FILE
-    #     value: /etc/ssl/corp/ca-bundle.crt
+    #     value: /etc/ssl/private/ca-bundle.crt
 
     # Extra volumes + volumeMounts appended to the Job's pod spec and
-    # container respectively. Use this to mount a corp CA bundle, swap
+    # container respectively. Use this to mount a private CA bundle, swap
     # the client-secret source for an alternate Secret, or attach any
     # other config/data the Job needs at registration time.
     extraVolumes: []
     extraVolumeMounts: []
     # extraVolumes:
-    #   - name: corp-ca
+    #   - name: private-ca
     #     configMap:
-    #       name: corp-ca-bundle
+    #       name: private-ca-bundle
     # extraVolumeMounts:
-    #   - name: corp-ca
-    #     mountPath: /etc/ssl/corp
+    #   - name: private-ca
+    #     mountPath: /etc/ssl/private
     #     readOnly: true
 
     # Job-spec tunables. Defaults are conservative for a one-shot

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -12148,6 +12148,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: union-registry-secret
       containers:
         - name: bootstrap
           image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.0"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -15657,6 +15657,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: union-registry-secret
       containers:
         - name: bootstrap
           image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.0"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -12152,6 +12152,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: union-registry-secret
       containers:
         - name: bootstrap
           image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.0"

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -12139,6 +12139,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: union-registry-secret
       containers:
         - name: bootstrap
           image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.0"

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -12423,6 +12423,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: union-registry-secret
       containers:
         - name: bootstrap
           image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.0"


### PR DESCRIPTION
## Summary

The post-install build-image bootstrap Job (introduced in #395, repointed at the pre-baked image in #409) needs a few escape hatches to work cleanly in restricted-network and GitOps-driven selfhosted deployments. This PR adds them as opt-in values; defaults preserve current behavior except for one improvement (see below).

New values on `imageBuilder.bootstrap`:

| Key | Behavior |
|---|---|
| `imagePullSecrets` | Attached to the bootstrap pod. **If unset, falls back to the chart-wide `.Values.imagePullSecrets`** — the bootstrap image lives under the same `global.IMAGE_REPOSITORY_PREFIX` as everything else, so inheriting is the right default. Set to `[]` to disable explicitly, or to a different list to override. |
| `annotations` | Merged into the Job's `metadata.annotations` alongside the chart-managed `helm.sh/hook*` annotations. Useful for GitOps sync hints, operator tooling that targets Jobs by annotation, or arbitrary metadata. Pod-template annotations remain on the existing `podAnnotations` key. |
| `extraEnv` | Appended to the bootstrap container's `env`. Primary use: proxy / CA-bundle settings (`HTTPS_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`) so the Job's `flyte` CLI can reach the public flyteadmin ingress over private TLS. |
| `extraVolumes` / `extraVolumeMounts` | Appended to the pod's `volumes` and the container's `volumeMounts`. Most common use: mounting a private CA bundle paired with `SSL_CERT_FILE` in `extraEnv`. |

Custom `command` override deliberately omitted — if the canonical `flyte create project` + `flyte deploy` recipe doesn't fit, `enabled: false` is the escape hatch and the operator owns registration. Surfacing a `command` override would invite silent forks of the recipe that would be hard to debug later.

## Snapshot tests

Regenerated. Only structural delta: every controlplane snapshot now shows `imagePullSecrets: [{name: union-registry-secret}]` on the bootstrap pod (inherited from the chart-wide default). This is a fix — the bootstrap pod previously had no pull secrets, which would have ImagePullBackOff'd in any deployment whose chart-wide registry needs auth.

## Test plan

- [x] `helm template` with defaults → bootstrap pod now picks up the chart-wide `union-registry-secret`; no other diff.
- [x] `helm template` with `imageBuilder.bootstrap.imagePullSecrets: []` → no imagePullSecrets in the rendered pod.
- [x] `helm template` with explicit override → renders the overridden secret list.
- [x] `helm template` with `annotations`, `extraEnv`, `extraVolumes`, `extraVolumeMounts` set → all merged into the expected positions.
- [x] `make generate-expected && make test` → snapshots match.
- [ ] Deploy to a selfhosted environment and confirm the Job pulls + runs cleanly with the chart-wide pull secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)