### PR TITLE
pr into runtime/selfhosted/head - init image and new global name

### DIFF
--- a/charts/controlplane/templates/actions/deployment-shard.yaml
+++ b/charts/controlplane/templates/actions/deployment-shard.yaml
@@ -106,7 +106,11 @@ spec:
               mountPath: /etc/config/
         {{- if $isSharded }}
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR

--- a/charts/controlplane/templates/configmap.yaml
+++ b/charts/controlplane/templates/configmap.yaml
@@ -6,7 +6,7 @@
 ---
 {{- $service := dict "config" $serviceConfig "key" $serviceKey "Release" $.Release "Values" $.Values "Chart" $.Chart }}
 {{/* leasor's ConfigMap is built bespoke at templates/leasor/configmap.yaml so
-     queueSync.queues can be auto-generated from global.LEASOR_ATTACHED_CLUSTERS.
+     queueSync.queues can be auto-generated from global.DATAPLANE_CLUSTER_NAME.
      Skip it here to avoid producing two ConfigMaps with the same name. */}}
 {{- if and (not $service.config.disabled) (ne $serviceKey "leasor") }}
 apiVersion: v1

--- a/charts/controlplane/templates/leasor/configmap.yaml
+++ b/charts/controlplane/templates/leasor/configmap.yaml
@@ -4,11 +4,11 @@ Bespoke ConfigMap for leasor. Mirrors what the generic services renderer
 (templates/configmap.yaml) would produce — same name, same labels, same
 unionai.configMap-style merge of global .Values.configMap with
 .Values.services.leasor.configMap — and then auto-generates
-queueSync.queues from .Values.global.LEASOR_ATTACHED_CLUSTERS following the
-self-hosted pattern: one `default` queue containing ALL attached clusters,
-plus one queue per cluster containing only that cluster. The auto-generation
-is skipped if services.leasor.configMap.leasor.queueSync.queues is already
-set explicitly (full override).
+queueSync.queues from .Values.global.DATAPLANE_CLUSTER_NAME: one `default`
+queue + one per-cluster queue, both containing that single cluster name. The
+auto-generation is skipped if services.leasor.configMap.leasor.queueSync.queues
+is already set explicitly (full override — use that to enumerate clusters in
+the rare multi-DP case).
 */ -}}
 {{- $service := dict "config" .Values.services.leasor "key" "leasor" "Release" .Release "Values" .Values "Chart" .Chart -}}
 
@@ -24,16 +24,14 @@ set explicitly (full override).
 {{- $leasor    := index $merged "leasor"    | default dict -}}
 {{- $queueSync := index $leasor "queueSync" | default dict -}}
 {{- $existing  := index $queueSync "queues" | default list -}}
-{{- $clusters  := .Values.global.LEASOR_ATTACHED_CLUSTERS | default list -}}
-{{- if and (eq (len $existing) 0) (gt (len $clusters) 0) -}}
+{{- $cluster   := .Values.global.DATAPLANE_CLUSTER_NAME | default "" -}}
+{{- if and (eq (len $existing) 0) (ne $cluster "") -}}
   {{- $org := .Values.global.UNION_ORG -}}
   {{- $queues := list -}}
