### PR TITLE
crds/flyte-v1: drop empty `properties:` line (perma OutOfSync fix)

### DIFF
--- a/charts/dataplane/crds/crd-flyteworkflows.yaml
+++ b/charts/dataplane/crds/crd-flyteworkflows.yaml
@@ -26,4 +26,3 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
-          properties:

--- a/crds/flyte-v1/crd-flyteworkflows.yaml
+++ b/crds/flyte-v1/crd-flyteworkflows.yaml
@@ -28,4 +28,3 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
-          properties:


### PR DESCRIPTION
## Summary

Fix CRD-syncing controllers stuck in permanent OutOfSync state. The FlyteWorkflow CRD's schema ended with a trailing `properties:` key with a null value. Kubernetes' openapi schema normalizer drops null `properties` server-side at admission, so on the next reconcile diff-based GitOps tools see:

- Desired (git): `properties: null`
- Live (server): no `properties` key
- → permanent OutOfSync

Reproducible with `kubectl diff` after applying the CRD: the diff is non-empty even though no actual change has occurred.

## Fix

Removed the trailing `properties:` line from `charts/dataplane/crds/crd-flyteworkflows.yaml` (the chart-dir source of truth) and re-ran `make vendor-crds` to propagate the change to `crds/flyte-v1/crd-flyteworkflows.yaml`.

With `x-kubernetes-preserve-unknown-fields: true` already set on `openAPIV3Schema`, dropping the empty `properties:` is semantically a no-op for what the CRD accepts.

## Introduced by

#401 (dataplane: bundle FlyteWorkflow CRD in chart's crds/) added the empty trailing key when the CRD was bundled into the chart.

## Validation

- `make check-vendored-crds` clean (chart-dir + vendored copy match).
- `make helm-test` clean (snapshot regen produced no diff).
- `kubectl diff -f crds/flyte-v1/crd-flyteworkflows.yaml` returns empty after applying once.
