### PR TITLE
dataplane: make CP connection TLS-mode flags consistent + drop redundant overlay blocks

### DIFF
--- a/charts/MIGRATION.md
+++ b/charts/MIGRATION.md
@@ -4,6 +4,87 @@ Tracking the migration story for the helm-charts cloud overlays. New entries at 
 
 ---
 
+## dataplane 2026.6.2 — DP→CP connection wiring centralized + TLS-by-default
+
+### What changed
+
+**1. The DP→CP connection wiring moves to a single shared expression.**
+
+A new `charts/dataplane/templates/_connection.tpl` exposes three helpers that all CP-pointed consumers (`config.admin.admin`, `config.catalog.catalog-cache`, `config.union.connection`, `clusterresourcesync.config.union.connection`, task-pod `_U_EP_OVERRIDE`) now reference:
+
+| Helper | Returns |
+|---|---|
+| `dataplane.cp.host` | Bare hostname. Coalesces `global.CONTROLPLANE_HOST` (selfmanaged convention) with `Values.host` (legacy / BYOK convention). |
+| `dataplane.cp.endpoint` | gRPC dial endpoint. Defaults to `dns:///<host>:443`; respects `global.CONTROLPLANE_GRPC_ENDPOINT` override. |
+| `dataplane.cp.queueEndpoint` | Task-pod queue endpoint. Cascades `global.QUEUE_GRPC_ENDPOINT` → `global.CONTROLPLANE_GRPC_ENDPOINT` → default. |
+
+Existing deployments don't need any values change — the helpers coalesce both old and new globals, so `host:` (legacy) and `global.CONTROLPLANE_HOST` (new) both work without modification.
+
+**2. The endpoint string now includes an explicit `:443` port.**
+
+| Before | After |
+|---|---|
+| `dns:///<host>` (no port) | `dns:///<host>:443` |
+
+Functionally equivalent — gRPC's TLS dialer defaults to port 443 when none is given. Anything pointing the DP at a non-443 CP endpoint via `global.CONTROLPLANE_GRPC_ENDPOINT` is unaffected (the override wins).
+
+**3. TLS-by-default on cloud overlays.**
+
+| Field (consumer) | Before | After |
+|---|---|---|
+| `config.admin.admin.insecure` | `true` (cloud overlays) | `false` |
+| `config.admin.admin.insecureSkipVerify` | (commented out, default `false`) | explicit `false` |
+| `config.catalog.catalog-cache.insecure` | `true` (cloud overlays) | `false` |
+| `config.catalog.catalog-cache.insecure-skip-verify` | (absent) | explicit `false` |
+| `config.union.connection.insecureSkipVerify` | (commented out, default `false`) | explicit `false` |
+| `clusterresourcesync.config.union.connection.insecureSkipVerify` | `true` (cloud overlays) | `false` |
+| `_U_INSECURE` (task-pod env var) | `"true"` | `"false"` |
+| `_U_INSECURE_SKIP_VERIFY` (task-pod env var) | `"false"` | `"false"` |
+
+The new out-of-box posture is "TLS with chain verification." Right for managed control planes with valid (publicly-signed or trusted-CA) certs.
+
+### Who needs to act
+
+- **Managed CP, valid cert:** no action. TLS-by-default just works.
+- **BYOK / Union-managed CP, valid cert:** no action. Helpers fall back to `Values.host` (legacy) and the new defaults work.
+- **Self-signed CP cert (most selfmanaged staging environments):** override the four `insecureSkipVerify` consumers AND `_U_INSECURE_SKIP_VERIFY` task-pod env var to `true` at the env-values layer. Without this, every DP→CP call fails TLS chain validation with `x509: certificate signed by unknown authority`.
+- **Plain-HTTP CP (rare):** override `insecure: true` on the affected consumers. The chart no longer ships this as a default for any cloud overlay.
+
+Reference env-values overlay shape for a self-signed-cert deployment:
+
+```yaml
+config:
+  admin:
+    admin:
+      insecureSkipVerify: true
+  catalog:
+    catalog-cache:
+      insecure-skip-verify: true
+  union:
+    connection:
+      insecureSkipVerify: true
+  k8s:
+    plugins:
+      k8s:
+        default-env-vars:
+          - _U_INSECURE_SKIP_VERIFY: "true"
+
+clusterresourcesync:
+  config:
+    union:
+      connection:
+        insecureSkipVerify: true
+```
+
+### Symptoms if you skip the migration
+
+- `union-syncresources` controller crashloops with `failed to fetch auth metadata: ... frame too large, note that the frame header looked like an HTTP/1.1 header` (was: `insecure: true` against TLS port 443).
+- Or, once TLS is reached but the cert isn't trusted: `x509: certificate signed by unknown authority` on every DP→CP call. Set `insecureSkipVerify: true` if the cert is self-signed.
+- Task pods schedule but fail to dial the CP queue with the same TLS errors.
+- Downstream effect: project-domain namespaces (e.g. `development`) are never created in the DP cluster; task scheduling fails with `namespaces "development" not found`.
+
+---
+
 ## 2026.X.Y — Cloud overlay consolidation + canonical host indirection
 
 ### What changed

--- a/charts/dataplane/templates/_connection.tpl
+++ b/charts/dataplane/templates/_connection.tpl
@@ -1,0 +1,40 @@
+{{/*
+Connection helpers for the data-plane → control-plane path.
+
+Single source of truth for the canonical CP endpoint expression and TLS
+posture. Consumers (`config.admin.admin`, `config.catalog.catalog-cache`,
+`config.k8s.plugins.k8s.default-env-vars`, `config.union.connection`,
+`clusterresourcesync.config.union.connection`, etc.) reference these
+helpers so the host, port, and TLS settings stay in sync across the chart.
+
+Override surface (globals declared at the top of values.yaml):
+  CONTROLPLANE_HOST           bare hostname (no scheme, no port) — required
+  CONTROLPLANE_GRPC_ENDPOINT  override the default `dns:///<host>:443`
+  QUEUE_GRPC_ENDPOINT         override the task-pod queue endpoint
+                              (cascades from CONTROLPLANE_GRPC_ENDPOINT)
+*/}}
+
+{{- define "dataplane.cp.host" -}}
+{{- $cp := tpl (default "" .Values.global.CONTROLPLANE_HOST) . -}}
+{{- $legacy := tpl (default "" .Values.host) . -}}
+{{- coalesce $cp $legacy -}}
+{{- end -}}
+
+{{- define "dataplane.cp.endpoint" -}}
+{{- $host := include "dataplane.cp.host" . -}}
+{{- $defaultEp := "" -}}
+{{- if $host -}}{{- $defaultEp = printf "dns:///%s:443" $host -}}{{- end -}}
+{{- default $defaultEp (tpl (default "" .Values.global.CONTROLPLANE_GRPC_ENDPOINT) .) -}}
+{{- end -}}
+
+{{- define "dataplane.cp.queueEndpoint" -}}
+{{- default (include "dataplane.cp.endpoint" .) (tpl (default "" .Values.global.QUEUE_GRPC_ENDPOINT) .) -}}
+{{- end -}}
+
+{{/*
+TLS posture for CP nginx (terminates TLS on 443 regardless of topology;
+selfhosted cert is self-signed). Per-consumer YAML literals — bool field
+spelling varies across config schemas (insecure vs insecure-skip-verify
+vs insecureSkipVerify) and YAML/Go-config bool coercion through helm
+template strings is fragile, so callers write the booleans inline.
+*/}}

--- a/charts/dataplane/values.aws.yaml
+++ b/charts/dataplane/values.aws.yaml
@@ -96,22 +96,9 @@ userRoleAnnotationValue: "{{ tpl .Values.global.WORKER_IAM_ROLE_ARN . }}"
 clusterresourcesync:
   config:
     union:
-      connection:
-        # Control plane gRPC endpoint. Default `dns:///{CONTROLPLANE_HOST}:443`
-        # via CONTROLPLANE_GRPC_ENDPOINT global; override that global to bypass
-        # the nginx ingress.
-        host: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-        # Skip SSL certificate verification for self-signed certs
-        # Set to true for self-signed certificates, false for trusted CA certs
-        insecureSkipVerify: true
-
-      # --- Service-to-service OAuth2 ---
-      # ClusterResourceSync acquires OAuth2 tokens via client_credentials
-      # flow and sends them on outgoing calls to the control plane.
-      # OAuth2 auth for dataplane → controlplane service-to-service calls.
-      # Uses: OAuth App 4 (Operator — confidential client, client_credentials grant).
-      # Flow: Service-to-service (Flow 3).
+      # Service-to-service OAuth2 (client_credentials grant) for outgoing calls
+      # to the control plane. Connection wiring (host, TLS) comes from base
+      # values.yaml via the dataplane.cp.endpoint helper.
       auth:
         enable: true
         type: "ClientSecret"
@@ -125,76 +112,35 @@ clusterresourcesync:
 # ----------------------------------------------------------------------------
 # Core Service Configuration
 # ----------------------------------------------------------------------------
-# Configure dataplane services to communicate with control plane services
-# using Kubernetes internal networking (ClusterIP services).
 
 config:
   sharedService:
     security:
       singleTenantOrgID: '{{ .Values.global.ORG_NAME }}'
 
+  # Selfmanaged auth shape: client_credentials grant; clientId from a global
+  # so the env layer can inject the AUTH_CLIENT_ID without forking the chart.
   admin:
     admin:
-      # Flyteadmin endpoint via CONTROLPLANE_GRPC_ENDPOINT (default
-      # `dns:///{CONTROLPLANE_HOST}:443`). Override the global to bypass nginx.
-      endpoint: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-      # Use insecure (non-TLS) connection for intra-cluster HTTP communication
-      insecure: true
-
-      # OAuth2 client credentials for authenticated admin calls
       clientId: '{{ .Values.global.AUTH_CLIENT_ID }}'
       clientSecretLocation: "/etc/union/secret/client_secret"
 
   catalog:
-    # Catalog service for task caching and reuse
     catalog-cache:
-
-      type: "cacheservicev2"
-
-      # Cacheservice endpoint via CONTROLPLANE_GRPC_ENDPOINT (default
-      # `dns:///{CONTROLPLANE_HOST}:443`).
-      cache-endpoint: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-      endpoint: ""
-
-      # Use insecure connection for intra-cluster communication
-      insecure: true
-
-      # Disable admin authentication (direct service-to-service)
       use-admin-auth: false
 
   k8s:
     plugins:
       k8s:
-        # Environment variables injected into all task pods
         default-env-vars:
-          # Optionally increase the log level for all execution pods for debugging
-          # - LOG_LEVEL: "10"
-
-          # Queue endpoint for task pods. Uses QUEUE_GRPC_ENDPOINT if set, else
-          # falls through to CONTROLPLANE_GRPC_ENDPOINT, else the canonical
-          # `dns:///{CONTROLPLANE_HOST}:443` default. Task pods can't carry OAuth
-          # creds, so this must be an auth-less path (intracluster Service in
-          # `union-cp` on AWS).
-          - _U_EP_OVERRIDE: '{{ default (default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT) .Values.global.QUEUE_GRPC_ENDPOINT }}'
-
-          # Assumed queue service is running with TLS disabled since it's intra-cluster,
-          # we can set the following env vars to skip TLS verification for the queue service.
-          - _U_INSECURE: true
+          - _U_EP_OVERRIDE: '{{ include `dataplane.cp.queueEndpoint` . }}'
+          - _U_INSECURE: false
           - _U_INSECURE_SKIP_VERIFY: false
 
+  # Operator acquires OAuth2 tokens via client_credentials and sends them on
+  # outgoing calls to the control plane. Connection wiring (host, TLS) is in
+  # base values.yaml via the dataplane.cp.endpoint helper.
   union:
-    connection:
-      # Control plane connection for Union services via CONTROLPLANE_GRPC_ENDPOINT
-      # (default `dns:///{CONTROLPLANE_HOST}:443`).
-      host: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-      # Skip SSL verification for self-signed certificates
-      insecureSkipVerify: true
-
-    # --- Service-to-service OAuth2 ---
-    # Operator acquires OAuth2 tokens via client_credentials
-    # flow and sends them on outgoing calls to the control plane.
     auth:
       enable: true
       type: "ClientSecret"

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -110,19 +110,9 @@ userRoleAnnotationValue: "{{ tpl .Values.global.WORKER_IAM_ROLE_ARN . }}"
 clusterresourcesync:
   config:
     union:
-      connection:
-        # Control plane gRPC endpoint. Default `dns:///{CONTROLPLANE_HOST}:443`
-        # via CONTROLPLANE_GRPC_ENDPOINT global; override that global to bypass
-        # the nginx ingress.
-        host: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-        # Skip SSL certificate verification for self-signed certs
-        # Set to true for self-signed certificates, false for trusted CA certs
-        insecureSkipVerify: true
-
-      # --- Service-to-service OAuth2 ---
-      # ClusterResourceSync acquires OAuth2 tokens via client_credentials
-      # flow and sends them on outgoing calls to the control plane.
+      # Service-to-service OAuth2 (client_credentials grant) for outgoing calls
+      # to the control plane. Connection wiring (host, TLS) comes from base
+      # values.yaml via the dataplane.cp.endpoint helper.
       auth:
         enable: true
         type: "ClientSecret"
@@ -148,65 +138,29 @@ config:
   core:
     propeller:
       rawoutput-prefix: "gs://{{ .Values.global.METADATA_BUCKET }}"
+  # Selfmanaged auth shape: client_credentials grant; clientId from a global
+  # so the env layer can inject the AUTH_CLIENT_ID without forking the chart.
   admin:
     admin:
-      # Flyteadmin endpoint via CONTROLPLANE_GRPC_ENDPOINT (default
-      # `dns:///{CONTROLPLANE_HOST}:443`). Override the global to bypass nginx.
-      endpoint: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-      # Use insecure (non-TLS) connection for intra-cluster HTTP communication
-      insecure: true
-
-      # OAuth2 client credentials for authenticated admin calls
       clientId: '{{ .Values.global.AUTH_CLIENT_ID }}'
       clientSecretLocation: "/etc/union/secret/client_secret"
 
   catalog:
-    # Catalog service for task caching and reuse
     catalog-cache:
-
-      type: "cacheservicev2"
-
-      # Cacheservice endpoint via CONTROLPLANE_GRPC_ENDPOINT (default
-      # `dns:///{CONTROLPLANE_HOST}:443`).
-      cache-endpoint: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-      endpoint: ""
-
-      # Use insecure connection for intra-cluster communication
-      insecure: true
-
-      # Disable admin authentication (direct service-to-service)
       use-admin-auth: false
 
   k8s:
     plugins:
       k8s:
-        # Environment variables injected into all task pods
         default-env-vars:
-          # Optionally increase the log level for all execution pods for debugging
-          # - LOG_LEVEL: "10"
-
-          # Queue endpoint for task pods via CONTROLPLANE_GRPC_ENDPOINT
-          # (default `dns:///{CONTROLPLANE_HOST}:443`).
-          - _U_EP_OVERRIDE: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-          # Assumed queue service is running with TLS disabled since it's intra-cluster,
-          # we can set the following env vars to skip TLS verification for the queue service.
-          - _U_INSECURE: true
+          - _U_EP_OVERRIDE: '{{ include `dataplane.cp.queueEndpoint` . }}'
+          - _U_INSECURE: false
           - _U_INSECURE_SKIP_VERIFY: false
 
+  # Operator acquires OAuth2 tokens via client_credentials and sends them on
+  # outgoing calls to the control plane. Connection wiring (host, TLS) is in
+  # base values.yaml via the dataplane.cp.endpoint helper.
   union:
-    connection:
-      # Control plane connection for Union services via CONTROLPLANE_GRPC_ENDPOINT
-      # (default `dns:///{CONTROLPLANE_HOST}:443`).
-      host: '{{ default (printf `dns:///%s:443` .Values.global.CONTROLPLANE_HOST) .Values.global.CONTROLPLANE_GRPC_ENDPOINT }}'
-
-      # Skip SSL verification for self-signed certificates
-      insecureSkipVerify: true
-
-    # --- Service-to-service OAuth2 ---
-    # Operator acquires OAuth2 tokens via client_credentials
-    # flow and sends them on outgoing calls to the control plane.
     auth:
       enable: true
       type: "ClientSecret"

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -197,14 +197,14 @@ clusterresourcesync:
       connection:
         # This is the defacto configuration for Union managed control planes.
         # -- Host to connect to
-        host: 'dns:///{{ tpl .Values.host . }}'
+        host: '{{ include "dataplane.cp.endpoint" . }}'
 
         # -- Whether to connect over insecure channel
         # insecure: false
 
         # -- InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
         # Caution: shouldn't be used for production use cases
-        # insecureSkipVerify: false
+        insecureSkipVerify: false
 
         # -- Minimum timeout for establishing a connection
         # minConnectTimeout: "10s"
@@ -322,19 +322,21 @@ config:
       rate: 500
       capacity: 1000
     admin:
-      endpoint: 'dns:///{{ tpl .Values.host . }}'
+      endpoint: '{{ include "dataplane.cp.endpoint" . }}'
       clientId: '{{ tpl .Values.secrets.admin.clientId . }}'
       clientSecretLocation: /etc/union/secret/client_secret
       insecure: false
+      insecureSkipVerify: false
   authorizer:
     type: noop
   # -- Catalog Client configuration [structure](https://pkg.go.dev/github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/catalog#Config)
   # Additional advanced Catalog configuration [here](https://pkg.go.dev/github.com/lyft/flyteplugins/go/tasks/pluginmachinery/catalog#Config)
   catalog:
     catalog-cache:
-      cache-endpoint: 'dns:///{{ tpl .Values.host . }}'
-      endpoint: 'dns:///{{ tpl .Values.host . }}'
+      cache-endpoint: '{{ include "dataplane.cp.endpoint" . }}'
+      endpoint: '{{ include "dataplane.cp.endpoint" . }}'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
   # -- Optional catalog cache configuration, rendered as catalog_cache.yaml for propeller.
@@ -607,14 +609,14 @@ config:
     connection:
       # This is the defacto configuration for Union managed control planes.
       # -- Host to connect to
-      host: 'dns:///{{ tpl .Values.host . }}'
+      host: '{{ include "dataplane.cp.endpoint" . }}'
 
       # -- Whether to connect over insecure channel
       # insecure: false
 
       # -- InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
       # Caution: shouldn't be used for production use cases
-      # insecureSkipVerify: false
+      insecureSkipVerify: false
 
       # -- Minimum timeout for establishing a connection
       # minConnectTimeout: "10s"

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -957,7 +957,8 @@ data:
       workerName: 'union-union-test-worker1'
     union:
       connection:
-        host: dns:///union.test.union.ai
+        host: 'dns:///union.test.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client'
@@ -967,14 +968,16 @@ data:
     admin:
       clientId: 'test-client'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.test.union.ai
+      endpoint: 'dns:///union.test.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.test.union.ai
-      endpoint: dns:///union.test.union.ai
+      cache-endpoint: 'dns:///union.test.union.ai:443'
+      endpoint: 'dns:///union.test.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3501,7 +3504,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///union.test.union.ai
+        host: 'dns:///union.test.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client'
@@ -3511,14 +3515,16 @@ data:
     admin:
       clientId: 'test-client'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.test.union.ai
+      endpoint: 'dns:///union.test.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.test.union.ai
-      endpoint: dns:///union.test.union.ai
+      cache-endpoint: 'dns:///union.test.union.ai:443'
+      endpoint: 'dns:///union.test.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3597,7 +3603,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///union.test.union.ai
+        host: 'dns:///union.test.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client'
@@ -6485,7 +6492,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af272c18c1a153f0dcd324411037c474b2bdea432d0e90c15685ae9af5d6328"
+        configChecksum: "0ba7ab67a1403db48d53b94beef26c078754729f52e265bb214090baef06585"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6589,7 +6596,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d5154bc26a2b8e52a22a16821031e24a380e12a15429af3c00ec1d91eae26ed"
+        configChecksum: "1b39fb93998c0b23888f4517108e47e52cea269726cdbba0bc5717c9dcdc8c4"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6698,7 +6705,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "08a8ba717cf14da4beba0cf69759a43ce98dd3495759da3cba9b90665aca86c"
+        configChecksum: "516fe541fcbb3d28b5696daefdb717f0962444840b1e55b06d3ab68453f2cd1"
         prometheus.io/scrape: "true"
       labels:
         
@@ -6838,7 +6845,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "08a8ba717cf14da4beba0cf69759a43ce98dd3495759da3cba9b90665aca86c"
+        configChecksum: "516fe541fcbb3d28b5696daefdb717f0962444840b1e55b06d3ab68453f2cd1"
         prometheus.io/scrape: "true"
       labels:
         
@@ -6968,7 +6975,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "af272c18c1a153f0dcd324411037c474b2bdea432d0e90c15685ae9af5d6328"
+        configChecksum: "0ba7ab67a1403db48d53b94beef26c078754729f52e265bb214090baef06585"
         prometheus.io/scrape: "true"
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -963,7 +963,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -973,14 +974,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.example.com
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.example.com
-      endpoint: dns:///test.example.com
+      cache-endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3515,7 +3518,8 @@ data:
       template: '{{ project }}-{{ domain }}'
     union:
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -3525,14 +3529,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.example.com
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.example.com
-      endpoint: dns:///test.example.com
+      cache-endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3617,7 +3623,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -6517,7 +6524,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6786767ed6b68eb16461a8f9c454943aa9c04b301fdbdc419f4f3fb493d7f9f"
+        configChecksum: "c22e2f3449522a2d4893f7ce5999a9f2ce3c1e86627128d7dbc2c93bea08c31"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6619,7 +6626,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f84e128b0db9de6636d6239fdc94e10ca8ec03dfe7ebde09097673b80ca385a"
+        configChecksum: "9e8740b6d5d93fb4460794ada878ff477d6fdc8f193c9b1faf3fbd15ad728f6"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6726,7 +6733,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7eeeb04104d44aa730c69ea9908953daba774ef7ae9d1c2bfd6a3d28fd73a92"
+        configChecksum: "6dd8d635cd40626140baaba3c0117acf5d32195e2aa0d5a644f74b4c04cb916"
         
       labels:
         
@@ -6864,7 +6871,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7eeeb04104d44aa730c69ea9908953daba774ef7ae9d1c2bfd6a3d28fd73a92"
+        configChecksum: "6dd8d635cd40626140baaba3c0117acf5d32195e2aa0d5a644f74b4c04cb916"
         
       labels:
         
@@ -6990,7 +6997,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "6786767ed6b68eb16461a8f9c454943aa9c04b301fdbdc419f4f3fb493d7f9f"
+        configChecksum: "c22e2f3449522a2d4893f7ce5999a9f2ce3c1e86627128d7dbc2c93bea08c31"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -1082,7 +1082,8 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: dns:///test-controlplane-host
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -1092,14 +1093,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test-controlplane-host
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test-controlplane-host
-      endpoint: dns:///test-controlplane-host
+      cache-endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3651,7 +3654,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///test-controlplane-host
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -3661,14 +3665,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test-controlplane-host
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test-controlplane-host
-      endpoint: dns:///test-controlplane-host
+      cache-endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3797,7 +3803,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///test-controlplane-host
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -7023,7 +7030,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a5757435ca6a577d1148deba1b4d649e24e6d1913c7606a9a30ee15e1254b25"
+        configChecksum: "da31fb5e109cebaeadce0827ef8b4662bc6dee68bca16c18cb7f55547b6e9a7"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7125,7 +7132,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8eb2b32d034fb0f8963dcdcb4544781f80d59220bd79e6f6b9d9beee2a9f3fb"
+        configChecksum: "7e6d9cf29217331900d6f98451f30c124cf499ec32a6b87574c1dde9b71b1c2"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7232,7 +7239,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "26e1820754d65726ad6ff0a74ec9b18201a7c1f2a5e95be651148bea1774b4d"
+        configChecksum: "3941617ca74250edd86d02dbd6447e327be0d4f61a82b08f75861b25cf9506b"
         
       labels:
         
@@ -7370,7 +7377,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "26e1820754d65726ad6ff0a74ec9b18201a7c1f2a5e95be651148bea1774b4d"
+        configChecksum: "3941617ca74250edd86d02dbd6447e327be0d4f61a82b08f75861b25cf9506b"
         
       labels:
         
@@ -7496,7 +7503,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "a5757435ca6a577d1148deba1b4d649e24e6d1913c7606a9a30ee15e1254b25"
+        configChecksum: "da31fb5e109cebaeadce0827ef8b4662bc6dee68bca16c18cb7f55547b6e9a7"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -957,7 +957,8 @@ data:
       workerName: 'union-union-aws-worker1'
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'clientId'
@@ -967,14 +968,16 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.us-west-2.union.ai
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.us-west-2.union.ai
-      endpoint: dns:///union.us-west-2.union.ai
+      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3501,7 +3504,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'clientId'
@@ -3511,14 +3515,16 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.us-west-2.union.ai
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.us-west-2.union.ai
-      endpoint: dns:///union.us-west-2.union.ai
+      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3597,7 +3603,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'clientId'
@@ -6485,7 +6492,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ec73d9f11bba62b6e4ea10f683590e6f2f813920c99093a62fb392d812bbdc2"
+        configChecksum: "6b7211a3e329c4e684c9d8df2a847cb0a47cfdb7b1eb5d49b1d63520da63b98"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6587,7 +6594,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6dae4c4d3fa72268a682f8c18bb4d25980489f85ce450122568726253e508b7"
+        configChecksum: "b61813f362282352a4b57d43849e26df7203c4522cd1c152dc9efd56cb06b0f"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6694,7 +6701,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2de2cb519a62cdd5f9591cf7f2e84071ef07c612ad29446ea9a6c178084d4bc"
+        configChecksum: "06cf9d1b20978c370914244002f11232b1598e249daf3831a3a23e943487105"
         
       labels:
         
@@ -6832,7 +6839,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2de2cb519a62cdd5f9591cf7f2e84071ef07c612ad29446ea9a6c178084d4bc"
+        configChecksum: "06cf9d1b20978c370914244002f11232b1598e249daf3831a3a23e943487105"
         
       labels:
         
@@ -6958,7 +6965,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ec73d9f11bba62b6e4ea10f683590e6f2f813920c99093a62fb392d812bbdc2"
+        configChecksum: "6b7211a3e329c4e684c9d8df2a847cb0a47cfdb7b1eb5d49b1d63520da63b98"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -1082,7 +1082,8 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: dns:///test-controlplane-host
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -1092,14 +1093,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test-controlplane-host
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test-controlplane-host
-      endpoint: dns:///test-controlplane-host
+      cache-endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3628,7 +3631,8 @@ data:
       template: '{{ project }}-{{ domain }}'
     union:
       connection:
-        host: dns:///test-controlplane-host
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -3638,14 +3642,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test-controlplane-host
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test-controlplane-host
-      endpoint: dns:///test-controlplane-host
+      cache-endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3724,7 +3730,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///test-controlplane-host
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -6950,7 +6957,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bf4ecc122bd58c01b1e2809d0563676393a101449d7f88733ea786cef5f2318"
+        configChecksum: "aebd1aea627f4cfc8d8daae413a931dc7180448d7810cf21fccfd0091a5ae50"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7052,7 +7059,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5b4caae6721fc6eb2d30673d2acc929faf173a7de2681af42f781abbe227452"
+        configChecksum: "4ea12e0a3053fe57c2acc3b022bca7eddd7f09758a25073131cd507345ad434"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7159,7 +7166,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "73a169892da5222023469a865e48389fc7ffdf18b7d2ea4d50b96b93caaff17"
+        configChecksum: "af7aa0c43db278ce52f48fa1f424f8cb3fcf13b98f31436c37e425758b85230"
         
       labels:
         
@@ -7297,7 +7304,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "73a169892da5222023469a865e48389fc7ffdf18b7d2ea4d50b96b93caaff17"
+        configChecksum: "af7aa0c43db278ce52f48fa1f424f8cb3fcf13b98f31436c37e425758b85230"
         
       labels:
         
@@ -7423,7 +7430,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "bf4ecc122bd58c01b1e2809d0563676393a101449d7f88733ea786cef5f2318"
+        configChecksum: "aebd1aea627f4cfc8d8daae413a931dc7180448d7810cf21fccfd0091a5ae50"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -2955,8 +2955,8 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: 'dns:///:443'
-        insecureSkipVerify: true
+        host: 'dns:///override.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: ''
@@ -2967,14 +2967,16 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///:443'
-      insecure: true
+      endpoint: 'dns:///override.example.com:443'
+      insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: 'dns:///:443'
-      endpoint: ""
-      insecure: true
+      cache-endpoint: 'dns:///override.example.com:443'
+      endpoint: 'dns:///override.example.com:443'
+      insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: false
     logger:
@@ -3011,8 +3013,8 @@ data:
           start-timeout: 30s
         default-cpus: 100m
         default-env-vars:
-        - _U_EP_OVERRIDE: dns:///:443
-        - _U_INSECURE: "true"
+        - _U_EP_OVERRIDE: dns:///override.example.com:443
+        - _U_INSECURE: "false"
         - _U_INSECURE_SKIP_VERIFY: "false"
         default-memory: 100Mi
         default-pod-template-name: task-template
@@ -5504,8 +5506,8 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///:443'
-        insecureSkipVerify: true
+        host: 'dns:///override.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: ''
@@ -5516,14 +5518,16 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///:443'
-      insecure: true
+      endpoint: 'dns:///override.example.com:443'
+      insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: 'dns:///:443'
-      endpoint: ""
-      insecure: true
+      cache-endpoint: 'dns:///override.example.com:443'
+      endpoint: 'dns:///override.example.com:443'
+      insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: false
     logger:
@@ -5561,8 +5565,8 @@ data:
         disable-inject-owner-references: true
         default-cpus: 100m
         default-env-vars:
-        - _U_EP_OVERRIDE: dns:///:443
-        - _U_INSECURE: "true"
+        - _U_EP_OVERRIDE: dns:///override.example.com:443
+        - _U_INSECURE: "false"
         - _U_INSECURE_SKIP_VERIFY: "false"
         default-memory: 100Mi
         default-pod-template-name: task-template
@@ -5600,16 +5604,16 @@ data:
       k8s:
         default-cpus: 100m
         default-env-vars:
-        - _U_EP_OVERRIDE: dns:///:443
-        - _U_INSECURE: "true"
+        - _U_EP_OVERRIDE: dns:///override.example.com:443
+        - _U_INSECURE: "false"
         - _U_INSECURE_SKIP_VERIFY: "false"
         default-memory: 100Mi
         default-pod-template-name: task-template
   config.yaml: |
     union:
       connection:
-        host: 'dns:///:443'
-        insecureSkipVerify: true
+        host: 'dns:///override.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: ''
@@ -8338,7 +8342,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c79d916c19b4cbd1f6cbdc5b7f0f308eb445e11f8c6c47c20213204b47b4bbe"
+        configChecksum: "45204f68fce2b927b143a343157f0e777caeadf8d1b250dca6283f3b8fff9e9"
         
       labels:
         
@@ -9457,7 +9461,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7eadedfb04049866d849e9189b3dbddd40b68501bfe8c0ebdad23aeeead677d"
+        configChecksum: "dec2a7d3a2fb3f621cb421a9951d6bafbc9aac65ad9d3301da0d77addb17c75"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9559,7 +9563,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d15ecbdba6a4877da09775ddf06098b23e8db453c9f16b36929cb901e9587d8"
+        configChecksum: "7a112992af05aa6b13d1e3c7fda27241e6c387446bc7fb3029a046388660805"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9666,7 +9670,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c79d916c19b4cbd1f6cbdc5b7f0f308eb445e11f8c6c47c20213204b47b4bbe"
+        configChecksum: "45204f68fce2b927b143a343157f0e777caeadf8d1b250dca6283f3b8fff9e9"
         
       labels:
         
@@ -9778,7 +9782,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c79d916c19b4cbd1f6cbdc5b7f0f308eb445e11f8c6c47c20213204b47b4bbe"
+        configChecksum: "45204f68fce2b927b143a343157f0e777caeadf8d1b250dca6283f3b8fff9e9"
         
       labels:
         
@@ -9904,7 +9908,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "7eadedfb04049866d849e9189b3dbddd40b68501bfe8c0ebdad23aeeead677d"
+        configChecksum: "dec2a7d3a2fb3f621cb421a9951d6bafbc9aac65ad9d3301da0d77addb17c75"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -2955,8 +2955,8 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: 'dns:///:443'
-        insecureSkipVerify: true
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: ''
@@ -2967,14 +2967,16 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///:443'
-      insecure: true
+      endpoint: 'dns:///test-controlplane-host:443'
+      insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: 'dns:///:443'
-      endpoint: ""
-      insecure: true
+      cache-endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host:443'
+      insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: false
     logger:
@@ -3011,8 +3013,8 @@ data:
           start-timeout: 30s
         default-cpus: 100m
         default-env-vars:
-        - _U_EP_OVERRIDE: dns:///:443
-        - _U_INSECURE: "true"
+        - _U_EP_OVERRIDE: dns:///test-controlplane-host:443
+        - _U_INSECURE: "false"
         - _U_INSECURE_SKIP_VERIFY: "false"
         default-memory: 100Mi
         default-pod-template-name: task-template
@@ -5504,8 +5506,8 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///:443'
-        insecureSkipVerify: true
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: ''
@@ -5516,14 +5518,16 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///:443'
-      insecure: true
+      endpoint: 'dns:///test-controlplane-host:443'
+      insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: 'dns:///:443'
-      endpoint: ""
-      insecure: true
+      cache-endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host:443'
+      insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: false
     logger:
@@ -5561,8 +5565,8 @@ data:
         disable-inject-owner-references: true
         default-cpus: 100m
         default-env-vars:
-        - _U_EP_OVERRIDE: dns:///:443
-        - _U_INSECURE: "true"
+        - _U_EP_OVERRIDE: dns:///test-controlplane-host:443
+        - _U_INSECURE: "false"
         - _U_INSECURE_SKIP_VERIFY: "false"
         default-memory: 100Mi
         default-pod-template-name: task-template
@@ -5600,16 +5604,16 @@ data:
       k8s:
         default-cpus: 100m
         default-env-vars:
-        - _U_EP_OVERRIDE: dns:///:443
-        - _U_INSECURE: "true"
+        - _U_EP_OVERRIDE: dns:///test-controlplane-host:443
+        - _U_INSECURE: "false"
         - _U_INSECURE_SKIP_VERIFY: "false"
         default-memory: 100Mi
         default-pod-template-name: task-template
   config.yaml: |
     union:
       connection:
-        host: 'dns:///:443'
-        insecureSkipVerify: true
+        host: 'dns:///test-controlplane-host:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: ''
@@ -8338,7 +8342,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "00cce549f31bddecb11546269a916b80f3106abd7a9440547218331b802272c"
+        configChecksum: "8158d6109b9c6d5a567b7bcb23bce8c4b9f13c3b62d08bfa9787e78f59d4b9d"
         
       labels:
         
@@ -9457,7 +9461,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7eadedfb04049866d849e9189b3dbddd40b68501bfe8c0ebdad23aeeead677d"
+        configChecksum: "0c888f23fe950ef9033f56b3b9fa9e4672477e115dbc83635d23a2b5ff2ebdf"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9559,7 +9563,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d15ecbdba6a4877da09775ddf06098b23e8db453c9f16b36929cb901e9587d8"
+        configChecksum: "348ba68c65e9f876384eab40742abe3522e1fc794bde7eecd8ad8bba59b944b"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9666,7 +9670,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "00cce549f31bddecb11546269a916b80f3106abd7a9440547218331b802272c"
+        configChecksum: "8158d6109b9c6d5a567b7bcb23bce8c4b9f13c3b62d08bfa9787e78f59d4b9d"
         
       labels:
         
@@ -9778,7 +9782,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "00cce549f31bddecb11546269a916b80f3106abd7a9440547218331b802272c"
+        configChecksum: "8158d6109b9c6d5a567b7bcb23bce8c4b9f13c3b62d08bfa9787e78f59d4b9d"
         
       labels:
         
@@ -9904,7 +9908,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "7eadedfb04049866d849e9189b3dbddd40b68501bfe8c0ebdad23aeeead677d"
+        configChecksum: "0c888f23fe950ef9033f56b3b9fa9e4672477e115dbc83635d23a2b5ff2ebdf"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -951,7 +951,8 @@ data:
       workerName: 'test-org-test-azure-cluster-worker1'
     union:
       connection:
-        host: dns:///test.dataplane.union.ai
+        host: 'dns:///test.dataplane.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -961,14 +962,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.dataplane.union.ai
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.dataplane.union.ai
-      endpoint: dns:///test.dataplane.union.ai
+      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3513,7 +3516,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///test.dataplane.union.ai
+        host: 'dns:///test.dataplane.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -3523,14 +3527,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.dataplane.union.ai
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.dataplane.union.ai
-      endpoint: dns:///test.dataplane.union.ai
+      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3645,7 +3651,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///test.dataplane.union.ai
+        host: 'dns:///test.dataplane.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -6552,7 +6559,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "121b705e5cf160da729a97b084800de8fcfaeaf8e46b63680099d5f25bbc685"
+        configChecksum: "cf44e0b13bbe3c43aa690d730d5a5868914ec16cb51b7acbf96eb79fe8c4428"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6655,7 +6662,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1fda2c79bb8d0fd2311d527f35a4e24d37b94822a3711895e9bc13e41169df7"
+        configChecksum: "4df6ac90b645d25eb996888199717417b2bd50aa650ad60772d0932644e0bab"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6763,7 +6770,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "43a96fbcc3eb63c921f253f6863f08a14f35930c78d9147adcd74ba29309ca6"
+        configChecksum: "3b6a983e64283df9c62c62fbed88d6fc752385557f1ac6a629b5efff3a80ebe"
         
       labels:
         
@@ -6902,7 +6909,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "43a96fbcc3eb63c921f253f6863f08a14f35930c78d9147adcd74ba29309ca6"
+        configChecksum: "3b6a983e64283df9c62c62fbed88d6fc752385557f1ac6a629b5efff3a80ebe"
         
       labels:
         
@@ -7030,7 +7037,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "121b705e5cf160da729a97b084800de8fcfaeaf8e46b63680099d5f25bbc685"
+        configChecksum: "cf44e0b13bbe3c43aa690d730d5a5868914ec16cb51b7acbf96eb79fe8c4428"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -951,7 +951,8 @@ data:
       workerName: 'test-org-test-azure-cluster-worker1'
     union:
       connection:
-        host: dns:///test.dataplane.union.ai
+        host: 'dns:///test.dataplane.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -961,14 +962,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.dataplane.union.ai
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.dataplane.union.ai
-      endpoint: dns:///test.dataplane.union.ai
+      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3513,7 +3516,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///test.dataplane.union.ai
+        host: 'dns:///test.dataplane.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -3523,14 +3527,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.dataplane.union.ai
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.dataplane.union.ai
-      endpoint: dns:///test.dataplane.union.ai
+      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3645,7 +3651,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///test.dataplane.union.ai
+        host: 'dns:///test.dataplane.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -6552,7 +6559,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1fded592f76ddae2960465556fbf53d51a788a09a9658186c217b3d611c4382"
+        configChecksum: "aa0bf43732e6d5a7cd70c466b22336f440c73dc22f7095a5f6a635f444bafd6"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6655,7 +6662,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "43c19f26de413b1c595d602a570f523cd7f73e26397a9baeb19033c4b1651df"
+        configChecksum: "a0b08b345594910ed0e9f9eb146f2dc97f14628702c17504bbf495e9d5b3f97"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6763,7 +6770,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cc5f2fada852ac741756daf72cc5c8513299140be5aedda2240e44933fc16a1"
+        configChecksum: "4a9eeb80b68b74257be64e154225f2f7f1d57739c484c6a1bc5c3fc36043b35"
         
       labels:
         
@@ -6902,7 +6909,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cc5f2fada852ac741756daf72cc5c8513299140be5aedda2240e44933fc16a1"
+        configChecksum: "4a9eeb80b68b74257be64e154225f2f7f1d57739c484c6a1bc5c3fc36043b35"
         
       labels:
         
@@ -7030,7 +7037,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "1fded592f76ddae2960465556fbf53d51a788a09a9658186c217b3d611c4382"
+        configChecksum: "aa0bf43732e6d5a7cd70c466b22336f440c73dc22f7095a5f6a635f444bafd6"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -816,13 +816,15 @@ data:
         tokenRefreshWindow: 5m
         type: ClientSecret
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
   admin.yaml: | 
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.example.com
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecureSkipVerify: false
     event:
       capacity: 1000
       rate: 500
@@ -1097,7 +1099,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -1107,14 +1110,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.example.com
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.example.com
-      endpoint: dns:///test.example.com
+      cache-endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3645,7 +3650,8 @@ data:
           memory: 2Ti
     union:
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -3655,14 +3661,16 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///test.example.com
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///test.example.com
-      endpoint: dns:///test.example.com
+      cache-endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3746,7 +3754,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///test.example.com
+        host: 'dns:///test.example.com:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test-client-id'
@@ -6405,7 +6414,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5dcd8c9d0f08e816197b552cda78697564d40e317810ce47fa3aa101a8a76eb"
+        configChecksum: "9ebf5780fa114cf13a39338732478321b2babfeef6124ba702f98abce32d705"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6684,7 +6693,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "59b1ef29e2ed9038bde29b9ffc3ed91cdbc637b24bf4e1c369f12d1754eee41"
+        configChecksum: "28ae043abe3c7e1079e09329cd63b313a2699d11ed0ca2130b0a06084aa0ce3"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6786,7 +6795,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ffadede1e72538f580970d26d129d3798f07f8b68798834b5ca2d58406e1b54"
+        configChecksum: "83a28f5804d226d78f9c85d37bb15afc92eab8aa20cee93b8609ac1786ac6d1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6893,7 +6902,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "884e8e2e6dc4176621dfc8aad38e5744024fb294e74f5b9ba73853fcee02aa1"
+        configChecksum: "b621e66170dc216ed30e79c6b6153688468a109bc786b11a9ca339dc297c09b"
         
       labels:
         
@@ -7033,7 +7042,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "884e8e2e6dc4176621dfc8aad38e5744024fb294e74f5b9ba73853fcee02aa1"
+        configChecksum: "b621e66170dc216ed30e79c6b6153688468a109bc786b11a9ca339dc297c09b"
         
       labels:
         
@@ -7159,7 +7168,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "59b1ef29e2ed9038bde29b9ffc3ed91cdbc637b24bf4e1c369f12d1754eee41"
+        configChecksum: "28ae043abe3c7e1079e09329cd63b313a2699d11ed0ca2130b0a06084aa0ce3"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -950,7 +950,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -960,14 +961,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3500,7 +3503,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -3510,14 +3514,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3602,7 +3608,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -6502,7 +6509,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ad8008098a5dfe09cea3612433ce65a56dfa7c9578f9d9e00a1a4b96beb525c"
+        configChecksum: "2cd0191484968c6334342e63bc5381287dedf2a5e23f1adf5f261ab79865275"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6604,7 +6611,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "841817ea8873e0592d093d9f564f22eb6a316a7cac8d611afc2582a4856dc7a"
+        configChecksum: "8655b854deda3dd76ce6a90e79a506077dbf2c133972104f938471dcf72f1e4"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6711,7 +6718,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "70d232f97aa6849d037211f53515916c1298d1b4a3e11b48c24591da3578e2d"
+        configChecksum: "7aefffca06e7204bad497d71acbeca6042cc041374048693859b1282221cf07"
         
       labels:
         
@@ -6849,7 +6856,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "70d232f97aa6849d037211f53515916c1298d1b4a3e11b48c24591da3578e2d"
+        configChecksum: "7aefffca06e7204bad497d71acbeca6042cc041374048693859b1282221cf07"
         
       labels:
         
@@ -6975,7 +6982,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ad8008098a5dfe09cea3612433ce65a56dfa7c9578f9d9e00a1a4b96beb525c"
+        configChecksum: "2cd0191484968c6334342e63bc5381287dedf2a5e23f1adf5f261ab79865275"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -1075,7 +1075,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -1085,14 +1086,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3625,7 +3628,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -3635,14 +3639,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3727,7 +3733,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -6833,7 +6840,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ad8008098a5dfe09cea3612433ce65a56dfa7c9578f9d9e00a1a4b96beb525c"
+        configChecksum: "2cd0191484968c6334342e63bc5381287dedf2a5e23f1adf5f261ab79865275"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6935,7 +6942,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "841817ea8873e0592d093d9f564f22eb6a316a7cac8d611afc2582a4856dc7a"
+        configChecksum: "8655b854deda3dd76ce6a90e79a506077dbf2c133972104f938471dcf72f1e4"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7042,7 +7049,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "70d232f97aa6849d037211f53515916c1298d1b4a3e11b48c24591da3578e2d"
+        configChecksum: "7aefffca06e7204bad497d71acbeca6042cc041374048693859b1282221cf07"
         
       labels:
         
@@ -7180,7 +7187,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "70d232f97aa6849d037211f53515916c1298d1b4a3e11b48c24591da3578e2d"
+        configChecksum: "7aefffca06e7204bad497d71acbeca6042cc041374048693859b1282221cf07"
         
       labels:
         
@@ -7306,7 +7313,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ad8008098a5dfe09cea3612433ce65a56dfa7c9578f9d9e00a1a4b96beb525c"
+        configChecksum: "2cd0191484968c6334342e63bc5381287dedf2a5e23f1adf5f261ab79865275"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -950,7 +950,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -961,14 +962,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3503,7 +3506,8 @@ data:
       template: '{{ project }}-{{ domain }}'
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -3514,14 +3518,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3606,7 +3612,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -6507,7 +6514,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a380fc8714a422a969a7b149bd27274b66784ab708512c3b29bfe08ec6a487c"
+        configChecksum: "80fde9479c4cb0b14265219baef89d73c3a7c45c83831563c0758253e41d3cc"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6599,7 +6606,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "22ca0f09911140e21d1d5702aed040eaf20f690b624ea6311bda41c4cd3266e"
+        configChecksum: "ab719197934a1ba9e76ee5777d46bbc8cde882c11a1fa80367373eac44b5721"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6696,7 +6703,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d6d641773afdaef5c967e83c4a30d4c71990c375cd3511a38a06332801ab593"
+        configChecksum: "b5ec65fbb10da0ee7d0b45cd38cb97f54ef9f1fbcde200235c3746c912e78ab"
         
       labels:
         
@@ -6803,7 +6810,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d6d641773afdaef5c967e83c4a30d4c71990c375cd3511a38a06332801ab593"
+        configChecksum: "b5ec65fbb10da0ee7d0b45cd38cb97f54ef9f1fbcde200235c3746c912e78ab"
         
       labels:
         
@@ -6924,7 +6931,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "a380fc8714a422a969a7b149bd27274b66784ab708512c3b29bfe08ec6a487c"
+        configChecksum: "80fde9479c4cb0b14265219baef89d73c3a7c45c83831563c0758253e41d3cc"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -960,7 +960,8 @@ data:
       workerName: 'byok-test-e2e-gcp-worker1'
     union:
       connection:
-        host: dns:///byok.us-west-2.union.ai
+        host: 'dns:///byok.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'byok-test-e2e-gcp-operator'
@@ -970,14 +971,16 @@ data:
     admin:
       clientId: 'byok-test-e2e-gcp-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///byok.us-west-2.union.ai
+      endpoint: 'dns:///byok.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///byok.us-west-2.union.ai
-      endpoint: dns:///byok.us-west-2.union.ai
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3507,7 +3510,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///byok.us-west-2.union.ai
+        host: 'dns:///byok.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'byok-test-e2e-gcp-operator'
@@ -3517,14 +3521,16 @@ data:
     admin:
       clientId: 'byok-test-e2e-gcp-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///byok.us-west-2.union.ai
+      endpoint: 'dns:///byok.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///byok.us-west-2.union.ai
-      endpoint: dns:///byok.us-west-2.union.ai
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3606,7 +3612,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///byok.us-west-2.union.ai
+        host: 'dns:///byok.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'byok-test-e2e-gcp-operator'
@@ -6500,7 +6507,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1d54475bf3e05f0fe1d70428930bd79333be05ed352cba53aada9fed6be39e8"
+        configChecksum: "e025f5d4a52b54a6720db405c369ee87862dd15639a7ada03e0ba2e2d6d5af1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6602,7 +6609,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cdc54eefe9995eb3d202a14f0bd36b5ec1cd7efa44d0be966cfcf30d938b64a"
+        configChecksum: "853ec47dc33f5ea966ca07248c68e5fffa132a5ec4bc62425bea48ad38b0a03"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6709,7 +6716,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e8004b1fc28bece8b93dcf0be0bd99c79c190eba76ba690bbe18dd33a501a9e"
+        configChecksum: "9183963bb2ce976b0859e384acc0ca0869e4f569d47e90480665a56be41442a"
         
       labels:
         
@@ -6847,7 +6854,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e8004b1fc28bece8b93dcf0be0bd99c79c190eba76ba690bbe18dd33a501a9e"
+        configChecksum: "9183963bb2ce976b0859e384acc0ca0869e4f569d47e90480665a56be41442a"
         
       labels:
         
@@ -6973,7 +6980,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "1d54475bf3e05f0fe1d70428930bd79333be05ed352cba53aada9fed6be39e8"
+        configChecksum: "e025f5d4a52b54a6720db405c369ee87862dd15639a7ada03e0ba2e2d6d5af1"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -964,7 +964,8 @@ data:
       workerName: 'union-my-cluster-worker1'
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'my-client-id'
@@ -974,14 +975,16 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.us-west-2.union.ai
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.us-west-2.union.ai
-      endpoint: dns:///union.us-west-2.union.ai
+      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3517,7 +3520,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'my-client-id'
@@ -3527,14 +3531,16 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.us-west-2.union.ai
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.us-west-2.union.ai
-      endpoint: dns:///union.us-west-2.union.ai
+      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3625,7 +3631,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'my-client-id'
@@ -6525,7 +6532,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cac35852716c33ace4d2aaf9a87702a5a08928dae39bc3f464a012e085095d0"
+        configChecksum: "83e5c16ffa05cde6b649f09a98113e9bd0ed94b7ccf15c766e30699f405f200"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6627,7 +6634,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f9987502f74cfc6192b29b3552077e9918321ae31d7d03f536759d9b9ef60e4"
+        configChecksum: "44257b4bad74284d978ebcf836cf48a61968f6450d3c0caeb83bc0c4b136fbe"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6734,7 +6741,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d0f99b05e65659432855764a03bacb5f9dd9f7f80979975f3ea3d221eb3cdd0"
+        configChecksum: "dae5900d56a1d9906b15b52a2b6b825ba59c33fdd298e0a0d7c9af44e16582e"
         
       labels:
         
@@ -6872,7 +6879,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d0f99b05e65659432855764a03bacb5f9dd9f7f80979975f3ea3d221eb3cdd0"
+        configChecksum: "dae5900d56a1d9906b15b52a2b6b825ba59c33fdd298e0a0d7c9af44e16582e"
         
       labels:
         
@@ -6998,7 +7005,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "cac35852716c33ace4d2aaf9a87702a5a08928dae39bc3f464a012e085095d0"
+        configChecksum: "83e5c16ffa05cde6b649f09a98113e9bd0ed94b7ccf15c766e30699f405f200"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -1778,7 +1778,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test'
@@ -1788,14 +1789,16 @@ data:
     admin:
       clientId: 'test'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -4328,7 +4331,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test'
@@ -4338,14 +4342,16 @@ data:
     admin:
       clientId: 'test'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -4430,7 +4436,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'test'
@@ -8639,7 +8646,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "456790078fe33865ec080b94c91fdecdcc28194a3baead56ca553d28a69828e"
+        configChecksum: "46d028058a8f3acd72e8b3374504b3e6631206f8495912b7e67aa03dd09cc69"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -8741,7 +8748,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "de0693f00d848b309738a692ce47b9db0d1896df0ddddc1391ca9f50a3f4c5a"
+        configChecksum: "d4b346179fdb01e7c67d236d76c9c95cfbd8514e65f49825dd8532283e5b4e3"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -8848,7 +8855,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5f296a49e96286a4ee35609ccf6531018a65f593c2d1ce26b9c48d6f93a8b0d"
+        configChecksum: "31f8ba39eb3add08df83294b304634ccc039f0a1bdefbbf0c3bc488c449f440"
         
       labels:
         
@@ -8986,7 +8993,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5f296a49e96286a4ee35609ccf6531018a65f593c2d1ce26b9c48d6f93a8b0d"
+        configChecksum: "31f8ba39eb3add08df83294b304634ccc039f0a1bdefbbf0c3bc488c449f440"
         
       labels:
         
@@ -9112,7 +9119,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "456790078fe33865ec080b94c91fdecdcc28194a3baead56ca553d28a69828e"
+        configChecksum: "46d028058a8f3acd72e8b3374504b3e6631206f8495912b7e67aa03dd09cc69"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -957,7 +957,8 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -967,14 +968,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3507,7 +3510,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -3517,14 +3521,16 @@ data:
     admin:
       clientId: 'dataplane-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///
+      endpoint: 'dns:///:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///
-      endpoint: dns:///
+      cache-endpoint: 'dns:///:443'
+      endpoint: 'dns:///:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3620,7 +3626,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///
+        host: 'dns:///:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'dataplane-operator'
@@ -6652,7 +6659,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ad8008098a5dfe09cea3612433ce65a56dfa7c9578f9d9e00a1a4b96beb525c"
+        configChecksum: "2cd0191484968c6334342e63bc5381287dedf2a5e23f1adf5f261ab79865275"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6754,7 +6761,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "841817ea8873e0592d093d9f564f22eb6a316a7cac8d611afc2582a4856dc7a"
+        configChecksum: "8655b854deda3dd76ce6a90e79a506077dbf2c133972104f938471dcf72f1e4"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6861,7 +6868,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "70d232f97aa6849d037211f53515916c1298d1b4a3e11b48c24591da3578e2d"
+        configChecksum: "7aefffca06e7204bad497d71acbeca6042cc041374048693859b1282221cf07"
         
       labels:
         