-  {{- /* default queue containing all attached clusters */ -}}
-  {{- $queues = append $queues (dict "org" $org "name" "default" "priority" 50 "fairnessAlgorithm" 1 "clusters" $clusters) -}}
-  {{- /* one queue per cluster, containing only that cluster */ -}}
-  {{- range $c := $clusters -}}
-    {{- $queues = append $queues (dict "org" $org "name" $c "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $c)) -}}
-  {{- end -}}
+  {{- /* default queue pointing at the attached cluster */ -}}
+  {{- $queues = append $queues (dict "org" $org "name" "default"  "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $cluster)) -}}
+  {{- /* per-cluster queue with the same name as the cluster */ -}}
+  {{- $queues = append $queues (dict "org" $org "name" $cluster   "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $cluster)) -}}
   {{- $_ := set $queueSync "queues" $queues -}}
   {{- if not (hasKey $queueSync "source") -}}{{- $_ := set $queueSync "source" "static" -}}{{- end -}}
   {{- $_ := set $leasor "queueSync" $queueSync -}}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -19,32 +19,30 @@ global:
   DATAPLANE_HOST: ""        # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
   DATAPLANE_ENDPOINT: ""    # Deprecated alias — falls back to DATAPLANE_HOST when unset.
 
-  # --- Leasor: list of attached dataplane cluster identifiers ---
-  # TEMPORARY. This static list is the ship-today way to tell leasor which
-  # dataplane clusters its queues should target. A future control-plane
-  # queue/cluster CRUD service will own this state and deprecate this knob —
-  # plan to migrate when that lands.
+  # --- Leasor: attached dataplane cluster identifier ---
+  # TEMPORARY. The ship-today way to tell leasor which dataplane cluster its
+  # queues should target. A future control-plane queue/cluster CRUD service
+  # will own this state and deprecate this knob — plan to migrate when that
+  # lands.
   #
-  # Each entry is a cluster identifier — the value the corresponding dataplane
-  # chart install sets in its own global.CLUSTER_NAME, which is what
-  # leaseworker reports on StreamLeases and what leasor matches queues
-  # against. For an intracluster deployment (CP+DP on the same K8s) list a
-  # single entry; for multi-DP deployments list every attached dataplane.
+  # The cluster identifier — same value the corresponding dataplane chart
+  # install sets in its own global.CLUSTER_NAME, which is what leaseworker
+  # reports on StreamLeases and what leasor matches queues against. The
+  # common self-hosted shape is one CP fronting one DP (often intracluster on
+  # the same K8s), so a single string fits. For the rare multi-DP case,
+  # override services.leasor.configMap.leasor.queueSync.queues directly to
+  # enumerate every dataplane.
   #
   # Used to auto-generate services.leasor.configMap.leasor.queueSync.queues
-  # (see comment on that block below). No reasonable default — set explicitly.
+  # (one `default` queue + one per-cluster queue, both containing this name).
+  # No reasonable default — set explicitly.
   #
   # NOT the same as flyte.configmap.clusters.clusterConfigs. That is
-  # flyteadmin's routing registry (name + endpoint + auth per cluster) used by
-  # RandomClusterSelector for v1 execution dispatch; populate that only when
-  # you actually need flyteadmin v1 multi-cluster routing. This list is
-  # leasor-only and just carries names.
-  #
-  # The auto-generated `default` queue lists ALL clusters here, so work fans
-  # out across every attached dataplane. Override
-  # services.leasor.configMap.leasor.queueSync.queues directly if you need a
-  # different policy.
-  LEASOR_ATTACHED_CLUSTERS: []   # e.g. ["my-dp-cluster"] or ["cluster-a", "cluster-b"]
+  # flyteadmin's routing registry (name + endpoint + auth per cluster) used
+  # by RandomClusterSelector for v1 execution dispatch; populate that only
+  # when you actually need flyteadmin v1 multi-cluster routing. This knob is
+  # leasor-only and just carries a name.
+  DATAPLANE_CLUSTER_NAME: ""     # e.g. "my-dp-cluster"
 
   # --- Images ---
   # Customer-facing registry default; internal deployments override to private ECR/GCR.
@@ -1297,9 +1295,9 @@ services:
   # ConfigMap special-cased: leasor's ConfigMap is NOT produced by the generic
   # services renderer. templates/leasor/configmap.yaml builds it instead so
   # that queueSync.queues can be auto-generated from
-  # global.LEASOR_ATTACHED_CLUSTERS (one `default` queue containing all
-  # attached clusters, plus one queue per cluster). To bypass auto-generation
-  # entirely, set configMap.leasor.queueSync.queues below explicitly.
+  # global.DATAPLANE_CLUSTER_NAME (one `default` queue + one per-cluster
+  # queue, both containing that name). To bypass auto-generation entirely,
+  # set configMap.leasor.queueSync.queues below explicitly.
   leasor:
     fullnameOverride: "leasor"
     replicaCount: 1

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -9786,7 +9786,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -9964,7 +9968,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10142,7 +10150,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10320,7 +10332,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10498,7 +10514,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10676,7 +10696,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10854,7 +10878,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11032,7 +11060,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11210,7 +11242,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11388,7 +11424,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -2895,15 +2895,15 @@ data:
       queueSync:
         queues:
         - clusters:
-          - test-cluster
+          - test-cluster-name
           fairnessAlgorithm: 1
           name: default
           org: test-org
           priority: 50
         - clusters:
-          - test-cluster
+          - test-cluster-name
           fairnessAlgorithm: 1
-          name: test-cluster
+          name: test-cluster-name
           org: test-org
           priority: 50
         source: static

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -9801,7 +9801,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -9979,7 +9983,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10157,7 +10165,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10335,7 +10347,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10513,7 +10529,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10691,7 +10711,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10869,7 +10893,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11047,7 +11075,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11225,7 +11257,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11403,7 +11439,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -9804,7 +9804,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -9982,7 +9986,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10160,7 +10168,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10338,7 +10350,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10516,7 +10532,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10694,7 +10714,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10872,7 +10896,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11050,7 +11078,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11228,7 +11260,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11406,7 +11442,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -9791,7 +9791,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -9969,7 +9973,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10147,7 +10155,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10325,7 +10337,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10503,7 +10519,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10681,7 +10701,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10859,7 +10883,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11037,7 +11065,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11215,7 +11247,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11393,7 +11429,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -9932,7 +9932,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10110,7 +10114,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10288,7 +10296,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10466,7 +10478,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10644,7 +10660,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -10822,7 +10842,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11000,7 +11024,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11178,7 +11206,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11356,7 +11388,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR
@@ -11534,7 +11570,11 @@ spec:
             - name: config
               mountPath: /etc/config/
         - name: wait-for-non-peers
-          image: alpine/kubectl:1.32.3
+          # alpine/k8s carries kubectl pinned to the cluster's k8s minor; matches
+          # the dataplane chart's convention (see dataplane/values.yaml). The
+          # internal cloud chart uses alpine/kubectl:latest, but the focused
+          # alpine/kubectl image has no 1.32.3 tag on docker.io.
+          image: alpine/k8s:1.32.3
           command: ["/scripts/wait-for-non-peers.sh"]
           env:
           - name: SHARD_LABEL_SELECTOR

--- a/tests/values/controlplane.aws.yaml
+++ b/tests/values/controlplane.aws.yaml
@@ -4,8 +4,8 @@ global:
   INTERNAL_CLIENT_ID: "test-internal-client-id"
   AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
   # Single attached dataplane — pins the snapshot for leasor's auto-generated
-  # queueSync.queues (default queue with all clusters + one queue per cluster).
-  LEASOR_ATTACHED_CLUSTERS: ["test-cluster"]
+  # queueSync.queues (default queue + per-cluster queue, both for this name).
+  DATAPLANE_CLUSTER_NAME: "test-cluster-name"   # matches dataplane chart's tests/values/dataplane.aws.yaml CLUSTER_NAME
 
 dbHost: "db-instance-url"
 # -- Set the DB Name used for the control plane services


### PR DESCRIPTION
## Summary

Two targeted fixes on top of the cp-actions-leasor squash that landed on `runtime/selfhosted/head`.

## 1. Actions coordination init container image

The `wait-for-non-peers` init container in each actions shard Deployment referenced `alpine/kubectl:1.32.3`. That tag does not exist on `docker.io/alpine/kubectl`, so every actions shard hit `Init:ImagePullBackOff` in the self-cp-runtime test deploy.

Switched to `alpine/k8s:1.32.3` — the image the dataplane chart already pins (`charts/dataplane/values.yaml`), which does have a 1.32.3 tag. `alpine/k8s` carries kubectl plus a few other k8s tools; marginally heavier than the focused `alpine/kubectl` would be, but it matches the rest of this repo's convention and unblocks the init.

The internal cloud chart at `deploy/devops/charts/actions` uses `alpine/kubectl:latest`; the chart-port to helm-charts had pinned the version to the cluster minor without checking that tag exists. This corrects that mistake.

## 2. Rename `global.LEASOR_ATTACHED_CLUSTERS` → `global.DATAPLANE_CLUSTER_NAME`

Per Mike's preference. The new name parallels the dataplane chart's existing `global.CLUSTER_NAME` (which holds the same logical value on the DP side). Self-hosted is overwhelmingly one CP fronting one DP, so a singular string is honest about the common case.

The bespoke `templates/leasor/configmap.yaml` queue auto-gen now reads a single string and synthesizes the same two queues as before: a `default` queue and a per-cluster queue, both pointing at that one name. Multi-DP deployments retain the escape hatch — set `services.leasor.configMap.leasor.queueSync.queues` explicitly to enumerate every cluster verbatim.

The values.yaml comment block continues to flag this as a **temporary** knob that a future control-plane queue/cluster CRUD service will own and deprecate.

