### PR TITLE
dataplane: set proxy smConfig.webhookHostTemplate default

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -537,6 +537,8 @@ config:
       enabled: "{{ .Values.proxy.secretManager.enabled }}"
       # -- The type of secret manager to use.
       type: "{{ .Values.proxy.secretManager.type }}"
+      # -- Template for the union-pod-webhook headless service host used for secret cache invalidation. %s is replaced with the operator pod namespace.
+      webhookHostTemplate: "union-pod-webhook-headless.%s.svc"
       # -- Kubernetes specific secret manager configuration.
       k8sConfig:
         namespace: '{{ include "proxy.secretsNamespace" . }}'

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -3668,6 +3668,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6696,7 +6697,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b980045003d40f62453003dc0a14ec866ceb64c4e7011f9a72f083a292b6ec8"
+        configChecksum: "1157d678b2e98655ec1d2c6f2407ca593e9e9c86a324451b8ed8b82b8c78d25"
         prometheus.io/scrape: "true"
       labels:
         
@@ -6836,7 +6837,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b980045003d40f62453003dc0a14ec866ceb64c4e7011f9a72f083a292b6ec8"
+        configChecksum: "1157d678b2e98655ec1d2c6f2407ca593e9e9c86a324451b8ed8b82b8c78d25"
         prometheus.io/scrape: "true"
       labels:
         

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -3688,6 +3688,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6724,7 +6725,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f74ca4e58d0e2b677cf94001e48a4de2b3b32bff0ec7643187de624f30643c8"
+        configChecksum: "620b756735e4d5760f8f32d88f18a33400f325bdad74b1d6d5bacdbf98e77db"
         
       labels:
         
@@ -6862,7 +6863,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f74ca4e58d0e2b677cf94001e48a4de2b3b32bff0ec7643187de624f30643c8"
+        configChecksum: "620b756735e4d5760f8f32d88f18a33400f325bdad74b1d6d5bacdbf98e77db"
         
       labels:
         

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3868,6 +3868,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -7230,7 +7231,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6aaf41a3d4860ee886d9eedb9f59d0aabe19b9a38878667de0618b45b4a9764"
+        configChecksum: "941ac3030391ec38a88a53820da47a9f7262ccb81aa0092933d353b10fb840c"
         
       labels:
         
@@ -7368,7 +7369,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6aaf41a3d4860ee886d9eedb9f59d0aabe19b9a38878667de0618b45b4a9764"
+        configChecksum: "941ac3030391ec38a88a53820da47a9f7262ccb81aa0092933d353b10fb840c"
         
       labels:
         

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -3668,6 +3668,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6692,7 +6693,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7f73e47ce4f196d1d0a88814bfff727a4cb63932cb5908a929ba9739f8349ab"
+        configChecksum: "4ea4adb763673df9cdeabfe145918b84be17bd12a9eb75d5e14130ad1f500f4"
         
       labels:
         
@@ -6830,7 +6831,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7f73e47ce4f196d1d0a88814bfff727a4cb63932cb5908a929ba9739f8349ab"
+        configChecksum: "4ea4adb763673df9cdeabfe145918b84be17bd12a9eb75d5e14130ad1f500f4"
         
       labels:
         

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -3795,6 +3795,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -7157,7 +7158,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2e8d985d48eacda2c9822bd6a88900a41fb43ee80294f16592bf01372001c98"
+        configChecksum: "17dbd977dbde42dd66908642ad1a50198466c4a173d1a726f843aa14d08e7ee"
         
       labels:
         
@@ -7295,7 +7296,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2e8d985d48eacda2c9822bd6a88900a41fb43ee80294f16592bf01372001c98"
+        configChecksum: "17dbd977dbde42dd66908642ad1a50198466c4a173d1a726f843aa14d08e7ee"
         
       labels:
         

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -3731,6 +3731,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: Azure
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6761,7 +6762,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "10356c042fd97a272d499af80eeb13689a886fb3871f3e05c8cdfe35f641f80"
+        configChecksum: "ec9964966c35e179688dbecaf8d0816b5374a73ca5c3a6ab34024d568557119"
         
       labels:
         
@@ -6900,7 +6901,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "10356c042fd97a272d499af80eeb13689a886fb3871f3e05c8cdfe35f641f80"
+        configChecksum: "ec9964966c35e179688dbecaf8d0816b5374a73ca5c3a6ab34024d568557119"
         
       labels:
         

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -3731,6 +3731,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: Azure
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6761,7 +6762,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e79332dbdbef145d9acb61e6be6426aee14bd89f516a90068559e4c4bd2d145"
+        configChecksum: "6aef562fcd0df8ba1495d7eaa644a8a19095a6fb74a0d6670cadf3dc4f2cb15"
         
       labels:
         
@@ -6900,7 +6901,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e79332dbdbef145d9acb61e6be6426aee14bd89f516a90068559e4c4bd2d145"
+        configChecksum: "6aef562fcd0df8ba1495d7eaa644a8a19095a6fb74a0d6670cadf3dc4f2cb15"
         
       labels:
         

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3813,6 +3813,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6891,7 +6892,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9bc3ae0e7b145390fa5ad3a3b731bd1bb19da3be858bb92a0c6638d1661bcb4"
+        configChecksum: "b517f4455bbbbc86f238c2c791eda20ca8789da8e0d3f3f838db2ea3717cb4f"
         
       labels:
         
@@ -7031,7 +7032,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9bc3ae0e7b145390fa5ad3a3b731bd1bb19da3be858bb92a0c6638d1661bcb4"
+        configChecksum: "b517f4455bbbbc86f238c2c791eda20ca8789da8e0d3f3f838db2ea3717cb4f"
         
       labels:
         

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -3673,6 +3673,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6709,7 +6710,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "620d01a342f32769b036c4e87ecf59cc0a097424b2effc178b3b2c6c9fdb5ef"
+        configChecksum: "ecf186d20e54f2599062fd0637b8ae24a465e46dea9811df942d923a92ad2dc"
         
       labels:
         
@@ -6847,7 +6848,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "620d01a342f32769b036c4e87ecf59cc0a097424b2effc178b3b2c6c9fdb5ef"
+        configChecksum: "ecf186d20e54f2599062fd0637b8ae24a465e46dea9811df942d923a92ad2dc"
         
       labels:
         

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3798,6 +3798,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -7040,7 +7041,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "620d01a342f32769b036c4e87ecf59cc0a097424b2effc178b3b2c6c9fdb5ef"
+        configChecksum: "ecf186d20e54f2599062fd0637b8ae24a465e46dea9811df942d923a92ad2dc"
         
       labels:
         
@@ -7178,7 +7179,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "620d01a342f32769b036c4e87ecf59cc0a097424b2effc178b3b2c6c9fdb5ef"
+        configChecksum: "ecf186d20e54f2599062fd0637b8ae24a465e46dea9811df942d923a92ad2dc"
         
       labels:
         

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -3678,6 +3678,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6694,7 +6695,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "99b48941cc511d7af67111a36a5a5fb8a04b8053f0d71bf0555220e0c37c012"
+        configChecksum: "4b2a5cde203db4a7a77c106f0ffee043eb5d371cb206024a7d5a1d1f233f053"
         
       labels:
         
@@ -6801,7 +6802,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "99b48941cc511d7af67111a36a5a5fb8a04b8053f0d71bf0555220e0c37c012"
+        configChecksum: "4b2a5cde203db4a7a77c106f0ffee043eb5d371cb206024a7d5a1d1f233f053"
         
       labels:
         

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -3677,6 +3677,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6707,7 +6708,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a8e3a9c000d2833b31f3b7675b079c1401fc548ed8f37e9a2bae5172400bc97"
+        configChecksum: "c16e03586e0fc8ed30dd3971d89948cb49abdd643a7aaa9b4ccbeef864e329e"
         
       labels:
         
@@ -6845,7 +6846,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a8e3a9c000d2833b31f3b7675b079c1401fc548ed8f37e9a2bae5172400bc97"
+        configChecksum: "c16e03586e0fc8ed30dd3971d89948cb49abdd643a7aaa9b4ccbeef864e329e"
         
       labels:
         

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -3696,6 +3696,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6732,7 +6733,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7947a621e34ce880215115cd315e8bcca25b35ed042fa74d26c55e2a56ad4ca"
+        configChecksum: "00e90ab85b637fb2e80fe210788120c19151f4ba490bc1f1092248b917813fa"
         
       labels:
         
@@ -6870,7 +6871,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7947a621e34ce880215115cd315e8bcca25b35ed042fa74d26c55e2a56ad4ca"
+        configChecksum: "00e90ab85b637fb2e80fe210788120c19151f4ba490bc1f1092248b917813fa"
         
       labels:
         

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -4501,6 +4501,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -8846,7 +8847,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c948d1ae1d50baadc829905cbe7097c4c38b2ce23d39e36915f8724477b09f6"
+        configChecksum: "8c9627ca797c27fcc7e6b2b93e8a7dce00a63d935358b02427293c563617ce8"
         
       labels:
         
@@ -8984,7 +8985,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c948d1ae1d50baadc829905cbe7097c4c38b2ce23d39e36915f8724477b09f6"
+        configChecksum: "8c9627ca797c27fcc7e6b2b93e8a7dce00a63d935358b02427293c563617ce8"
         
       labels:
         

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -3691,6 +3691,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6859,7 +6860,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "620d01a342f32769b036c4e87ecf59cc0a097424b2effc178b3b2c6c9fdb5ef"
+        configChecksum: "ecf186d20e54f2599062fd0637b8ae24a465e46dea9811df942d923a92ad2dc"
         
       labels:
         
@@ -6997,7 +6998,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "620d01a342f32769b036c4e87ecf59cc0a097424b2effc178b3b2c6c9fdb5ef"
+        configChecksum: "ecf186d20e54f2599062fd0637b8ae24a465e46dea9811df942d923a92ad2dc"
         
       labels:
         

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3711,6 +3711,7 @@ data:
         k8sConfig:
           namespace: 'union'
         type: 'K8s'
+        webhookHostTemplate: union-pod-webhook-headless.%s.svc
   logger.yaml: |
     logger:
       formatter:
@@ -6779,7 +6780,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d722054974dcd88fd8ff7d2633a377c91bb65ac5ec9dc76615ce7552ca29c98"
+        configChecksum: "a0279c2311b5d5f60a345634c7f5a8eeeccc850a9727be765662bc40c14db95"
         
       labels:
         
@@ -6930,7 +6931,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d722054974dcd88fd8ff7d2633a377c91bb65ac5ec9dc76615ce7552ca29c98"
+        configChecksum: "a0279c2311b5d5f60a345634c7f5a8eeeccc850a9727be765662bc40c14db95"
         
       labels:
         


### PR DESCRIPTION
## Overview
Sets the default for the new dataproxy `SecretManagerConfig.WebhookHostTemplate` field (added in unionai/cloud#16293) to `union-pod-webhook-headless.%s.svc`.

The dataproxy secret-manager service uses the webhook headless service to invalidate the secret cache across all webhook replicas. This chart renders the headless webhook service as `union-pod-webhook-headless` (`{{ template "flyte-pod-webhook.name" . }}-headless`), so the template is set accordingly. `%s` is replaced at runtime with the operator pod namespace.

## Test Plan
- Value matches the headless `Service` name produced by `charts/dataplane/templates/webhook/service.yaml`.

## Related
- unionai/cloud#16293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