@@ -6999,7 +7006,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "70d232f97aa6849d037211f53515916c1298d1b4a3e11b48c24591da3578e2d"
+        configChecksum: "7aefffca06e7204bad497d71acbeca6042cc041374048693859b1282221cf07"
         
       labels:
         
@@ -7125,7 +7132,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ad8008098a5dfe09cea3612433ce65a56dfa7c9578f9d9e00a1a4b96beb525c"
+        configChecksum: "2cd0191484968c6334342e63bc5381287dedf2a5e23f1adf5f261ab79865275"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -964,7 +964,8 @@ data:
       workerName: 'union-union-oci-worker1'
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'clientId'
@@ -974,14 +975,16 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.us-west-2.union.ai
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.us-west-2.union.ai
-      endpoint: dns:///union.us-west-2.union.ai
+      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3522,7 +3525,8 @@ data:
       template: union
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'clientId'
@@ -3532,14 +3536,16 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: dns:///union.us-west-2.union.ai
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecureSkipVerify: false
     authorizer:
       type: noop
     catalog-cache:
-      cache-endpoint: dns:///union.us-west-2.union.ai
-      endpoint: dns:///union.us-west-2.union.ai
+      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai:443'
       insecure: false
+      insecure-skip-verify: false
       type: cacheservicev2
       use-admin-auth: true
     logger:
@@ -3640,7 +3646,8 @@ data:
   config.yaml: |
     union:
       connection:
-        host: dns:///union.us-west-2.union.ai
+        host: 'dns:///union.us-west-2.union.ai:443'
+        insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
         clientId: 'clientId'
@@ -6546,7 +6553,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5edf37a23cd2954f47b023a27f207b6651bd19622dd7dfef183c649f3c24bbe"
+        configChecksum: "cd74240e0dce26f41defe58c5dee0e0f0108f58c635638c7f6bd0cc70947a5e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6661,7 +6668,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ab417e9c80ea8e0680ba7733a11f4fd2cc2edc0ec72da30177b267fcec1da54"
+        configChecksum: "8856874b107ad8c8b6fa15d5c72fcdcd58f44b87329f0a72bde52d7e3a53352"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6781,7 +6788,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3f70327f97dfc27ce55a8dc6bd3b1199107198549bf50d9e3ca63ca50fc4661"
+        configChecksum: "17eccec6798cd4856b965a9313ac145ab04e853e5f18cc259c151f030ad291a"
         
       labels:
         
@@ -6932,7 +6939,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3f70327f97dfc27ce55a8dc6bd3b1199107198549bf50d9e3ca63ca50fc4661"
+        configChecksum: "17eccec6798cd4856b965a9313ac145ab04e853e5f18cc259c151f030ad291a"
         
       labels:
         
@@ -7071,7 +7078,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "5edf37a23cd2954f47b023a27f207b6651bd19622dd7dfef183c649f3c24bbe"
+        configChecksum: "cd74240e0dce26f41defe58c5dee0e0f0108f58c635638c7f6bd0cc70947a5e"
         
     spec:
       securityContext:


### PR DESCRIPTION
## Summary

Make the TLS-mode flags (`insecure`, `insecureSkipVerify`, `_U_INSECURE`, `_U_INSECURE_SKIP_VERIFY`) consistent across the four DP→CP connection consumers and flip the default to TLS-on. Drop redundant connection blocks from the cloud overlays since they were just restating values that already exist in base `values.yaml`.

## Why

Five places in the chart wire DP→CP gRPC connections:

| Consumer                                              | File            | TLS flag pair                            |
| ----------------------------------------------------- | --------------- | ---------------------------------------- |
| `config.admin.admin`                                  | base + overlays | `insecure`, `insecureSkipVerify`         |
| `config.catalog.catalog-cache`                        | base + overlays | `insecure`, `insecure-skip-verify`       |
| `config.union.connection`                             | base + overlays | `insecure`, `insecureSkipVerify`         |
| `clusterresourcesync.config.union.connection`         | base + overlays | `insecure`, `insecureSkipVerify`         |
| `config.k8s.plugins.k8s.default-env-vars` (task pods) | overlays only   | `_U_INSECURE`, `_U_INSECURE_SKIP_VERIFY` |

Base `values.yaml` had `insecure: false`. The AWS + GCP overlays restated each connection block with `insecure: true` (commented "intra-cluster HTTP"). The task-pod env vars set `_U_INSECURE: true`. The four control-plane defaults disagreed with each other and the task-pod env-var pair disagreed within itself (`_U_INSECURE: true, _U_INSECURE_SKIP_VERIFY: false` is nonsense — skipVerify only matters with TLS on).

That mismatch is the load-bearing bug. After cloud #16265 made the canonical DP→CP path `dns:///{CONTROLPLANE_HOST}:443` (TLS-terminating nginx on :443), `insecure: true` cleanly produces:

```
rpc error: code = Unavailable desc = connection error: desc =
"error reading server preface: http2: failed reading the frame payload:
http2: frame too large, note that the frame header looked like an HTTP/1.1 header"
```

That's `union-syncresources` (and any other consumer using the operator-side connection block) sending plain HTTP/2 to a TLS endpoint.

## Changes

1. **Flip defaults**: every consumer now has `insecure: false` + `insecureSkipVerify: false`. Task-pod env vars: `_U_INSECURE: false` + `_U_INSECURE_SKIP_VERIFY: false`. Self-signed-cert envs override `insecureSkipVerify: true` at the env layer (the companion cloud terraform PR #16340 injects this automatically for selfmanaged envs).
2. **Drop redundant overlay blocks**: `values.aws.yaml` and `values.gcp.yaml` had `config.admin.admin`, `config.catalog.catalog-cache`, `config.union.connection`, and `clusterresourcesync.config.union.connection` blocks that re-declared the same `host` expression already in `values.yaml`. Remove those redundant copies; cloud overlays keep only cloud-specific bits (auth client id, catalog `use-admin-auth`, task-pod env vars).
3. **Helper**: `charts/dataplane/templates/_connection.tpl` defines `dataplane.cp.host`/`dataplane.cp.endpoint`/`dataplane.cp.queueEndpoint`. The host expression that was duplicated inline (`dns:///{ tpl .Values.host . }` etc.) is now one helper call. Coalesces a new `global.CONTROLPLANE_HOST` with legacy `Values.host` so existing managed deployments keep working with no change.
4. **MIGRATION.md** entry under `dataplane 2026.6.2`.

## Migration

| Audience                             | Action                                                                                                                       |
| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
| Managed CP (Union-hosted)            | None                                                                                                                         |
| BYOK                                 | None — `Values.host` legacy path still resolves through the helper                                                           |
| Selfmanaged with self-signed CP cert | Cloud terraform PR #16340 injects `insecureSkipVerify: true` automatically. Re-apply `union_extension` to regen values.yaml. |
| Selfmanaged with valid CP cert       | None                                                                                                                         |

## Test plan

- `make generate-expected` + `make test` snapshot tests — green
- Co-deployed with cloud #16340 on `mike-apple-gcp` (multi-cluster GCP) and `mike-apple-aws` (intracluster AWS). `union-syncresources` reconciles project-domain namespaces: `Successfully completed cluster resource creation loop`.
- Buildkite `internal-selfmanaged-staging-sync` #863 — V2 functional tests green: <https://buildkite.com/unionai/internal-selfmanaged-staging-sync/builds/863>

Version bump deferred to the next release cut.

- `main` <!-- branch-stack -->
  - **dataplane: make CP connection TLS-mode flags consistent + drop redundant overlay blocks** :point\_left:
    - \#431
