### PR TITLE
chore: drop personal lineage + perennial entries from team git-town config

### DIFF
--- a/.git-branches.toml
+++ b/.git-branches.toml
@@ -3,11 +3,9 @@ ship-strategy = "api"
 
 [branches]
 main = "main"
-perennials = ["mike/monitoring-testing-wip"]
+perennials = []
 
 [hosting]
 platform = "github"
 
 [lineage]
-"mike/prometheus-refactor" = "main"
-"mike/controlplane-monitoring" = "mike/prometheus-refactor"


### PR DESCRIPTION
## Summary

`.git-branches.toml` is the team-shared git-town config. Today it carries entries that only mean something to one contributor's working branches:

```toml
perennials = ["mike/monitoring-testing-wip"]

[lineage]
"mike/prometheus-refactor" = "main"
"mike/controlplane-monitoring" = "mike/prometheus-refactor"
```

Those refs don't exist for anyone else and just clutter the shared config. Personal lineage + perennial bookkeeping belongs in each contributor's local `.git/config` (which `git town set-parent` and `git config git-town.perennial-branches` write to).

## Changes

- `perennials = []`
- `[lineage]` empty

## Test plan

- `git town config` still parses; lineage shows whatever's set in local `.git/config` per contributor.
- No effect on CI, builds, or any chart output.