### PR TITLE
dataplane: unified top-level secrets block (eagerApiKey, eagerClientCreds, imageBuilder.{push,pull}, admin)

### DIFF
--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1546,6 +1546,22 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
+{{/* FAB-241 file-mount: when eagerClientCreds is enabled, switch the webhook
+to inject the ConfigMap + Secret as volume mounts instead of env vars for
+matching SecurityContext.Secrets entries. Pre-check is wired by mirrorcheck
+inside flyte. Single customer-facing flag (secrets.eagerClientCreds.enabled)
+auto-derives the entire file-mount path. */}}
+{{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $_ := set $webhook "fileMount" (dict
+    "enabled" true
+    "secretKeyMatch" "EAGER_API_KEY"
+    "configMapName" (include "secrets.eagerOAuthConfig.configMapName" .)
+    "secretName" (include "secrets.eagerClientCreds.secretName" .)
+    "configMapMountPath" (.Values.mirroring.eagerOAuth.configMapMountPath | default "/etc/flyte/config.yaml")
+    "secretMountPath" (.Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret")
+    "managedByLabelValue" (.Values.mirroring.managedByLabelValue | default "union-operator")
+) }}
+{{- end }}
 {{- if include "singleNamespace" . }}
 propeller:
   limit-namespace: {{ .Release.Namespace }}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1546,20 +1546,59 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
-{{/* FAB-241 file-mount: when eagerClientCreds is enabled, switch the webhook
-to inject the ConfigMap + Secret as volume mounts instead of env vars for
-matching SecurityContext.Secrets entries. Pre-check is wired by mirrorcheck
-inside flyte. Single customer-facing flag (secrets.eagerClientCreds.enabled)
-auto-derives the entire file-mount path. */}}
+{{/* FAB-241 file-mount: list-of-corev1-Volume/VolumeMount pairs the
+flytepropeller webhook injects onto matching task pods. Two unconditional
+entries (config.yaml ConfigMap + client_secret Secret) plus a conditional
+ca.crt Secret when secrets.internalCaCert is enabled. Mirror-presence in
+the target NS (managedByLabelValue) is what gates injection at admission
+time; no magic Flyte-secret-key string. */}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $mounts := list
+    (dict
+      "volume" (dict
+        "name" "union-eager-auth-config"
+        "configMap" (dict "name" (include "secrets.eagerOAuthConfig.configMapName" .))
+      )
+      "volumeMount" (dict
+        "name" "union-eager-auth-config"
+        "mountPath" "/etc/flyte/config.yaml"
+        "subPath" "config.yaml"
+        "readOnly" true
+      )
+    )
+    (dict
+      "volume" (dict
+        "name" "union-eager-client-secret"
+        "secret" (dict "secretName" (include "secrets.eagerClientCreds.secretName" .))
+      )
+      "volumeMount" (dict
+        "name" "union-eager-client-secret"
+        "mountPath" "/etc/flyte/credentials/client_secret"
+        "subPath" "client_secret"
+        "readOnly" true
+      )
+    )
+}}
+{{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
+{{- $mounts = append $mounts
+    (dict
+      "volume" (dict
+        "name" "union-internal-ca"
+        "secret" (dict "secretName" (include "secrets.internalCaCert.secretName" .))
+      )
+      "volumeMount" (dict
+        "name" "union-internal-ca"
+        "mountPath" "/etc/flyte/credentials/ca.crt"
+        "subPath" "ca.crt"
+        "readOnly" true
+      )
+    )
+}}
+{{- end }}
 {{- $_ := set $webhook "fileMount" (dict
     "enabled" true
-    "secretKeyMatch" "EAGER_API_KEY"
-    "configMapName" (include "secrets.eagerOAuthConfig.configMapName" .)
-    "secretName" (include "secrets.eagerClientCreds.secretName" .)
-    "configMapMountPath" (.Values.mirroring.eagerOAuth.configMapMountPath | default "/etc/flyte/config.yaml")
-    "secretMountPath" (.Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret")
     "managedByLabelValue" (.Values.mirroring.managedByLabelValue | default "union-operator")
+    "mounts" $mounts
 ) }}
 {{- end }}
 {{- if include "singleNamespace" . }}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -783,6 +783,16 @@ plugins:
       {{ include "var.FLYTE_AWS_ACCESS_KEY_ID" . | indent 6 }}
       {{ include "var.FLYTE_AWS_SECRET_ACCESS_KEY" . | indent 6 }}
       {{- end }}
+      {{- /*
+           When the file-mount path is on, the SDK config + creds live at
+           /etc/flyte/config.yaml on the task pod (mounted by the webhook from
+           the eager-oauth-config ConfigMap). Point the SDK at it via the
+           standard FLYTECTL_CONFIG env var so init_in_cluster()'s
+           resolve_config_path() picks it up.
+      */}}
+      {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+      - FLYTECTL_CONFIG: "/etc/flyte/config.yaml"
+      {{- end }}
       {{- range $k, $v := .Values.additionalPodEnvVars }}
       - {{ $k }}: {{ $v | quote }}
       {{- end }}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -954,7 +954,7 @@ Global pod environment variables
       resource: limits.cpu
 - name: CLUSTER_NAME
   valueFrom:
-    secretKeyRef:
+    configMapKeyRef:
       name: operator-cluster-name
       key: cluster_name
 - name: DEPLOYMENT_NAME

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -1,0 +1,189 @@
+{{/*
+Unified secrets helpers.
+
+Each managed secret follows the same shape under `.Values.secrets.<name>`:
+
+  enabled: bool
+  existingSecret:
+    name: ""
+    key: ""            # single-key secrets only — defaults to the canonical key
+  value: ""            # inline value for single-key secrets
+  # (multi-key secrets carry their inline fields at the top level — see eagerClientCreds, admin)
+
+State machine (single- and multi-key alike):
+
+  enabled: false                                  → render nothing; consumers must not reference
+  enabled: true  + existingSecret.name set        → skip chart-managed Secret; consumers reference external by name
+  enabled: true  + inline value(s) set            → chart creates `{{ .Release.Name }}-<logical>`; consumers reference it
+  enabled: true  + existingSecret.name + inline   → fail (ambiguous)
+  enabled: true  + neither                        → fail (must provide one)
+
+Consumer pattern for single-key:
+
+  {{- $ref := include "secrets.eagerApiKey.secretRef" . | fromYaml }}
+  - name: EAGER_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ $ref.name }}
+        key:  {{ $ref.key }}
+
+Consumer pattern for multi-key (eagerClientCreds, admin):
+
+  {{- $name := include "secrets.eagerClientCreds.secretName" . }}
+  - name: UNION_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ $name }}
+        key:  {{ include "secrets.eagerClientCreds.clientIdKey" . }}
+*/}}
+
+{{/*
+secrets.eagerApiKey
+*/}}
+
+{{- define "secrets.eagerApiKey.canonicalKey" -}}EAGER_API_KEY{{- end -}}
+
+{{- define "secrets.eagerApiKey.computedName" -}}{{ .Release.Name }}-eager-api-key{{- end -}}
+
+{{- define "secrets.eagerApiKey.enabled" -}}
+{{- $s := .Values.secrets.eagerApiKey -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerApiKey.validate" -}}
+{{- $s := .Values.secrets.eagerApiKey -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := $s.value -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.eagerApiKey: set either existingSecret.name OR value, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.eagerApiKey.enabled=true requires existingSecret.name or value" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerApiKey.secretRef" -}}
+{{- include "secrets.eagerApiKey.validate" . -}}
+{{- $s := .Values.secrets.eagerApiKey -}}
+{{- $defaultKey := include "secrets.eagerApiKey.canonicalKey" . -}}
+{{- if $s.existingSecret.name -}}
+name: {{ $s.existingSecret.name }}
+key: {{ default $defaultKey $s.existingSecret.key }}
+{{- else -}}
+name: {{ include "secrets.eagerApiKey.computedName" . }}
+key: {{ $defaultKey }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+secrets.eagerClientCreds — multi-key (client_id + client_secret)
+*/}}
+
+{{- define "secrets.eagerClientCreds.clientIdCanonical" -}}client_id{{- end -}}
+{{- define "secrets.eagerClientCreds.clientSecretCanonical" -}}client_secret{{- end -}}
+
+{{- define "secrets.eagerClientCreds.computedName" -}}{{ .Release.Name }}-eager-client-creds{{- end -}}
+
+{{- define "secrets.eagerClientCreds.enabled" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.validate" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := or $s.clientId $s.clientSecret -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.eagerClientCreds: set either existingSecret.name OR clientId/clientSecret, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.eagerClientCreds.enabled=true requires existingSecret.name or clientId+clientSecret" -}}
+  {{- end -}}
+  {{- if and $hasInline (or (not $s.clientId) (not $s.clientSecret)) -}}
+    {{- fail "secrets.eagerClientCreds: both clientId and clientSecret must be set for inline credentials" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.secretName" -}}
+{{- include "secrets.eagerClientCreds.validate" . -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.eagerClientCreds.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.clientIdKey" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- default (include "secrets.eagerClientCreds.clientIdCanonical" .) $s.existingSecret.clientIdKey -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.clientSecretKey" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- default (include "secrets.eagerClientCreds.clientSecretCanonical" .) $s.existingSecret.clientSecretKey -}}
+{{- end -}}
+
+{{/*
+secrets.imageBuilder.push — buildkit push credentials (opaque KV)
+*/}}
+
+{{- define "secrets.imageBuilder.push.computedName" -}}{{ .Release.Name }}-image-builder-push{{- end -}}
+
+{{- define "secrets.imageBuilder.push.enabled" -}}
+{{- $s := .Values.secrets.imageBuilder.push -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.push.validate" -}}
+{{- $s := .Values.secrets.imageBuilder.push -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := gt (len $s.values) 0 -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.imageBuilder.push: set either existingSecret.name OR values, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.imageBuilder.push.enabled=true requires existingSecret.name or values" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.push.secretName" -}}
+{{- include "secrets.imageBuilder.push.validate" . -}}
+{{- $s := .Values.secrets.imageBuilder.push -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.imageBuilder.push.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{/*
+secrets.imageBuilder.pull — image pull (imagePullSecrets dockerconfigjson). Absorbs depot-token.
+*/}}
+
+{{- define "secrets.imageBuilder.pull.canonicalKey" -}}.dockerconfigjson{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.computedName" -}}{{ .Release.Name }}-image-builder-pull{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.enabled" -}}
+{{- $s := .Values.secrets.imageBuilder.pull -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.validate" -}}
+{{- $s := .Values.secrets.imageBuilder.pull -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := $s.dockerconfigjson -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.imageBuilder.pull: set either existingSecret.name OR dockerconfigjson, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.imageBuilder.pull.enabled=true requires existingSecret.name or dockerconfigjson" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.secretName" -}}
+{{- include "secrets.imageBuilder.pull.validate" . -}}
+{{- $s := .Values.secrets.imageBuilder.pull -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.imageBuilder.pull.computedName" . }}{{- end -}}
+{{- end -}}

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -162,6 +162,47 @@ secrets.eagerClientCreds — multi-key (client_id + client_secret)
 {{- end -}}
 
 {{/*
+secrets.internalCaCert — single-key (ca.crt) trust bundle for the CP
+internal-tls cert. Cluster operators typically wire `existingSecret.name`
+to an ExternalSecret-managed Secret (`internal-ca-bundle`); chart users
+without ExternalSecrets supply the PEM inline via `value`.
+*/}}
+
+{{- define "secrets.internalCaCert.caCertCanonical" -}}ca.crt{{- end -}}
+
+{{- define "secrets.internalCaCert.computedName" -}}{{ .Release.Name }}-internal-ca{{- end -}}
+
+{{- define "secrets.internalCaCert.enabled" -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.internalCaCert.validate" -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := $s.value -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.internalCaCert: set either existingSecret.name OR value, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.internalCaCert.enabled=true requires existingSecret.name or value" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.internalCaCert.secretName" -}}
+{{- include "secrets.internalCaCert.validate" . -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.internalCaCert.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{- define "secrets.internalCaCert.caCertKey" -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- default (include "secrets.internalCaCert.caCertCanonical" .) $s.existingSecret.caCertKey -}}
+{{- end -}}
+
+{{/*
 secrets.imageBuilder.push — buildkit push credentials (opaque KV)
 */}}
 

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -143,6 +143,8 @@ secrets.eagerClientCreds — multi-key (client_id + client_secret)
 {{- end -}}
 {{- end -}}
 
+{{- define "secrets.eagerOAuthConfig.configMapName" -}}{{ .Release.Name }}-eager-oauth-config{{- end -}}
+
 {{- define "secrets.eagerClientCreds.secretName" -}}
 {{- include "secrets.eagerClientCreds.validate" . -}}
 {{- $s := .Values.secrets.eagerClientCreds -}}

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -38,6 +38,41 @@ Consumer pattern for multi-key (eagerClientCreds, admin):
 */}}
 
 {{/*
+secrets.admin — admin client credentials.
+
+Carries the unified shape but also accepts the legacy `enable` and `create` flags so
+existing values files keep working. Default computed name is `union-secret-auth` to
+preserve the name historically baked into consumer configs.
+
+Legacy:
+  enable: bool            (alias for enabled)
+  create: bool            (legacy: false → external secret with hardcoded name `union-secret-auth`)
+*/}}
+
+{{- define "secrets.admin.computedName" -}}union-secret-auth{{- end -}}
+
+{{- define "secrets.admin.enabled" -}}
+{{- $s := .Values.secrets.admin -}}
+{{- if hasKey $s "enabled" -}}{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- else if hasKey $s "enable" -}}{{- if $s.enable -}}true{{- else -}}false{{- end -}}
+{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.admin.shouldCreate" -}}
+{{- $s := .Values.secrets.admin -}}
+{{- if eq (include "secrets.admin.enabled" .) "true" -}}
+  {{- if $s.existingSecret.name -}}false
+  {{- else if and (hasKey $s "create") (not $s.create) -}}false
+  {{- else -}}true{{- end -}}
+{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.admin.secretName" -}}
+{{- $s := .Values.secrets.admin -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.admin.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{/*
 secrets.eagerApiKey
 */}}
 

--- a/charts/dataplane/templates/common/auth-secret.yaml
+++ b/charts/dataplane/templates/common/auth-secret.yaml
@@ -1,14 +1,13 @@
-{{- if and .Values.secrets.admin.enable  .Values.secrets.admin.create }}
+{{- if eq (include "secrets.admin.shouldCreate" .) "true" }}
 {{- $secret := .Values.secrets.admin.clientSecret | required ".Values.secrets.admin.clientSecret is required when admin client credentials has been enabled." -}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: union-secret-auth
+  name: {{ include "secrets.admin.secretName" . }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: {{ $secret | b64enc | toString }}
   client_secret: {{ $secret | b64enc | toString }}
 {{- end }}

--- a/charts/dataplane/templates/common/cluster-name-configmap.yaml
+++ b/charts/dataplane/templates/common/cluster-name-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: {{ tpl .Values.clusterName $ | quote }}

--- a/charts/dataplane/templates/common/cluster-secret.yaml
+++ b/charts/dataplane/templates/common/cluster-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: {{ tpl .Values.clusterName $ | b64enc }}

--- a/charts/dataplane/templates/common/eager-api-key-secret.yaml
+++ b/charts/dataplane/templates/common/eager-api-key-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq (include "secrets.eagerApiKey.enabled" .) "true") (not .Values.secrets.eagerApiKey.existingSecret.name) }}
+{{- $ref := include "secrets.eagerApiKey.secretRef" . | fromYaml -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ref.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: eager-api-key
+type: Opaque
+data:
+  {{ $ref.key }}: {{ .Values.secrets.eagerApiKey.value | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/eager-client-creds-secret.yaml
+++ b/charts/dataplane/templates/common/eager-client-creds-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq (include "secrets.eagerClientCreds.enabled" .) "true") (not .Values.secrets.eagerClientCreds.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.eagerClientCreds.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: eager-client-creds
+type: Opaque
+data:
+  {{ include "secrets.eagerClientCreds.clientIdKey" . }}: {{ .Values.secrets.eagerClientCreds.clientId | b64enc }}
+  {{ include "secrets.eagerClientCreds.clientSecretKey" . }}: {{ .Values.secrets.eagerClientCreds.clientSecret | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -33,7 +33,11 @@ metadata:
 data:
   config.yaml: |
     admin:
-      endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
+      {{/* Use the PUBLIC CP hostname (Values.host = global.UNION_CONTROL_PLANE_HOST)
+           so the SDK's OAuth + gRPC traffic hits a name covered by the CP TLS
+           cert SAN. The chart helper dataplane.cp.endpoint would resolve to
+           the INTERNAL CONTROLPLANE_HOST which is not in the cert. */}}
+      endpoint: {{ printf "dns:///%s:443" (tpl .Values.host .) | quote }}
       insecure: {{ default false $cpConn.insecure }}
       insecureSkipVerify: {{ default false $cpConn.insecureSkipVerify }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -13,7 +13,15 @@ Carries app.kubernetes.io/managed-by=union-operator AND the
 union.ai/mirrored-from-namespace=<operator NS> annotation so the
 mirror's cleanup query scopes copies to this install.
 */}}
+{{/*
+The endpoint, insecure, and insecureSkipVerify values mirror the
+dataplane's own CP-connection wiring (config.union.connection on the
+chart). For selfmanaged envs with self-signed CP certs, terraform sets
+insecureSkipVerify: true; the chart default is false (managed CP with
+valid cert).
+*/}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $cpConn := default dict (default dict .Values.config.union).connection -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,8 +33,10 @@ metadata:
 data:
   config.yaml: |
     admin:
-      endpoint: {{ tpl .Values.host . | quote }}
+      endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
+      insecure: {{ default false $cpConn.insecure }}
+      insecureSkipVerify: {{ default false $cpConn.insecureSkipVerify }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
       clientSecretLocation: {{ .Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret" | quote }}
-      authType: ClientSecret
+      authType: ClientCredentials
 {{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -12,16 +12,16 @@ _UNION_EAGER_API_KEY env-var path.
 Carries app.kubernetes.io/managed-by=union-operator AND the
 union.ai/mirrored-from-namespace=<operator NS> annotation so the
 mirror's cleanup query scopes copies to this install.
-*/}}
-{{/*
-The endpoint, insecure, and insecureSkipVerify values mirror the
-dataplane's own CP-connection wiring (config.union.connection on the
-chart). For selfmanaged envs with self-signed CP certs, terraform sets
-insecureSkipVerify: true; the chart default is false (managed CP with
-valid cert).
+
+Endpoint uses the chart's `dataplane.cp.endpoint` helper, which resolves
+to the CP's internal hostname (control-plane.internal.<full_domain>) —
+covered by the cert-manager-issued `controlplane-internal-tls` SAN. The
+SDK trusts the issuing CA via caCertFilePath, mounted from
+secrets.internalCaCert. Both `insecure` and `insecureSkipVerify` are
+deliberately omitted; the SDK defaults to verify, which is the only
+correct behavior under this trust chain.
 */}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-{{- $cpConn := default dict (default dict .Values.config.union).connection -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,14 +33,11 @@ metadata:
 data:
   config.yaml: |
     admin:
-      {{/* Use the PUBLIC CP hostname (Values.host = global.UNION_CONTROL_PLANE_HOST)
-           so the SDK's OAuth + gRPC traffic hits a name covered by the CP TLS
-           cert SAN. The chart helper dataplane.cp.endpoint would resolve to
-           the INTERNAL CONTROLPLANE_HOST which is not in the cert. */}}
-      endpoint: {{ printf "dns:///%s:443" (tpl .Values.host .) | quote }}
-      insecure: {{ default false $cpConn.insecure }}
-      insecureSkipVerify: {{ default false $cpConn.insecureSkipVerify }}
+      endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
-      clientSecretLocation: {{ .Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret" | quote }}
+      clientSecretLocation: "/etc/flyte/credentials/client_secret"
       authType: ClientCredentials
+      {{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
+      caCertFilePath: "/etc/flyte/credentials/ca.crt"
+      {{- end }}
 {{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -1,0 +1,32 @@
+{{/*
+eager-auth-config: SDK config.yaml mounted on task pods by the
+flyte-pod-webhook's file-mount path (FAB-241 file-mount workstream).
+
+When secrets.eagerClientCreds.enabled is true and the operator's
+SecretMirrorSyncer is enabled, the operator mirrors this ConfigMap and
+the client_secret Secret into every flyte-typed target NS. Task pods
+mount config.yaml at /etc/flyte/config.yaml and the SDK's
+init_from_config() reads it at startup, replacing the legacy
+_UNION_EAGER_API_KEY env-var path.
+
+Carries app.kubernetes.io/managed-by=union-operator AND the
+union.ai/mirrored-from-namespace=<operator NS> annotation so the
+mirror's cleanup query scopes copies to this install.
+*/}}
+{{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Values.mirroring.managedByLabelValue | default "union-operator" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  config.yaml: |
+    admin:
+      endpoint: {{ tpl .Values.host . | quote }}
+      clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
+      clientSecretLocation: {{ .Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret" | quote }}
+      authType: ClientSecret
+{{- end }}

--- a/charts/dataplane/templates/common/image-builder-push-secret.yaml
+++ b/charts/dataplane/templates/common/image-builder-push-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and (eq (include "secrets.imageBuilder.push.enabled" .) "true") (not .Values.secrets.imageBuilder.push.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.imageBuilder.push.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: image-builder-push
+type: Opaque
+data:
+{{- range $k, $v := .Values.secrets.imageBuilder.push.values }}
+  {{ $k }}: {{ $v | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/dataplane/templates/common/image-pull-secret.yaml
+++ b/charts/dataplane/templates/common/image-pull-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (include "secrets.imageBuilder.pull.enabled" .) "true") (not .Values.secrets.imageBuilder.pull.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.imageBuilder.pull.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: image-builder-pull
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.secrets.imageBuilder.pull.dockerconfigjson | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/internal-ca-secret.yaml
+++ b/charts/dataplane/templates/common/internal-ca-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (include "secrets.internalCaCert.enabled" .) "true") (not .Values.secrets.internalCaCert.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.internalCaCert.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: internal-ca-cert
+type: Opaque
+data:
+  {{ include "secrets.internalCaCert.caCertKey" . }}: {{ .Values.secrets.internalCaCert.value | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/task-podtemplate.yaml
+++ b/charts/dataplane/templates/common/task-podtemplate.yaml
@@ -1,4 +1,5 @@
-{{- if or (include "singleNamespace" .) (include "operator.enableDepot" .) }}
+{{- $imageBuilderPullEnabled := eq (include "secrets.imageBuilder.pull.enabled" .) "true" }}
+{{- if or (include "singleNamespace" .) (include "operator.enableDepot" .) $imageBuilderPullEnabled }}
 apiVersion: v1
 kind: PodTemplate
 metadata:
@@ -9,7 +10,10 @@ template:
 {{- if include "singleNamespace" . }}
     serviceAccountName: union
 {{- end }}
-{{- if include "operator.enableDepot" . }}
+{{- if $imageBuilderPullEnabled }}
+    imagePullSecrets:
+      - name: {{ include "secrets.imageBuilder.pull.secretName" . }}
+{{- else if include "operator.enableDepot" . }}
     imagePullSecrets:
       - name: depot-token
 {{- end }}

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -20,22 +20,7 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- /*
-         When the chart-managed eager-credentials file-mount path is on
-         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
-         + CA from mounted files via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
-         so leaseworker stops appending EAGER_API_KEY to
-         SecurityContext.Secrets and the webhook never emits the env var
-         on task pods. Users can still set injectSecret explicitly via
-         values-overrides to preserve a hybrid setup if needed.
-    */}}
     {{- $leaseworkerConfig := deepCopy (.Values.leaseworker.config | default dict) }}
-    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-    {{- $unionAuth := deepCopy (index $leaseworkerConfig "unionAuth" | default dict) }}
-    {{- $_ := set $unionAuth "injectSecret" false }}
-    {{- $_ = set $leaseworkerConfig "unionAuth" $unionAuth }}
-    {{- end }}
     {{- $_ := set $leaseworkerConfig "capacity" .Values.leaseworker.capacity }}
     {{- $_ = set $leaseworkerConfig "dispatcherCount" .Values.leaseworker.dispatcherCount }}
     {{- $_ = set $leaseworkerConfig "refreshInterval" .Values.leaseworker.refreshInterval }}

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -20,7 +20,22 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
+    {{- /*
+         When the chart-managed eager-credentials file-mount path is on
+         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
+         + CA from mounted files via init_from_config(). The legacy
+         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
+         so leaseworker stops appending EAGER_API_KEY to
+         SecurityContext.Secrets and the webhook never emits the env var
+         on task pods. Users can still set injectSecret explicitly via
+         values-overrides to preserve a hybrid setup if needed.
+    */}}
     {{- $leaseworkerConfig := deepCopy (.Values.leaseworker.config | default dict) }}
+    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+    {{- $unionAuth := deepCopy (index $leaseworkerConfig "unionAuth" | default dict) }}
+    {{- $_ := set $unionAuth "injectSecret" false }}
+    {{- $_ = set $leaseworkerConfig "unionAuth" $unionAuth }}
+    {{- end }}
     {{- $_ := set $leaseworkerConfig "capacity" .Values.leaseworker.capacity }}
     {{- $_ = set $leaseworkerConfig "dispatcherCount" .Values.leaseworker.dispatcherCount }}
     {{- $_ = set $leaseworkerConfig "refreshInterval" .Values.leaseworker.refreshInterval }}

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -18,23 +18,7 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- /*
-         When the chart-managed eager-credentials file-mount path is on
-         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
-         + CA from mounted files via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
-         so leaseworker/executor/operator-apps stop appending EAGER_API_KEY
-         to SecurityContext.Secrets and the webhook never emits the env var
-         on task pods. Users can still set injectSecret explicitly via
-         values-overrides to preserve a hybrid setup if needed.
-    */}}
-    {{- $executorConfig := deepCopy (.Values.executor.config | default dict) }}
-    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-    {{- $unionAuth := deepCopy (index $executorConfig "unionAuth" | default dict) }}
-    {{- $_ := set $unionAuth "injectSecret" false }}
-    {{- $_ = set $executorConfig "unionAuth" $unionAuth }}
-    {{- end }}
-    {{- with $executorConfig }}
+    {{- with .Values.executor.config }}
     executor:
       {{- tpl (toYaml .) $ | nindent 6 }}
     {{- end }}

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -18,7 +18,23 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- with .Values.executor.config }}
+    {{- /*
+         When the chart-managed eager-credentials file-mount path is on
+         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
+         + CA from mounted files via init_from_config(). The legacy
+         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
+         so leaseworker/executor/operator-apps stop appending EAGER_API_KEY
+         to SecurityContext.Secrets and the webhook never emits the env var
+         on task pods. Users can still set injectSecret explicitly via
+         values-overrides to preserve a hybrid setup if needed.
+    */}}
+    {{- $executorConfig := deepCopy (.Values.executor.config | default dict) }}
+    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+    {{- $unionAuth := deepCopy (index $executorConfig "unionAuth" | default dict) }}
+    {{- $_ := set $unionAuth "injectSecret" false }}
+    {{- $_ = set $executorConfig "unionAuth" $unionAuth }}
+    {{- end }}
+    {{- with $executorConfig }}
     executor:
       {{- tpl (toYaml .) $ | nindent 6 }}
     {{- end }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -136,6 +136,10 @@ data:
         - kind: ConfigMap
           name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
         {{- end }}
+        {{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
+        - kind: Secret
+          name: {{ include "secrets.internalCaCert.secretName" . }}
+        {{- end }}
         {{- if .Values.imageBuilder.enabled }}
         - kind: ConfigMap
           name: {{ .Values.imageBuilder.targetConfigMapName | default "build-image-config" }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -119,6 +119,28 @@ data:
         referenceConfigmapName: {{ include "union-operator.fullname" . }}
         targetConfigMapName: {{ .Values.imageBuilder.targetConfigMapName | quote }}
     {{- end }}
+    {{- if .Values.mirroring.enabled }}
+      mirroring:
+        enabled: true
+        managedByLabelValue: {{ .Values.mirroring.managedByLabelValue | default "union-operator" | quote }}
+        defaultNamespaceSelector:
+{{ toYaml .Values.mirroring.defaultNamespaceSelector | indent 10 }}
+        provenanceAnnotations:
+          sourceNamespace: union.ai/mirrored-from-namespace
+          sourceName: union.ai/mirrored-from-name
+          sourceVersion: union.ai/mirrored-from-version
+        resources:
+        {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+        - kind: Secret
+          name: {{ include "secrets.eagerClientCreds.secretName" . }}
+        - kind: ConfigMap
+          name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
+        {{- end }}
+        {{- if .Values.imageBuilder.enabled }}
+        - kind: ConfigMap
+          name: {{ .Values.imageBuilder.targetConfigMapName | default "build-image-config" }}
+        {{- end }}
+    {{- end }}
   {{- with .Values.config.proxy }}
     proxy:
       {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1887,6 +1887,51 @@ secrets:
     # -- The client id used to authenticate to the control plane.  This will be provided by Union.
     clientId: dataplane-operator
 
+  # -- Eager-execution API key (DP → CP callback). Replaces post-install `flyte create secret EAGER_API_KEY`.
+  eagerApiKey:
+    # -- Reference an externally-provisioned Secret (Whisper, sealed-secrets, external-secrets, etc.).
+    existingSecret:
+      # -- Name of the existing Secret. When set, the chart skips creating its own and consumers reference this name.
+      name: ""
+      # -- Optional override of the data key. Defaults to `EAGER_API_KEY`.
+      key: ""
+    # -- Activate the consumer secretKeyRef wiring. When false, downstream env vars and references are omitted entirely.
+    enabled: false
+    # -- Inline API key value. Used only when `existingSecret.name` is empty. Chart creates `<release>-eager-api-key`.
+    value: ""
+
+  # -- Eager-execution client credentials (UNION_CLIENT_ID / UNION_CLIENT_SECRET). Kept separate from `admin` client creds.
+  eagerClientCreds:
+    existingSecret:
+      # -- Name of the existing Secret. When set, the chart skips creating its own.
+      name: ""
+      # -- Optional override of the client-id data key. Defaults to `client_id`.
+      clientIdKey: ""
+      # -- Optional override of the client-secret data key. Defaults to `client_secret`.
+      clientSecretKey: ""
+    enabled: false
+    # -- Inline client id. Used only when `existingSecret.name` is empty.
+    clientId: ""
+    # -- Inline client secret. Used only when `existingSecret.name` is empty.
+    clientSecret: ""
+
+  # -- Image builder registry credentials. Split into push (buildkit) and pull (task pods, replaces depot-token).
+  imageBuilder:
+    push:
+      existingSecret:
+        # -- Name of the existing Secret. When set, the chart skips creating its own.
+        name: ""
+      enabled: false
+      # -- Inline opaque KV map. Each key becomes a Secret data key. Used only when `existingSecret.name` is empty.
+      values: {}
+    pull:
+      existingSecret:
+        # -- Name of the existing Secret. When set, the chart skips creating its own.
+        name: ""
+      enabled: false
+      # -- Inline dockerconfigjson value (full JSON string). Used only when `existingSecret.name` is empty.
+      dockerconfigjson: ""
+
 sparkoperator:
   enabled: false
   plugin_config: { }

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1875,6 +1875,35 @@ proxy:
 resourcequota:
   create: false
 
+# -- Operator-side SecretMirrorSyncer config (FAB-241). When enabled, the
+# operator propagates chart-managed Secrets and ConfigMaps from this
+# release's namespace into every namespace matching the selector. The
+# flyte-pod-webhook's file-mount path activates simultaneously when
+# secrets.eagerClientCreds.enabled is true — it pre-checks the
+# mirror is present before injecting volume mounts and denies
+# admission with HTTP 503 on miss so the upstream retry path
+# absorbs operator-mirror lag.
+mirroring:
+  # -- Master switch. When false, SecretMirrorSyncer does not run and
+  # the legacy BuildImageConfigSyncer continues handling build-image
+  # ConfigMap mirror. When true, the new syncer subsumes it.
+  enabled: false
+  # -- Value applied as app.kubernetes.io/managed-by on every mirrored
+  # copy. Stable literal — does NOT incorporate release name. Customer-
+  # overridable for brand/white-label. Stability-critical: changing
+  # post-install orphans previously-mirrored copies.
+  managedByLabelValue: union-operator
+  # -- Default namespace selector applied to every mirror entry that
+  # doesn't override.
+  defaultNamespaceSelector:
+    matchLabels:
+      union.ai/namespace-type: flyte
+  # -- File-mount paths used by the operator config rendering and the
+  # webhook's fileMount block. Defaults match the SDK's expectations.
+  eagerOAuth:
+    configMapMountPath: /etc/flyte/config.yaml
+    secretMountPath: /etc/flyte/credentials/client_secret
+
 # -- Connection secrets for the Union control plane services.
 secrets:
   admin:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1950,6 +1950,23 @@ secrets:
     # -- Inline client secret. Used only when `existingSecret.name` is empty.
     clientSecret: ""
 
+  # -- Internal-CA trust bundle (`ca.crt`) used by the SDK to verify the
+  # CP `internal-tls` cert on the DP→CP gRPC path. Distinct from
+  # `eagerClientCreds`: trust material, not OAuth creds, so independent
+  # lifecycle and IAM scope (cluster operators typically point at an
+  # ExternalSecret-managed `internal-ca-bundle`). Single key inside the
+  # Secret: `ca.crt`. Picked up by the FAB-241 mirror + propeller
+  # webhook file-mount path when `secrets.internalCaCert.enabled` is true.
+  internalCaCert:
+    existingSecret:
+      # -- Name of the existing Secret. When set, the chart skips creating its own.
+      name: ""
+      # -- Optional override of the ca.crt data key. Defaults to `ca.crt`.
+      caCertKey: ""
+    enabled: false
+    # -- Inline PEM-encoded CA bundle. Used only when `existingSecret.name` is empty.
+    value: ""
+
   # -- Image builder registry credentials. Split into push (buildkit) and pull (task pods, replaces depot-token).
   imageBuilder:
     push:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1878,9 +1878,15 @@ resourcequota:
 # -- Connection secrets for the Union control plane services.
 secrets:
   admin:
-    # -- Enable or disable the admin secret.  This is used to authenticate to the control plane.
+    # -- Reference an externally-provisioned Secret. When set, the chart skips creating its own
+    # -- regardless of the legacy `create` flag.
+    existingSecret:
+      name: ""
+    # -- Enable or disable the admin secret. This is used to authenticate to the control plane.
+    # -- DEPRECATED alias for `enable`. Either field is accepted; `enabled` wins when both are set.
     enable: true
-    # -- Create the secret resource containing the client id and secret.  If set to false the user is responsible for creating the secret before the installation.
+    # -- DEPRECATED. Set `existingSecret.name` instead. When `create: false` is left in place the
+    # -- chart treats it as referencing the historical name `union-secret-auth`.
     create: true
     # -- The client secret used to authenticate to the control plane.  This will be provided by Union.
     clientSecret: ""

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1zZWNyZXQ=
   client_secret: dGVzdC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -891,6 +891,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6488,7 +6489,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8dd61d12833bb8969f034899deb15c1705e832760b9c4c6f924af2c6a0b361c"
+        configChecksum: "399ed73be6266aad9e87e002e273697856a4e9b4c81de5efaa3dec4a92ab0da"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6971,7 +6972,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8dd61d12833bb8969f034899deb15c1705e832760b9c4c6f924af2c6a0b361c"
+        configChecksum: "399ed73be6266aad9e87e002e273697856a4e9b4c81de5efaa3dec4a92ab0da"
         prometheus.io/scrape: "true"
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tdGVzdA==
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-test"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6410,7 +6409,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6548,7 +6547,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6654,7 +6653,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6783,7 +6782,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6907,7 +6906,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7012,7 +7011,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -897,6 +897,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6520,7 +6521,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "385f72f71de64efc2cd659f39f6d5438ba13fd52f1b9755f07f519bcf993301"
+        configChecksum: "15c59c30c88bbc61180d11087d9025e671de1be1489cf0c8a5828351fc8f74d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6993,7 +6994,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "385f72f71de64efc2cd659f39f6d5438ba13fd52f1b9755f07f519bcf993301"
+        configChecksum: "15c59c30c88bbc61180d11087d9025e671de1be1489cf0c8a5828351fc8f74d"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6442,7 +6441,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6578,7 +6577,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6682,7 +6681,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6809,7 +6808,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6931,7 +6930,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7034,7 +7033,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -187,16 +187,6 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -842,6 +832,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6948,7 +6947,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7084,7 +7083,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7188,7 +7187,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7315,7 +7314,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7437,7 +7436,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7540,7 +7539,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -183,7 +183,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -1016,6 +1016,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -7026,7 +7027,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e60d1991c51a392fc4200858d2748de7eaaa5118560c5ff356586d4e71622c7"
+        configChecksum: "36a1faa7dbec782dfc331b5a55f3a0abaa05cd329723a3d5171816dab5ab6bd"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7499,7 +7500,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "e60d1991c51a392fc4200858d2748de7eaaa5118560c5ff356586d4e71622c7"
+        configChecksum: "36a1faa7dbec782dfc331b5a55f3a0abaa05cd329723a3d5171816dab5ab6bd"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -891,6 +891,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6488,7 +6489,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2db733ad473adf73c6473424f4f8632e8e395369b49aaf3a59386713a673ab7"
+        configChecksum: "0df87715d3c2e3c7db062d3a14b7689c0b02a7cca882e32735867ec850457e9"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6961,7 +6962,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "2db733ad473adf73c6473424f4f8632e8e395369b49aaf3a59386713a673ab7"
+        configChecksum: "0df87715d3c2e3c7db062d3a14b7689c0b02a7cca882e32735867ec850457e9"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: Y2xpZW50U2VjcmV0
   client_secret: Y2xpZW50U2VjcmV0
 

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: Y2xpZW50U2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tYXdz
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-aws"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6410,7 +6409,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6546,7 +6545,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6650,7 +6649,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6777,7 +6776,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6899,7 +6898,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7002,7 +7001,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -1016,6 +1016,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6953,7 +6954,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "48929dcd17c30dc691d1cae7aea0a707a0dd53e9ac25034d3f05c4160942c6f"
+        configChecksum: "66fcaec06051eb037dbdcfcd7da2664eecea3b85b563290078a57aff3daeeb5"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7426,7 +7427,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "48929dcd17c30dc691d1cae7aea0a707a0dd53e9ac25034d3f05c4160942c6f"
+        configChecksum: "66fcaec06051eb037dbdcfcd7da2664eecea3b85b563290078a57aff3daeeb5"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -183,7 +183,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -187,16 +187,6 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -842,6 +832,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6875,7 +6874,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7011,7 +7010,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7115,7 +7114,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7242,7 +7241,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7364,7 +7363,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7467,7 +7466,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -181,16 +181,6 @@ metadata:
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/component: activator
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/gateway/webhook.yaml
 # Copyright 2020 The Knative Authors
 #
@@ -840,6 +830,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -8411,7 +8410,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9380,7 +9379,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9516,7 +9515,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9620,7 +9619,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9747,7 +9746,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -9843,7 +9842,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9946,7 +9945,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -2890,6 +2890,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -9458,7 +9459,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "92b621c136a0ecdf3cc5c2fbd1f67cd8e1b2d388db186bf6195571a68d3bd32"
+        configChecksum: "ac397608350f9b95bc4098fe41a1f63044c9fcff398808bffcbf9ef254d696a"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9905,7 +9906,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "92b621c136a0ecdf3cc5c2fbd1f67cd8e1b2d388db186bf6195571a68d3bd32"
+        configChecksum: "ac397608350f9b95bc4098fe41a1f63044c9fcff398808bffcbf9ef254d696a"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -181,16 +181,6 @@ metadata:
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/component: activator
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/gateway/webhook.yaml
 # Copyright 2020 The Knative Authors
 #
@@ -840,6 +830,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -8411,7 +8410,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9380,7 +9379,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9516,7 +9515,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9620,7 +9619,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9747,7 +9746,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -9843,7 +9842,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9946,7 +9945,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -2890,6 +2890,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -9458,7 +9459,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "92c77518e5cd20906e9148bd3e3cdd36d18ede1a3d09ce9123070a77e3594cc"
+        configChecksum: "2f674984e08e4f74f2726ad53fdaeb593bc30a6766e78fbff1bb861a142f6d1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9905,7 +9906,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "92c77518e5cd20906e9148bd3e3cdd36d18ede1a3d09ce9123070a77e3594cc"
+        configChecksum: "2f674984e08e4f74f2726ad53fdaeb593bc30a6766e78fbff1bb861a142f6d1"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1henVyZS1jbHVzdGVy
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-azure-cluster"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6477,7 +6476,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6614,7 +6613,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6719,7 +6718,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6847,7 +6846,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6970,7 +6969,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7074,7 +7073,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -882,6 +882,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6555,7 +6556,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "132273bd9c0bc79f7074b245b32e5671f8c48d2283106157316a2e13ad4098b"
+        configChecksum: "c4433f20bdda6e1a5497d10799cb910c044297daa19080bda9f6ed78d7f65cf"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7033,7 +7034,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "132273bd9c0bc79f7074b245b32e5671f8c48d2283106157316a2e13ad4098b"
+        configChecksum: "c4433f20bdda6e1a5497d10799cb910c044297daa19080bda9f6ed78d7f65cf"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1henVyZS1jbHVzdGVy
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-azure-cluster"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6477,7 +6476,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6614,7 +6613,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6719,7 +6718,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6847,7 +6846,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6970,7 +6969,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7074,7 +7073,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -882,6 +882,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6555,7 +6556,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "66dd99d3c078d373ff7f5fbf9a36b3c514ac074122e7fda9d3b2198a6b89369"
+        configChecksum: "99106c59adbf858f458faa23153ef5d8f007782a610a30b7087bd2e0f651911"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7033,7 +7034,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "66dd99d3c078d373ff7f5fbf9a36b3c514ac074122e7fda9d3b2198a6b89369"
+        configChecksum: "99106c59adbf858f458faa23153ef5d8f007782a610a30b7087bd2e0f651911"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -187,7 +187,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -1037,6 +1037,7 @@ data:
   webhook.yaml: |
 
     
+    
     webhook:
       certDir: /etc/webhook/certs
       disableCreateMutatingWebhookConfig: true
@@ -6689,7 +6690,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c77b8e234e874393773b557311a1731670d4e51c8b009711940e5afd27a5fa0"
+        configChecksum: "ef6473ba966e3e3b4d7de7652c7106d04706ccce996e1ef75ec2bca5c7bc651"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7164,7 +7165,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "c77b8e234e874393773b557311a1731670d4e51c8b009711940e5afd27a5fa0"
+        configChecksum: "ef6473ba966e3e3b4d7de7652c7106d04706ccce996e1ef75ec2bca5c7bc651"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -191,16 +191,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -891,6 +881,15 @@ data:
         limits.memory: {{ projectQuotaMemory }}
         requests.nvidia.com/gpu: {{ projectQuotaNvidiaGpu }}
     
+
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
 
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
@@ -6449,7 +6448,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6611,7 +6610,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6747,7 +6746,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6851,7 +6850,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6980,7 +6979,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7102,7 +7101,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7205,7 +7204,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -146,16 +146,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -705,6 +695,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6428,7 +6427,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6564,7 +6563,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6668,7 +6667,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6795,7 +6794,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6917,7 +6916,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7020,7 +7019,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -885,6 +885,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6506,7 +6507,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6979,7 +6980,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -175,16 +175,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -830,6 +820,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6759,7 +6758,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6895,7 +6894,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6999,7 +6998,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7126,7 +7125,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7248,7 +7247,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7351,7 +7350,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -1010,6 +1010,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6837,7 +6838,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7310,7 +7311,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -885,6 +885,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6511,7 +6512,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f24aa9aa16d7d6fec22c6e5c91babc367bb53875efbb19d969ce718a8a3ef66"
+        configChecksum: "9079da048d4503fa9bd876f1998747cf8206521d1c453c9a53ca049c0191815"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6928,7 +6929,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "f24aa9aa16d7d6fec22c6e5c91babc367bb53875efbb19d969ce718a8a3ef66"
+        configChecksum: "9079da048d4503fa9bd876f1998747cf8206521d1c453c9a53ca049c0191815"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -146,16 +146,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -705,6 +695,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6433,7 +6432,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6563,7 +6562,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6657,7 +6656,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6775,7 +6774,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6866,7 +6865,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6969,7 +6968,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1lMmUtZ2Nw
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-e2e-gcp"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6425,7 +6424,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6561,7 +6560,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6665,7 +6664,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6792,7 +6791,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6914,7 +6913,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7017,7 +7016,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -894,6 +894,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6503,7 +6504,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b8c386452255d0b4c657421f5b16a7cd03e88cb09c5613c37ed984344786447"
+        configChecksum: "b1aa562e3127e355cd7b84fea788998a2c8a52a031743e1dc5a564dbeb4715f"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6976,7 +6977,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "b8c386452255d0b4c657421f5b16a7cd03e88cb09c5613c37ed984344786447"
+        configChecksum: "b1aa562e3127e355cd7b84fea788998a2c8a52a031743e1dc5a564dbeb4715f"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: bXktc2VjcmV0
   client_secret: bXktc2VjcmV0
 

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -898,6 +898,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6528,7 +6529,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a80079a52c829d53e66ae96b112c5240c3263972592298bd1a7e76cf2be1b9a"
+        configChecksum: "18ef6b4f25b6852c2eb040e07b8735f6f4f13700973bd007eccb1cf601d45fd"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7001,7 +7002,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "a80079a52c829d53e66ae96b112c5240c3263972592298bd1a7e76cf2be1b9a"
+        configChecksum: "18ef6b4f25b6852c2eb040e07b8735f6f4f13700973bd007eccb1cf601d45fd"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: bXktc2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: bXktY2x1c3Rlcg==
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "my-cluster"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6450,7 +6449,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6586,7 +6585,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6690,7 +6689,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6817,7 +6816,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6939,7 +6938,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7042,7 +7041,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -256,16 +256,6 @@ data:
   ldap-toml: ""
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -1533,6 +1523,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -8565,7 +8564,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -8701,7 +8700,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -8805,7 +8804,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -8932,7 +8931,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -9054,7 +9053,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9157,7 +9156,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -1713,6 +1713,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -8643,7 +8644,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ee00187332ecf53c71f841e031b2473575b41f18d2bb3c3442d30bdd05e081a"
+        configChecksum: "3658700f6da4ffaa88c0ce11f155062384cdb5b7df6c3b57ce1762dfd360b2d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9116,7 +9117,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ee00187332ecf53c71f841e031b2473575b41f18d2bb3c3442d30bdd05e081a"
+        configChecksum: "3658700f6da4ffaa88c0ce11f155062384cdb5b7df6c3b57ce1762dfd360b2d"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -153,16 +153,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -712,6 +702,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6014,7 +6013,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6578,7 +6577,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6714,7 +6713,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6818,7 +6817,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6945,7 +6944,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7067,7 +7066,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7170,7 +7169,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -892,6 +892,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6656,7 +6657,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7129,7 +7130,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -898,6 +898,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6549,7 +6550,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d801712faeb5cad40384bce7b75230459fb57b4f63898d3fb94fb918eb9a4b3"
+        configChecksum: "8a3b0d5d8fa1edc507a39d0355fadfb63142c8af62cc19568dc1d987cec03ca"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7074,7 +7075,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "d801712faeb5cad40384bce7b75230459fb57b4f63898d3fb94fb918eb9a4b3"
+        configChecksum: "8a3b0d5d8fa1edc507a39d0355fadfb63142c8af62cc19568dc1d987cec03ca"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: Y2xpZW50U2VjcmV0
   client_secret: Y2xpZW50U2VjcmV0
 

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: Y2xpZW50U2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tb2Np
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-oci"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6465,7 +6464,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6607,7 +6606,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6724,7 +6723,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6864,7 +6863,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6999,7 +6998,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7115,7 +7114,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -154,19 +154,8 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: Y2xpZW50U2VjcmV0
   client_secret: Y2xpZW50U2VjcmV0
-
----
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tb2Np
 
 ---
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -718,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-oci"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6435,7 +6433,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6571,7 +6569,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6675,7 +6673,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6802,7 +6800,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6924,7 +6922,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7027,7 +7025,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -896,6 +896,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6512,7 +6513,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "391b029baf52660e261385ff4dd41738443ff7bf076252aeb82b6931dafb0b0"
+        configChecksum: "a23b580bc8c58781371583dbd9bb13a3b9360acc13f826ef9050b1ff626b84b"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6985,7 +6986,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "391b029baf52660e261385ff4dd41738443ff7bf076252aeb82b6931dafb0b0"
+        configChecksum: "a23b580bc8c58781371583dbd9bb13a3b9360acc13f826ef9050b1ff626b84b"
         
     spec:
       securityContext:


### PR DESCRIPTION
## Summary

Reshape the dataplane chart's secret provisioning into a single declarative `secrets:` block at the top level. Replaces three post-install side channels (`flyte create secret EAGER_API_KEY`, `flyte create secret image-builder-secret`, `kubectl patch depot-token`) with chart-managed Secrets that respect an `existingSecret.name` redirect for users wiring their own secret manager (Whisper / sealed-secrets / external-secrets).

Four commits, each defaults-off so generated test snapshots remain byte-identical with main until an environment opts in:

| Commit    | Description                                                                                                                                                                                                                                                                                                                                                          |
| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `d399219` | Scaffold `templates/_secrets.tpl` consumer helpers (`secretRef`, `secretName`, `enabled`, `validate`) plus the unified `secrets:` block in `values.yaml`. No new templates, no behaviour change.                                                                                                                                                                     |
| `89eb7dd` | Materialize four templates (`eager-api-key`, `eager-client-creds`, `image-builder-push`, `image-pull`) when enabled. `task-podtemplate.yaml` consumes the new image-pull helper, falls through to the legacy `depot-token` reference when the helper is disabled. Each Secret carries a `union.ai/secret-type:` label so operator cleanup informers can identify it. |
| `ee35a99` | Normalize `secrets.admin` to the unified `existingSecret.name` + `enabled` shape while keeping the legacy `enable` / `create` fields as a deprecation shim. Default computed name preserved so existing deployments see no name change.                                                                                                                              |
| `7387df1` | Convert `operator-cluster-name` from Secret to ConfigMap (it is an identifier, not a credential). Same metadata.name preserved; `_helpers.tpl` consumer flipped from `secretKeyRef` to `configMapKeyRef`.                                                                                                                                                            |

## Why

Every selfmanaged environment has had to run post-install workarounds to populate these Secrets. Apple in particular wants declarative provisioning: either chart-managed Secrets from values, or references to pre-existing names. The new shape supports both via `existingSecret.name`. The `operator-cluster-name` change is hygiene — cluster names are configuration, not credentials, and shouldn't live in Secrets.

## Migration

See `charts/MIGRATION.md` for the per-secret migration table. TL;DR for existing deployments:

- All new fields default `enabled: false` → no behaviour change unless opted in
- `secrets.admin.enable` / `create` legacy fields still honoured (with deprecation warning) so existing values overlays keep working
- `operator-cluster-name` Secret → ConfigMap is the one resource-type flip in this PR — on helm upgrade / argocd sync, the existing Secret is removed and the ConfigMap created at the same name

## Test plan

- [x] `make test` — generated snapshots match expected
- [x] `helm template` rendering against three overlays (defaults-off, inline-value, existingSecret redirect)
- [x] mike-apple-aws (staging): ExternalSecret materializes K8s Secret, chart references `existingSecret.name`, PodTemplate carries the new imagePullSecrets entry
- [ ] End-to-end pull validation — task pod actually fetches a private-registry image via the chart-managed pull secret (label-mirror alignment pending verification)
- [ ] Push path validation — companion `build_image_task.py` + bootstrap-Job edits not yet in this PR (planned follow-up commit)

## Stacked on

- Base: `mike/dataplane-shared-connection-config` (the DP→CP TLS-default flip + connection wiring dedup). Will rebase onto main once that branch merges.

## Open

- Label on chart-managed Secrets is `union.ai/secret-type: image-builder-pull` etc.; existing operator mirror code may look for `union.ai/secret-type: image-pull-secret`. Need to align — either chart adjusts to legacy label or operator/webhook side adds parameterized label-set support (in the companion cloud-side PR).
- `build_image_task.py` push-secret volume mount + bootstrap Job env passthrough is the next commit to add here, enabling `Image.from_debian_base(registry="<private-registry>", name="<repo>")` to work without per-task `registry_secret`.

* `main` <!-- branch-stack -->
  - \#428
    - **dataplane: unified top-level secrets block (eagerApiKey, eagerClientCreds, imageBuilder.{push,pull}, admin)** :point\_left:
