### PR TITLE
chart(controlplane): add actionsLeasor.enabled toggle

### DIFF
--- a/charts/MIGRATION.md
+++ b/charts/MIGRATION.md
@@ -4,6 +4,38 @@ Tracking the migration story for the helm-charts cloud overlays. New entries at 
 
 ---
 
+## controlplane — `actionsLeasor.enabled` toggle (queue/executor deprecation)
+
+### What changed
+
+New top-level chart value `actionsLeasor.enabled` (default `false`). When `true`, the `unionai.configMap` helper patches the executions service ConfigMap so that:
+
+- `useActionsServiceForOrgs: [<global.UNION_ORG>]` — the deployment's own org routes `CreateRun` through the v2 actions service.
+- `rejectLegacySDKVersions: true` — sub-2.0.4 SDK `CreateRun` is hard-rejected.
+
+### Deprecation timeline
+
+| Date | Phase | Customer-visible effect |
+|---|---|---|
+| 2026-06-30 | **Deprecation announced** | Queue + executor services formally marked deprecated. SDK <2.0.4 keeps working via the legacy queue path. `actionsLeasor.enabled` default remains `false`. Customers should plan to upgrade SDKs and (optionally) opt into the v2-actions path. |
+| 2026-07-31 | **Complete switch-over** | Chart default flips to `actionsLeasor.enabled: true`. Queue + executor templates/services are removed. SDK <2.0.4 `CreateRun` hard-fails. `actionsLeasor` knob retained for one more minor release for compatibility, then removed. |
+
+### Migration
+
+| Audience | Action |
+|---|---|
+| Managed multi-tenant CP | None today. Track the 2026-06-30 announcement; coordinate SDK upgrade with customer base before 2026-07-31. |
+| Selfhosted single-tenant | Set `actionsLeasor: { enabled: true }` in `values-overrides.yaml` (or via cloud-side `var.actions_leasor_enabled = true` on `union_extension/{aws,gcp}`). Confirm all in-use SDKs are >=2.0.4. After 2026-07-31, drop the override — it becomes the default. |
+| BYOC | Coordinate SDK upgrade with operator. The chart default flip on 2026-07-31 will turn off the legacy path for any deployment that hasn't already migrated. |
+
+### After 2026-07-31
+
+- `actionsLeasor.enabled: true` becomes the default; queue + executor templates are removed.
+- Env overlays that set `actionsLeasor.enabled: true` explicitly can drop the override.
+- The `unionai.configMap` injection block in `templates/_helpers.tpl` becomes unconditional (or moves into values.yaml as plain defaults) and the toggle itself is dropped.
+
+---
+
 ## dataplane 2026.6.2 — DP→CP connection wiring centralized + TLS-by-default
 
 ### What changed

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -406,6 +406,22 @@ IfNotPresent
 
 {{- $merged := (include "unionai.deepMerge" (dict "dest" $global "source" $svc) | fromYaml) }}
 
+{{- /* actionsLeasor.enabled: opt this deployment's own UNION_ORG into v2-actions
+       CreateRun routing and hard-reject sub-2.0.4 SDKs. Chart default is off so
+       chart upgrades don't break existing legacy-SDK users; single-tenant
+       selfhosted envs flip the toggle in values-overrides.yaml. The run service
+       reads useActionsServiceForOrgs + rejectLegacySDKVersions out of the
+       executions configmap (services.executions.configMap.executions.task
+       in values.yaml), so we patch that path before rendering. */}}
+{{- if and (eq .key "executions") (hasKey .Values "actionsLeasor") .Values.actionsLeasor.enabled }}
+  {{- $executions := index $merged "executions" | default dict }}
+  {{- $task := index $executions "task" | default dict }}
+  {{- $_ := set $task "useActionsServiceForOrgs" (list .Values.global.UNION_ORG) }}
+  {{- $_ := set $task "rejectLegacySDKVersions" true }}
+  {{- $_ := set $executions "task" $task }}
+  {{- $_ := set $merged "executions" $executions }}
+{{- end }}
+
 {{- if hasKey .Values "logging" }}
   {{- $_ := set $merged "logger" (omit .Values.logging "pythonLevel") }}
 {{- end }}

--- a/charts/controlplane/templates/actions/deployment-shard.yaml
+++ b/charts/controlplane/templates/actions/deployment-shard.yaml
@@ -179,10 +179,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             {{- toYaml $.Values.actions.resources | nindent 12 }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1388,6 +1388,16 @@ services:
 # this true in their per-env values-overrides.yaml — no need to duplicate the
 # executions.configMap block. The injection happens in templates/_helpers.tpl
 # (unionai.configMap), see actionsLeasor block there.
+#
+# DEPRECATION TIMELINE
+#   2026-06-30 — queue + executor services formally deprecated. SDK <2.0.4 still
+#                works through the legacy path but customers should migrate.
+#   2026-07-31 — complete switch-over: chart default flips to `enabled: true`,
+#                queue + executor templates are removed, and this knob becomes
+#                a no-op (kept briefly for compatibility, then removed). Any env
+#                still on SDK <2.0.4 after this date will hard-fail CreateRun.
+# After 2026-07-31, env overlays that set `actionsLeasor.enabled: true`
+# explicitly can drop the override entirely.
 actionsLeasor:
   enabled: false
 

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1375,6 +1375,22 @@ services:
 # shard via the actions-shard-id header — the same routing semantics used in
 # Union's managed control plane.
 #
+# actionsLeasor: deployment-wide opt-in for v2-actions CreateRun routing.
+# When enabled:
+#   - This deployment's own UNION_ORG goes through the v2 actions service
+#     (services.executions.configMap.executions.apps.task.useActionsServiceForOrgs
+#     gets [.Values.global.UNION_ORG]).
+#   - Sub-2.0.4 SDK CreateRun requests are hard-rejected
+#     (rejectLegacySDKVersions = true), exercising the queue/executor
+#     decommissioning path.
+# Chart default is off so chart upgrades don't break existing legacy-SDK users
+# in managed multi-tenant deployments. Fresh single-tenant selfhosted envs flip
+# this true in their per-env values-overrides.yaml — no need to duplicate the
+# executions.configMap block. The injection happens in templates/_helpers.tpl
+# (unionai.configMap), see actionsLeasor block there.
+actionsLeasor:
+  enabled: false
+
 # Self-hosted runs 10 fixed shards (the same count Union's managed control
 # planes run). Each shard is its own single-replica Deployment owning a
 # contiguous slice of the 1024 partitions. The Watch endpoint is heavy, so this

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -1,0 +1,16098 @@
+---
+# Source: controlplane/templates/scylla/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scylla-operator
+---
+# Source: controlplane/charts/scylla-operator/templates/operator.pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: scylla-operator
+  namespace: scylla-operator
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scylla-operator
+      app.kubernetes.io/instance: scylla-operator
+
+---
+# Source: controlplane/charts/scylla-operator/templates/webhookserver.pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: webhook-server
+  namespace: scylla-operator
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook-server
+      app.kubernetes.io/instance: webhook-server
+
+---
+# Source: controlplane/charts/flyte/templates/admin/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyteadmin
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+imagePullSecrets: 
+  - name: union-registry-secret
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx
+  namespace: union
+automountServiceAccountToken: true
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator.serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scylla-operator
+  namespace: scylla-operator
+  labels:
+    app.kubernetes.io/name: scylla-operator
+    app.kubernetes.io/instance: scylla-operator
+
+---
+# Source: controlplane/charts/scylla-operator/templates/webhookserver.serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: scylla-operator
+  name: webhook-server
+  labels:
+    app.kubernetes.io/name: webhook-server
+    app.kubernetes.io/instance: webhook-server
+
+---
+# Source: controlplane/templates/actions/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: actions
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+
+---
+# Source: controlplane/templates/cacheservice/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/managed-by: Helm
+imagePullSecrets: 
+  - name: union-registry-secret
+
+---
+# Source: controlplane/templates/console/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unionconsole
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: unionconsole
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+
+---
+# Source: controlplane/templates/serviceaccount.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: leasor
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: leasor
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: queue
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: queue
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: run-scheduler
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: run-scheduler
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+
+---
+# Source: controlplane/templates/union-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: union
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: union
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+
+---
+# Source: controlplane/charts/flyte/templates/admin/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flyte-admin-secrets
+  namespace: union
+type: Opaque
+stringData:
+
+---
+# Source: controlplane/charts/flyte/templates/common/secret-auth.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flyte-secret-auth
+  namespace: union
+type: Opaque
+stringData:
+  client_secret: placeholder
+
+---
+# Source: controlplane/charts/flyte/templates/admin/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flyte-admin-clusters-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+data:
+  clusters.yaml: |
+    clusters:
+      clusterConfigs: []
+      labelClusterMap: {}
+---
+# Source: controlplane/charts/flyte/templates/admin/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flyte-admin-base-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+data:
+  db.yaml: | 
+    database:
+      connMaxLifeTime: 120s
+      dbname: flyteadmin
+      host: ''
+      maxIdleConnections: 10
+      maxOpenConnections: 80
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+  domain.yaml: | 
+    domains:
+    - id: development
+      name: development
+    - id: staging
+      name: staging
+    - id: production
+      name: production
+  otel.yaml: | 
+    otel:
+      file:
+        filename: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
+  server.yaml: | 
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/client_secret
+      endpoint: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      insecure: true
+    auth:
+      appAuth:
+        authServerType: External
+        externalAuthServer:
+          allowedAudience:
+          - https://test.example.com
+          baseUrl: ""
+          metadataUrl: .well-known/oauth-authorization-server
+        thirdPartyConfig:
+          flyteClient:
+            audience: ""
+            clientId: ""
+            redirectUri: http://localhost:53593/callback
+            scopes:
+            - all
+      authorizedUris:
+      - http://flyteadmin:80
+      - http://flyteadmin.union.svc.cluster.local:80
+      - https://test.example.com
+      grpcAuthorizationHeader: flyte-authorization
+      httpAuthorizationHeader: flyte-authorization
+      userAuth:
+        cookieSetting:
+          domain: ""
+          sameSitePolicy: LaxMode
+        idpQueryParameter: idp
+        openId:
+          baseUrl: ""
+          clientId: ""
+          scopes:
+          - profile
+          - openid
+          - offline_access
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cloudEvents:
+      enable: false
+    connection:
+      environment: staging
+      region: ""
+      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+    flyteadmin:
+      eventVersion: 2
+      metadataStoragePrefix:
+      - metadata
+      - admin
+      metricsKeys:
+      - phase
+      metricsScope: 'flyte:'
+      profilerPort: 10254
+      roleNameKey: iam.amazonaws.com/role
+      useOffloadedInputs: true
+      useOffloadedWorkflowClosure: true
+    otel:
+      type: noop
+    private:
+      app:
+        cacheProviderConfig:
+          kind: bypass
+        populateUserFields: false
+    server:
+      grpc:
+        port: 8089
+      httpPort: 8088
+      security:
+        allowCors: true
+        allowedHeaders:
+        - Content-Type
+        - flyte-authorization
+        allowedOrigins:
+        - '*'
+        secure: false
+        useAuth: false
+    sharedService:
+      connectPort: 8089
+      httpPort: 8088
+      port: 8089
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '_SERVICE_.union.svc.cluster.local:80'
+  remoteData.yaml: | 
+    remoteData:
+      region: us-east-1
+      scheme: local
+      signedUrls:
+        durationMinutes: 3
+  storage.yaml: | 
+    storage:
+      enable-multicontainer: false
+      limits:
+        maxDownloadMBs: 10
+      cache:
+        max_size_mbs: 1024
+        target_gc_percent: 70
+  task_resource_defaults.yaml: | 
+    task_resources:
+      defaults:
+        cpu: 100m
+        memory: 500Mi
+      limits:
+        cpu: 2
+        gpu: 1
+        memory: 1Gi
+
+---
+# Source: controlplane/charts/flyte/templates/console/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flyte-console-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteconsole
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+data: 
+  BASE_URL: /console
+  CONFIG_DIR: /etc/flyte/config
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx-controller
+  namespace: union
+data:
+  allow-snippet-annotations: "true"
+  annotations-risk-level: "Critical"
+  grpc-connect-timeout: "1200"
+  grpc-read-timeout: "604800"
+  grpc-send-timeout: "604800"
+  proxy-connect-timeout: "60"
+  proxy-read-timeout: "3600"
+  proxy-send-timeout: "3600"
+
+---
+# Source: controlplane/templates/actions/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: actions
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    actions:
+      db:
+        cql:
+          hosts:
+          - 'scylla-client.union.svc.cluster.local'
+          keyspace: actions
+        type: CQL
+      partitions:
+      - endPartition: 102
+        startPartition: 0
+      - endPartition: 205
+        startPartition: 103
+      - endPartition: 308
+        startPartition: 206
+      - endPartition: 411
+        startPartition: 309
+      - endPartition: 513
+        startPartition: 412
+      - endPartition: 615
+        startPartition: 514
+      - endPartition: 717
+        startPartition: 616
+      - endPartition: 819
+        startPartition: 718
+      - endPartition: 921
+        startPartition: 820
+      - endPartition: 1023
+        startPartition: 922
+      replicatorType: GRPCService
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      metrics:
+        scope: 'actions:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+
+---
+# Source: controlplane/templates/actions/coordination.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: actions-coordination
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  peer-hashes: |
+    actions-0-f288b103
+    actions-1-f6a76bed
+    actions-2-44d51338
+    actions-3-0e2fc543
+    actions-4-b7f95723
+    actions-5-3d7905f8
+    actions-6-a7e57068
+    actions-7-a5084d4e
+    actions-8-2e085e60
+    actions-9-cf8e9eab
+
+  wait-for-non-peers.sh: |
+    #!/bin/sh
+
+    set -euo pipefail
+
+    # Use timeout to enforce deadline - it will exit with 124 on timeout
+    timeout "${TIMEOUT_SECONDS:-120}" /bin/sh -euo pipefail <<'EOF'
+      get_non_peers() {
+        local pattern="$(echo "$PEER_HASHES" | tr '\n' '|' | sed 's/|$//')"
+
+        # Get pods, exit if kubectl fails
+        pods="$(kubectl get pods -n "$NAMESPACE" -l "$SHARD_LABEL_SELECTOR" -o name 2>&1)"
+        if [ $? -ne 0 ]; then
+          echo "Error: kubectl failed to list pods in namespace $NAMESPACE with selector $SHARD_LABEL_SELECTOR" >&2
+          echo "kubectl output: $pods" >&2
+          return 1
+        fi
+
+        # Filter out valid peers
+        echo "$pods" | grep -vE "${pattern}" || true
+      }
+
+      while :; do
+        non_peers="$(get_non_peers)"
+        if [ $? -ne 0 ]; then
+          echo "Error: Failed to check for non-peer pods" >&2
+          exit 1
+        fi
+
+        if [ -z "$non_peers" ]; then
+          echo "Success: Only found valid peers"
+          exit 0
+        fi
+
+        echo "Waiting for invalid peers to be removed:"
+        echo "$non_peers" | sed 's/^/  /'
+        sleep "${POLL_INTERVAL:-1}"
+      done
+    EOF
+
+    # Check timeout exit code
+    exit_code=$?
+    if [ $exit_code -eq 124 ]; then
+      echo "Error: Timed out waiting for invalid peers to be removed" >&2
+      exit 1
+    fi
+
+    exit $exit_code
+---
+# Source: controlplane/templates/actions/router-cds.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: actions-router-cds
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: router
+data:
+  cds.yaml: |
+    version_info: "1"
+    resources:
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-0
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-0
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-0-f288b103.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-0
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-0
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-0-f288b103.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-1
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-1
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-1-f6a76bed.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-1
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-1
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-1-f6a76bed.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-2
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-2
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-2-44d51338.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-2
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-2
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-2-44d51338.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-3
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-3
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-3-0e2fc543.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-3
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-3
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-3-0e2fc543.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-4
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-4
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-4-b7f95723.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-4
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-4
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-4-b7f95723.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-5
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-5
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-5-3d7905f8.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-5
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-5
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-5-3d7905f8.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-6
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-6
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-6-a7e57068.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-6
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-6
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-6-a7e57068.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-7
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-7
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-7-a5084d4e.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-7
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-7
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-7-a5084d4e.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-8
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-8
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-8-2e085e60.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-8
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-8
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-8-2e085e60.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-grpc-9
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: actions-grpc-9
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-9-cf8e9eab.union.svc.cluster.local
+                  port_value: 8080
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: actions-http-9
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+        - priority: DEFAULT
+          max_connections: 1000000
+          max_pending_requests: 1000000
+          max_requests: 1000000
+          max_retries: 1000000
+      load_assignment:
+        cluster_name: actions-http-9
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: actions-9-cf8e9eab.union.svc.cluster.local
+                  port_value: 8089
+              health_check_config:
+                port_value: 10254
+      health_checks:
+      - timeout: 5s
+        interval: 10s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: "/healthcheck"
+
+---
+# Source: controlplane/templates/actions/router-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: actions-router
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: router
+data:
+  envoy.yaml: |
+    node:
+      cluster: actions-router
+      id: actions-router-union
+
+    dynamic_resources:
+      cds_config:
+        path_config_source:
+          path: /etc/envoy/cds.yaml
+      lds_config:
+        path_config_source:
+          path: /etc/envoy/lds.yaml
+
+    admin:
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9901
+
+---
+# Source: controlplane/templates/actions/router-lds.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: actions-router-lds
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: router
+data:
+  lds.yaml: |
+    version_info: "1"
+    resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: grpc
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: actions_grpc
+            codec_type: AUTO
+            route_config:
+              name: local_route
+              virtual_hosts:
+              - name: backend
+                domains: ["*"]
+                retry_policy:
+                  retry_on: 5xx
+                  num_retries: 10
+                  retry_back_off:
+                    base_interval:
+                      nanos: 25000000
+                    max_interval:
+                      seconds: 10
+                routes:
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "0"
+                  route:
+                    cluster: actions-grpc-0
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "1"
+                  route:
+                    cluster: actions-grpc-1
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "2"
+                  route:
+                    cluster: actions-grpc-2
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "3"
+                  route:
+                    cluster: actions-grpc-3
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "4"
+                  route:
+                    cluster: actions-grpc-4
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "5"
+                  route:
+                    cluster: actions-grpc-5
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "6"
+                  route:
+                    cluster: actions-grpc-6
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "7"
+                  route:
+                    cluster: actions-grpc-7
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "8"
+                  route:
+                    cluster: actions-grpc-8
+                    timeout: 0s
+                    idle_timeout: 7200s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "9"
+                  route:
+                    cluster: actions-grpc-9
+                    timeout: 0s
+                    idle_timeout: 7200s
+            http_filters:
+            - name: envoy.filters.http.golang
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
+                library_id: actions-service-router
+                library_path: /lib/actions-service-router.so
+                plugin_name: actions-service-router
+                plugin_config:
+                  "@type": type.googleapis.com/xds.type.v3.TypedStruct
+                  value:
+                    enabled: true
+                    shards:
+                    - startPartition: 0
+                      endPartition: 102
+                    - startPartition: 103
+                      endPartition: 205
+                    - startPartition: 206
+                      endPartition: 308
+                    - startPartition: 309
+                      endPartition: 411
+                    - startPartition: 412
+                      endPartition: 513
+                    - startPartition: 514
+                      endPartition: 615
+                    - startPartition: 616
+                      endPartition: 717
+                    - startPartition: 718
+                      endPartition: 819
+                    - startPartition: 820
+                      endPartition: 921
+                    - startPartition: 922
+                      endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
+            - name: envoy.filters.http.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: http
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8089
+      filter_chains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: actions_http
+            codec_type: AUTO
+            route_config:
+              name: local_route
+              virtual_hosts:
+              - name: backend
+                domains: ["*"]
+                retry_policy:
+                  retry_on: 5xx
+                  num_retries: 10
+                  retry_back_off:
+                    base_interval:
+                      nanos: 25000000
+                    max_interval:
+                      seconds: 10
+                routes:
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "0"
+                  route:
+                    cluster: actions-http-0
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "1"
+                  route:
+                    cluster: actions-http-1
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "2"
+                  route:
+                    cluster: actions-http-2
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "3"
+                  route:
+                    cluster: actions-http-3
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "4"
+                  route:
+                    cluster: actions-http-4
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "5"
+                  route:
+                    cluster: actions-http-5
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "6"
+                  route:
+                    cluster: actions-http-6
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "7"
+                  route:
+                    cluster: actions-http-7
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "8"
+                  route:
+                    cluster: actions-http-8
+                    timeout: 30s
+                - match:
+                    prefix: "/"
+                    headers:
+                    - name: "actions-shard-id"
+                      string_match:
+                        exact: "9"
+                  route:
+                    cluster: actions-http-9
+                    timeout: 30s
+            http_filters:
+            - name: envoy.filters.http.golang
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
+                library_id: actions-service-router
+                library_path: /lib/actions-service-router.so
+                plugin_name: actions-service-router
+                plugin_config:
+                  "@type": type.googleapis.com/xds.type.v3.TypedStruct
+                  value:
+                    enabled: true
+                    shards:
+                    - startPartition: 0
+                      endPartition: 102
+                    - startPartition: 103
+                      endPartition: 205
+                    - startPartition: 206
+                      endPartition: 308
+                    - startPartition: 309
+                      endPartition: 411
+                    - startPartition: 412
+                      endPartition: 513
+                    - startPartition: 514
+                      endPartition: 615
+                    - startPartition: 616
+                      endPartition: 717
+                    - startPartition: 718
+                      endPartition: 819
+                    - startPartition: 820
+                      endPartition: 921
+                    - startPartition: 922
+                      endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
+            - name: envoy.filters.http.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+---
+# Source: controlplane/templates/cacheservice/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cacheservice-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/managed-by: Helm
+data:
+  db.yaml: | 
+    database:
+      connMaxLifeTime: 120s
+      dbname: cacheservice
+      host: ''
+      maxIdleConnections: 10
+      maxOpenConnections: 20
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+  logger.yaml: | 
+    formatter:
+      type: json
+    level: 6
+    show-source: true
+  server.yaml: | 
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache-server:
+      grpcPort: 8089
+      grpcServerReflection: true
+      httpPort: 8080
+    cacheservice:
+      heartbeat-grace-period-multiplier: 3
+      max-reservation-heartbeat: 30s
+      metrics-scope: flyte
+      profiler-port: 10254
+      storage-prefix: cached_outputs
+    otel:
+      type: noop
+    private:
+      app:
+        cacheProviderConfig:
+          kind: bypass
+    union:
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: '_SERVICE_.union.svc.cluster.local:80'
+  storage.yaml: | 
+    storage:
+      enable-multicontainer: false
+      limits:
+        maxDownloadMBs: 10
+      cache:
+        max_size_mbs: 1024
+        target_gc_percent: 70
+
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      bootstrap:
+        adminUsers: []
+        dataplaneClusters: []
+        domains:
+        - development
+        - staging
+        - production
+        maxRetries: 30
+        organization: 'test-org'
+        projects: []
+        retryInterval: 5s
+        serviceAccounts: []
+      externalClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+      internalCommunicationConfig:
+        enabled: false
+      type: Noop
+      useExternalIdentity: 'false'
+      userCloudsClient:
+        clientID: 'union-authz-client'
+        clientSecretName: union/client_secret
+        enableLogging: true
+        tenantID: 623771e7-ddd6-4575-bedb-7c970ec75b87
+        tenantUrl: http://release-name-union-authz.union.svc.cluster.local:8080
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'authorizer:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: Mock
+    cluster:
+      cloudflare:
+        active: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      debug: 'false'
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'cluster:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    dataproxy:
+      clusterSelector:
+        type: local
+      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      taskMetrics:
+        agentQuery:
+          mappings:
+            dgx_job:
+              queries:
+                EXECUTION_METRIC_ALLOCATED_CPU_AVG: CPU_ALLOCATION:MEAN
+                EXECUTION_METRIC_ALLOCATED_MEMORY_BYTES_AVG: MEM_ALLOCATION:MEAN
+                EXECUTION_METRIC_CPU_UTILIZATION: CPU_UTILIZATION:MEAN
+                EXECUTION_METRIC_GPU_UTILIZATION: GPU_UTILIZATION:MEAN
+                EXECUTION_METRIC_MEMORY_UTILIZATION: MEM_UTILIZATION:MEAN
+        metricDelayToleranceDuration: 0s
+        promQuery:
+          queries:
+            EXECUTION_METRIC_ALLOCATED_CPU_AVG: |
+              max by (namespace, pod) (
+                (
+                  sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}[5m])) >
+                  sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"})
+                )
+                or
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"})
+              ) *
+              on (namespace, pod) group_left max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_ALLOCATED_MEMORY_BYTES_AVG: |
+              max by (namespace, pod) (
+                (
+                  sum by (namespace, pod) (container_memory_working_set_bytes{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}) >
+                  sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"})
+                )
+                or
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"})
+              ) *
+              on (namespace, pod) group_left max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_APP_REPLICA_COUNT: |
+              sum (kube_pod_status_phase{phase=~"Running|Pending", namespace="{{.Namespace}}", pod=~"{{.AppName}}.*"} == 1) or vector(0)
+            EXECUTION_METRIC_APP_REQUESTS: |
+              sum(rate((
+                envoy_cluster_upstream_rq_xx{
+                  job="serving-envoy",
+                  project=~"{{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, envoy_response_code_class)
+            EXECUTION_METRIC_APP_RESPONSE_TIME_P50: |
+              histogram_quantile(0.5, sum(rate((
+                envoy_cluster_upstream_rq_time_bucket{
+                  job="serving-envoy",
+                  project=~"${{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, le))
+            EXECUTION_METRIC_APP_RESPONSE_TIME_P90: |
+              histogram_quantile(0.90, sum(rate((
+                envoy_cluster_upstream_rq_time_bucket{
+                  job="serving-envoy",
+                  project=~"${{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, le))
+            EXECUTION_METRIC_APP_RESPONSE_TIME_P95: |
+              histogram_quantile(0.95, sum(rate((
+                envoy_cluster_upstream_rq_time_bucket{
+                  job="serving-envoy",
+                  project=~"${{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, le))
+            EXECUTION_METRIC_CPU_UTILIZATION: |
+              (sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}[5m])) /
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"})) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_GPU_FRAME_BUFFER_UTILIZATION: |
+              (sum by (namespace, pod, gpu) (DCGM_FI_DEV_FB_USED{namespace="{{.Namespace}}",pod=~"{{.PodName}}"}) /
+                sum by (namespace, pod, gpu) (DCGM_FI_DEV_FB_USED{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} + DCGM_FI_DEV_FB_FREE{namespace="{{.Namespace}}",pod=~"{{.PodName}}"})) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_GPU_MEMORY_UTILIZATION: |
+              sum by (gpu) (DCGM_FI_DEV_MEM_COPY_UTIL{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)) / 100.0
+            EXECUTION_METRIC_GPU_SM_ACTIVE: |
+              sum by (gpu) (DCGM_FI_PROF_SM_ACTIVE{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_GPU_SM_OCCUPANCY: |
+              sum by (gpu) (DCGM_FI_PROF_SM_OCCUPANCY{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_GPU_UTILIZATION: |
+              sum by (gpu) (DCGM_FI_DEV_GPU_UTIL{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)) / 100.0
+            EXECUTION_METRIC_LIMIT_CPU: |
+              sum by (namespace, pod) (kube_pod_container_resource_limits{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_LIMIT_MEMORY_BYTES: |
+              sum by (namespace, pod) (kube_pod_container_resource_limits{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_MEMORY_UTILIZATION: |
+              (sum by (namespace, pod) (container_memory_working_set_bytes{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}) /
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"})) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_REQUEST_CPU: |
+              sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_REQUEST_MEMORY_BYTES: |
+              sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_USED_CPU_AVG: |
+              sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}[5m]) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_USED_MEMORY_BYTES_AVG: |
+              sum by (namespace, pod) (container_memory_working_set_bytes{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      metrics:
+        scope: 'dataproxy:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    cloudEventsProcessor:
+      cloudProvider: Local
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      debug: 'false'
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    eventsProxy:
+      recorderType: RunService
+    executions:
+      app:
+        adminClient:
+          connection:
+            authorizationHeader: flyte-authorization
+            clientId: 'test-internal-client-id'
+            clientSecretLocation: /etc/secrets/union/client_secret
+            endpoint: flyteadmin.union.svc.cluster.local:81
+            insecure: true
+            scopes:
+            - 'all'
+            tokenUrl: 'https://test.example.com/oauth2/v1/token'
+      apps:
+        enrichIdentities: false
+        publicURLPattern: https://%s.apps.test.example.com
+      llm:
+        enabled: false
+      task:
+        clusterCacheConfig:
+          ttl: 10m
+        enabled: true
+        enrichIdentities: false
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      metrics:
+        scope: 'executions:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+    workspace:
+      enable: false
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: true
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    identity:
+      app:
+        adminClient:
+          connection:
+            authorizationHeader: flyte-authorization
+            clientId: 'test-internal-client-id'
+            clientSecretLocation: /etc/secrets/union/client_secret
+            insecure: true
+            scopes:
+            - 'all'
+            tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        identityProviderConfig:
+          provider: noop
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      debug: 'false'
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    organizations:
+      bootStrapConfig:
+        organizations:
+        - 'test-org'
+        tenantType: SELF_MANAGED
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'organizations:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: queue
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: queue
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    queue:
+      db:
+        hosts:
+        - 'scylla-client.union.svc.cluster.local'
+        threadCount: 64
+        type: cql
+      eventer:
+        recordActionThreadCount: 16
+        type: runservice
+        updateActionStatusThreadCount: 16
+    sharedService:
+      metrics:
+        scope: 'queue:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: run-scheduler
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: run-scheduler
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      debug: 'false'
+      host: ''
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      metrics:
+        scope: 'run-scheduler:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    billing:
+      enable: false
+    cache:
+      identity:
+        enabled: false
+    cloudProvider:
+      provider: Mock
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      connectPort: 8081
+      metrics:
+        scope: 'usage:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+    usage:
+      taskMetrics:
+        agentQuery:
+          mappings:
+            dgx_job:
+              queries:
+                EXECUTION_METRIC_ALLOCATED_CPU_AVG: CPU_ALLOCATION:MEAN
+                EXECUTION_METRIC_ALLOCATED_MEMORY_BYTES_AVG: MEM_ALLOCATION:MEAN
+                EXECUTION_METRIC_CPU_UTILIZATION: CPU_UTILIZATION:MEAN
+                EXECUTION_METRIC_GPU_UTILIZATION: GPU_UTILIZATION:MEAN
+                EXECUTION_METRIC_MEMORY_UTILIZATION: MEM_UTILIZATION:MEAN
+        metricDelayToleranceDuration: 0s
+        promQuery:
+          queries:
+            EXECUTION_METRIC_ALLOCATED_CPU_AVG: |
+              max by (namespace, pod) (
+                (
+                  sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}[5m])) >
+                  sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"})
+                )
+                or
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"})
+              ) *
+              on (namespace, pod) group_left max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_ALLOCATED_MEMORY_BYTES_AVG: |
+              max by (namespace, pod) (
+                (
+                  sum by (namespace, pod) (container_memory_working_set_bytes{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}) >
+                  sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"})
+                )
+                or
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"})
+              ) *
+              on (namespace, pod) group_left max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_APP_REPLICA_COUNT: |
+              sum (kube_pod_status_phase{phase=~"Running|Pending", namespace="{{.Namespace}}", pod=~"{{.AppName}}.*"} == 1) or vector(0)
+            EXECUTION_METRIC_APP_REQUESTS: |
+              sum(rate((
+                envoy_cluster_upstream_rq_xx{
+                  job="serving-envoy",
+                  project=~"{{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, envoy_response_code_class)
+            EXECUTION_METRIC_APP_RESPONSE_TIME_P50: |
+              histogram_quantile(0.5, sum(rate((
+                envoy_cluster_upstream_rq_time_bucket{
+                  job="serving-envoy",
+                  project=~"${{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, le))
+            EXECUTION_METRIC_APP_RESPONSE_TIME_P90: |
+              histogram_quantile(0.90, sum(rate((
+                envoy_cluster_upstream_rq_time_bucket{
+                  job="serving-envoy",
+                  project=~"${{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, le))
+            EXECUTION_METRIC_APP_RESPONSE_TIME_P95: |
+              histogram_quantile(0.95, sum(rate((
+                envoy_cluster_upstream_rq_time_bucket{
+                  job="serving-envoy",
+                  project=~"${{.Project}}",
+                  domain=~"{{.Domain}}",
+                  name=~"{{.AppName}}",
+                  name!=""}
+              )[5m:])) by (project, domain, name, le))
+            EXECUTION_METRIC_CPU_UTILIZATION: |
+              (sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}[5m])) /
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"})) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_GPU_FRAME_BUFFER_UTILIZATION: |
+              (sum by (namespace, pod, gpu) (DCGM_FI_DEV_FB_USED{namespace="{{.Namespace}}",pod=~"{{.PodName}}"}) /
+                sum by (namespace, pod, gpu) (DCGM_FI_DEV_FB_USED{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} + DCGM_FI_DEV_FB_FREE{namespace="{{.Namespace}}",pod=~"{{.PodName}}"})) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_GPU_MEMORY_UTILIZATION: |
+              sum by (gpu) (DCGM_FI_DEV_MEM_COPY_UTIL{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)) / 100.0
+            EXECUTION_METRIC_GPU_SM_ACTIVE: |
+              sum by (gpu) (DCGM_FI_PROF_SM_ACTIVE{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_GPU_SM_OCCUPANCY: |
+              sum by (gpu) (DCGM_FI_PROF_SM_OCCUPANCY{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_GPU_UTILIZATION: |
+              sum by (gpu) (DCGM_FI_DEV_GPU_UTIL{namespace="{{.Namespace}}",pod=~"{{.PodName}}"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)) / 100.0
+            EXECUTION_METRIC_LIMIT_CPU: |
+              sum by (namespace, pod) (kube_pod_container_resource_limits{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_LIMIT_MEMORY_BYTES: |
+              sum by (namespace, pod) (kube_pod_container_resource_limits{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_MEMORY_UTILIZATION: |
+              (sum by (namespace, pod) (container_memory_working_set_bytes{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}) /
+                sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"})) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1)
+            EXECUTION_METRIC_REQUEST_CPU: |
+              sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="cpu"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_REQUEST_MEMORY_BYTES: |
+              sum by (namespace, pod) (kube_pod_container_resource_requests{namespace="{{.Namespace}}",pod=~"{{.PodName}}",resource="memory"} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_USED_CPU_AVG: |
+              sum by (namespace, pod) (irate(container_cpu_usage_seconds_total{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""}[5m]) *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+            EXECUTION_METRIC_USED_MEMORY_BYTES_AVG: |
+              sum by (namespace, pod) (container_memory_working_set_bytes{namespace="{{.Namespace}}",pod=~"{{.PodName}}",image!=""} *
+              on (namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{namespace="{{.Namespace}}",pod=~"{{.PodName}}",phase=~"Pending|Running"} == 1))
+      workers: 10
+---
+# Source: controlplane/templates/flyteadmin-private-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flyte-admin-private-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    #app.kubernetes.io/managed-by: Helm
+data:
+  private.yaml: |
+    app:
+      cacheProviderConfig:
+        kind: bypass
+      populateUserFields: false
+
+---
+# Source: controlplane/templates/leasor/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: leasor
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: leasor
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    leasor:
+      db:
+        cql:
+          hosts:
+          - 'scylla-client.union.svc.cluster.local'
+          keyspace: leasor
+        type: CQL
+      numBuckets: 512
+      partitions:
+      - - 0
+      shardIndex: 0
+      skipPartitionCheckForDevbox: true
+      totalPartitions: 1
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      metrics:
+        scope: 'leasor:'
+      security:
+        singleTenantOrgID: 'test-org'
+      selfServeConfig:
+        legacyHosts:
+        - 'test-org'
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+
+---
+# Source: controlplane/templates/monitoring/dashboard-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-dashboard-union-controlplane-overview
+  namespace: union
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/managed-by: Helm
+data:
+  union-controlplane-overview.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "description": "Union Controlplane health and service metrics",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "title": "Health",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "auto"
+          },
+          "title": "Service Availability",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "avg(kube_deployment_status_replicas_available{namespace=\"$namespace\"} / kube_deployment_spec_replicas{namespace=\"$namespace\"})",
+              "legendFormat": "Availability",
+              "refId": "A"
+            }
+          ],
+          "description": "Percentage of deployments with all requested replicas available. 1.0 = all healthy."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 3
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "auto"
+          },
+          "title": "Pod Restarts (1h)",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}[1h]))",
+              "legendFormat": "Restarts",
+              "refId": "A"
+            }
+          ],
+          "description": "Total container restarts in the last hour. Non-zero indicates crashlooping or OOM kills."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 7,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "auto"
+          },
+          "title": "Connect Error Rate",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "sum(rate(connect:server_requests_handled_total{namespace=\"$namespace\", code!~\"0|OK|Canceled|NotFound\"}[$__rate_interval])) / sum(rate(connect:server_requests_handled_total{namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "Error %",
+              "refId": "A"
+            }
+          ],
+          "description": "Fraction of Connect RPC responses with non-OK/non-Canceled codes across all CP services."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "none"
+                }
+              },
+              "unit": "reqps"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "title": "Connect Request Rate by Service",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "sum by (service) (rate(connect:server_requests_handled_total{namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "description": "Connect protocol request throughput broken down by service (e.g. ExecutionService, ClusterService)."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "showPoints": "never"
+              },
+              "unit": "reqps"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "title": "Connect Errors by Code",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "sum by (code) (rate(connect:server_requests_handled_total{namespace=\"$namespace\", code!~\"0|OK|Canceled|NotFound\"}[$__rate_interval]))",
+              "legendFormat": "{{ code }}",
+              "refId": "A"
+            }
+          ],
+          "description": "Connect error responses by gRPC status code (Internal, Unavailable, etc.)."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "id": 11,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "value_and_name"
+          },
+          "title": "Handler Panics",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "sum(authorizer:handler_panic{namespace=\"$namespace\"} + cluster:handler_panic{namespace=\"$namespace\"} + dataproxy:handler_panic{namespace=\"$namespace\"} + executions:handler_panic{namespace=\"$namespace\"} + queue:handler_panic{namespace=\"$namespace\"} + usage:handler_panic{namespace=\"$namespace\"})",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "description": "Total handler panics across all CP services. Any non-zero value indicates a service caught a panic during request handling."
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 1200,
+          "title": "SLOs",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.99
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.999
+                  }
+                ]
+              },
+              "unit": "percentunit",
+              "decimals": 3
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 10
+          },
+          "id": 1201,
+          "title": "Service Availability",
+          "type": "stat",
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "expr": "avg(kube_deployment_status_replicas_available{namespace=\"$namespace\"} / kube_deployment_spec_replicas{namespace=\"$namespace\"})",
+              "refId": "A"
+            }
+          ],
+          "description": "Current service availability across all deployments."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": -999
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.5
+                  }
+                ]
+              },
+              "unit": "percentunit",
+              "decimals": 1,
+              "noValue": "N/A"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 10
+          },
+          "id": 1202,
+          "title": "Error Budget Remaining",
+          "type": "stat",
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "expr": "union:cp:slo:error_budget_remaining",
+              "refId": "A"
+            }
+          ],
+          "description": "Fraction of error budget remaining. <0 = budget exhausted. Requires monitoring.slos.enabled."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.95
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.999
+                  }
+                ]
+              },
+              "unit": "percentunit",
+              "decimals": 2,
+              "noValue": "N/A"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 10
+          },
+          "id": 1203,
+          "title": "Ingress Success Rate",
+          "type": "stat",
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "expr": "union:cp:slo:ingress_success_rate or (1 - sum(rate(nginx_ingress_controller_request_duration_seconds_count{namespace=\"$namespace\", status=~\"5..\"}[5m])) / sum(rate(nginx_ingress_controller_request_duration_seconds_count{namespace=\"$namespace\"}[5m])))",
+              "refId": "A"
+            }
+          ],
+          "description": "Ingress success rate (non-5xx). Customer-facing SLO metric. Falls back to raw metric if SLO recording rules are not enabled."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 2
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "s",
+              "decimals": 2
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 10
+          },
+          "id": 1204,
+          "title": "Ingress Latency p99",
+          "type": "stat",
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "expr": "union:cp:slo:ingress_latency_p99 or histogram_quantile(0.99, sum by (le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m])))",
+              "refId": "A"
+            }
+          ],
+          "description": "Ingress p99 latency. Falls back to raw metric if SLO recording rules are not enabled."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "showPoints": "never"
+              },
+              "unit": "percentunit"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 1205,
+          "title": "Availability Over Time",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "avg(kube_deployment_status_replicas_available{namespace=\"$namespace\"} / kube_deployment_spec_replicas{namespace=\"$namespace\"})",
+              "legendFormat": "Availability",
+              "refId": "A"
+            },
+            {
+              "expr": "vector(0.999)",
+              "legendFormat": "Target (99.9%)",
+              "refId": "B"
+            }
+          ],
+          "description": "Service availability over time with SLO target line.",
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "min",
+                "max",
+                "lastNotNull"
+              ]
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "showPoints": "never"
+              },
+              "unit": "percentunit",
+              "max": 1,
+              "min": -0.5
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 1206,
+          "title": "Error Budget Burn Rate",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "union:cp:slo:error_budget_remaining",
+              "legendFormat": "Budget remaining",
+              "refId": "A"
+            },
+            {
+              "expr": "vector(0)",
+              "legendFormat": "Exhausted",
+              "refId": "B"
+            }
+          ],
+          "description": "Error budget remaining over time. Requires monitoring.slos.enabled.",
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "min",
+                "max",
+                "lastNotNull"
+              ]
+            }
+          }
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 31
+          },
+          "id": 100,
+          "title": "Ingress (nginx)",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "reqps"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 10
+              },
+              "id": 101,
+              "title": "Request Rate by Path",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{ host }}{{ path }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Ingress request rate broken down by host and URL path.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "reqps"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 10
+              },
+              "id": 102,
+              "title": "Error Rate by Status Code",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (status) (rate(nginx_ingress_controller_request_duration_seconds_count{namespace=\"$namespace\", status=~\"[45]..\"}[$__rate_interval]))",
+                  "legendFormat": "{{ status }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "4xx and 5xx error rates from ingress-nginx by HTTP status code.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 18
+              },
+              "id": 103,
+              "title": "Latency p50 / p95 / p99",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.50, sum by (le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum by (le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p95",
+                  "refId": "B"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum by (le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "description": "Ingress request latency percentiles. Includes TLS + routing + upstream response time.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 18
+              },
+              "id": 104,
+              "title": "Active Connections",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum(nginx_ingress_controller_nginx_process_connections{namespace=\"$namespace\"})",
+                  "legendFormat": "Active",
+                  "refId": "A"
+                }
+              ],
+              "description": "Current number of active client connections to ingress-nginx.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 200,
+          "title": "Connect / gRPC",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "reqps"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 11
+              },
+              "id": 201,
+              "title": "Connect Request Rate by Service",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (service) (rate(connect:server_requests_handled_total{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{ service }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Connect protocol request throughput broken down by service (e.g. ExecutionService, ClusterService).",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "reqps"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 11
+              },
+              "id": 202,
+              "title": "Connect Errors by Service & Code",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (service, code) (rate(connect:server_requests_handled_total{namespace=\"$namespace\", code!~\"0|OK|Canceled|NotFound\"}[$__rate_interval]))",
+                  "legendFormat": "{{ service }} {{ code }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Connect errors broken down by service and gRPC code. Identifies which services are erroring.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "reqps"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 19
+              },
+              "id": 203,
+              "title": "gRPC Server Request Rate (CacheService)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (grpc_service, grpc_method) (rate(grpc_server_handled_total{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{ grpc_service }}/{{ grpc_method }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "CacheService is the only CP service using gRPC (not Connect). Shows Get/Put/Delete/Reservation rates.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "reqps"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 19
+              },
+              "id": 204,
+              "title": "gRPC Server Errors (CacheService)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", grpc_code!=\"OK\"}[$__rate_interval]))",
+                  "legendFormat": "{{ grpc_method }} {{ grpc_code }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "CacheService gRPC errors by method and code.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "id": 300,
+          "title": "FlyteAdmin",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 12
+              },
+              "id": 301,
+              "title": "Active Executions",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "flyte:admin:execution_manager:active_executions{namespace=\"$namespace\"}",
+                  "legendFormat": "Workflows",
+                  "refId": "A"
+                },
+                {
+                  "expr": "flyte:admin:node_execution_manager:active_node_executions{namespace=\"$namespace\"}",
+                  "legendFormat": "Nodes",
+                  "refId": "B"
+                },
+                {
+                  "expr": "flyte:admin:task_execution_manager:active_executions{namespace=\"$namespace\"}",
+                  "legendFormat": "Tasks",
+                  "refId": "C"
+                }
+              ],
+              "description": "Current count of active workflow, node, and task executions tracked by FlyteAdmin.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 12
+              },
+              "id": 302,
+              "title": "Execution Create / Event Rate",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(flyte:admin:execution_manager:executions_created{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Executions created",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(flyte:admin:execution_manager:execution_events_created{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Workflow events",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(flyte:admin:node_execution_manager:node_execution_events_created{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Node events",
+                  "refId": "C"
+                },
+                {
+                  "expr": "rate(flyte:admin:task_execution_manager:task_execution_events_created{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Task events",
+                  "refId": "D"
+                }
+              ],
+              "description": "Rate of execution creations and event ingestion (workflow, node, task events from propeller).",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 12
+              },
+              "id": 303,
+              "title": "Errors",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(flyte:admin:execution_manager:propeller_failures{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Propeller failures",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(flyte:admin:execution_manager:transformer_error{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Transformer errors",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(flyte:admin:execution_manager:publish_error{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Publish errors",
+                  "refId": "C"
+                },
+                {
+                  "expr": "rate(flyte:admin:execution_manager:execution_termination_failure{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Termination failures",
+                  "refId": "D"
+                }
+              ],
+              "description": "FlyteAdmin error rates: propeller communication failures, model transform errors, notification publish failures.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 20
+              },
+              "id": 304,
+              "title": "Endpoint Latency (p95)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "flyte:admin:create_execution:duration_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
+                  "legendFormat": "CreateExecution",
+                  "refId": "A"
+                },
+                {
+                  "expr": "flyte:admin:create_execution_event:duration_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
+                  "legendFormat": "CreateExecutionEvent",
+                  "refId": "B"
+                },
+                {
+                  "expr": "flyte:admin:get_execution:duration_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
+                  "legendFormat": "GetExecution",
+                  "refId": "C"
+                },
+                {
+                  "expr": "flyte:admin:list_execution:duration_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
+                  "legendFormat": "ListExecution",
+                  "refId": "D"
+                }
+              ],
+              "description": "FlyteAdmin gRPC endpoint latency at p95. Key endpoints: CreateExecution, CreateExecutionEvent, GetExecution.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 20
+              },
+              "id": 305,
+              "title": "Auth Middleware Decisions",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(flyte:middleware:authorization:authz_approved{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Approved",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(flyte:middleware:authorization:authz_denied{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Denied",
+                  "refId": "B"
+                }
+              ],
+              "description": "Authorization approve/deny rate from the FlyteAdmin auth middleware. High deny rate may indicate auth misconfiguration.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 34
+          },
+          "id": 400,
+          "title": "Executions (V2)",
+          "type": "row",
+          "panels": [
+            {
+              "title": "CreateRun Rate",
+              "type": "timeseries",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(connect:server_requests_handled_total{namespace=\"$namespace\", method=\"CreateRun\"}[$__rate_interval]))",
+                  "legendFormat": "CreateRun",
+                  "refId": "A"
+                }
+              ],
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 0
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "title": "CreateRun Latency (p50 / p95 / p99)",
+              "type": "timeseries",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.50, sum by (le) (rate(connect:server_request_duration_seconds_bucket{namespace=\"$namespace\", method=\"CreateRun\"}[$__rate_interval])))",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum by (le) (rate(connect:server_request_duration_seconds_bucket{namespace=\"$namespace\", method=\"CreateRun\"}[$__rate_interval])))",
+                  "legendFormat": "p95",
+                  "refId": "B"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum by (le) (rate(connect:server_request_duration_seconds_bucket{namespace=\"$namespace\", method=\"CreateRun\"}[$__rate_interval])))",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 0
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "title": "V2 Run Methods",
+              "type": "timeseries",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (method) (rate(connect:server_requests_handled_total{namespace=\"$namespace\", service=~\".*RunService.*\"}[$__rate_interval]))",
+                  "legendFormat": "{{method}}",
+                  "refId": "A"
+                }
+              ],
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 0
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 20
+              },
+              "id": 405,
+              "title": "DB Operation Rate",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (op) (rate(label_replace({__name__=~\"executions:database:postgres:repositories:execution_ops:.*_count\", namespace=\"$namespace\"}, \"op\", \"$1\", \"__name__\", \"executions:database:postgres:repositories:execution_ops:(.*)_count\")[$__rate_interval:]))",
+                  "legendFormat": "{{ op }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Execution operations DB latency: create, ack, claim, unclaim, get, update.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 20
+              },
+              "id": 406,
+              "title": "DB Errors",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(executions:database:postgres:errors:gorm_error{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "gorm_error",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(executions:database:postgres:errors:postgres_error{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "postgres_error",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(executions:database:postgres:errors:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "not_found",
+                  "refId": "C"
+                }
+              ],
+              "description": "Executions service Postgres error rates by type: gorm errors, native postgres errors, not-found.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 28
+              },
+              "id": 407,
+              "title": "Cluster Cache Hit/Miss",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(executions:executions:list_clusters:hits{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Cluster hits",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(executions:executions:list_clusters:miss{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Cluster miss",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(executions:executions:list_nodepools:hits{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Nodepool hits",
+                  "refId": "C"
+                },
+                {
+                  "expr": "rate(executions:executions:list_nodepools:miss{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Nodepool miss",
+                  "refId": "D"
+                }
+              ],
+              "description": "Cluster and nodepool list cache effectiveness. High miss rate = excessive DB queries.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 28
+              },
+              "id": 408,
+              "title": "Apps \u2014 Pending Assignments",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "executions:app:leaser:pending_assignment_unlabeled{namespace=\"$namespace\"}",
+                  "legendFormat": "Pending",
+                  "refId": "A"
+                }
+              ],
+              "description": "Number of apps waiting for cluster assignment. Growing backlog = scheduling bottleneck.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 36
+              },
+              "id": 409,
+              "title": "Apps \u2014 First Ack Latency",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.50, sum by (le) (rate(executions:app:service:first_ack_latency_unlabeled_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum by (le) (rate(executions:app:service:first_ack_latency_unlabeled_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p95",
+                  "refId": "B"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum by (le) (rate(executions:app:service:first_ack_latency_unlabeled_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "description": "Key V2 SLI: time to deliver an app to the dataplane. Measures end-to-end scheduling latency.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 36
+              },
+              "id": 410,
+              "title": "V2 Run Dispatch",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(executions:run:runs_sent{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Runs sent",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(executions:run:actions_sent{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Actions sent",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(executions:run:enqueue_action_failures{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Enqueue failures",
+                  "refId": "C"
+                }
+              ],
+              "description": "V2 run/action dispatch throughput. Enqueue failures indicate queue service issues.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 36
+              },
+              "id": 411,
+              "title": "V2 Run Notifier",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(executions:run_notifier:notifications_sent{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Notifications/s",
+                  "refId": "A"
+                },
+                {
+                  "expr": "executions:run_notifier:subscribers{namespace=\"$namespace\"}",
+                  "legendFormat": "Subscribers",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(executions:run:logs:tail_logs_bytes_read{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Log bytes/s",
+                  "refId": "C"
+                }
+              ],
+              "description": "V2 notification pipeline: notifications sent per second, active subscribers, log bytes streamed.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 34
+          },
+          "id": 500,
+          "title": "Queue / Run-Scheduler",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 13
+              },
+              "id": 501,
+              "title": "Metadata Store Counts",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "queue:metadata_store:total_run_count{namespace=\"$namespace\"}",
+                  "legendFormat": "Total runs",
+                  "refId": "A"
+                },
+                {
+                  "expr": "queue:metadata_store:total_action_count{namespace=\"$namespace\"}",
+                  "legendFormat": "Total actions",
+                  "refId": "B"
+                },
+                {
+                  "expr": "queue:metadata_store:scheduled_run_count{namespace=\"$namespace\"}",
+                  "legendFormat": "Scheduled runs",
+                  "refId": "C"
+                },
+                {
+                  "expr": "queue:metadata_store:scheduled_action_count{namespace=\"$namespace\"}",
+                  "legendFormat": "Scheduled actions",
+                  "refId": "D"
+                }
+              ],
+              "description": "Total and scheduled run/action counts in the queue. Shows system load.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 13
+              },
+              "id": 502,
+              "title": "Scheduler / Runner / Aborter Throughput",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(queue:scheduler:enqueued_leases{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Enqueued",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(queue:runner:completed_leases{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Completed",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(queue:aborter:aborted_leases{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Aborted",
+                  "refId": "C"
+                }
+              ],
+              "description": "Lease lifecycle throughput: enqueued (new), completed (done), aborted (cancelled).",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 13
+              },
+              "id": 503,
+              "title": "Queue Lengths",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "queue:scheduler:input_queue_length{namespace=\"$namespace\"}",
+                  "legendFormat": "Scheduler input",
+                  "refId": "A"
+                },
+                {
+                  "expr": "queue:runner:input_queue_length{namespace=\"$namespace\"}",
+                  "legendFormat": "Runner input",
+                  "refId": "B"
+                },
+                {
+                  "expr": "queue:aborter:input_queue_length{namespace=\"$namespace\"}",
+                  "legendFormat": "Aborter input",
+                  "refId": "C"
+                },
+                {
+                  "expr": "queue:dispatcher:chain_queue_length{namespace=\"$namespace\"}",
+                  "legendFormat": "Dispatcher chain",
+                  "refId": "D"
+                },
+                {
+                  "expr": "queue:db:queue_length{namespace=\"$namespace\"}",
+                  "legendFormat": "DB queue",
+                  "refId": "E"
+                }
+              ],
+              "description": "Internal queue depths across scheduler, runner, aborter, dispatcher, and DB worker pool. Growing = backpressure.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 21
+              },
+              "id": 504,
+              "title": "Dispatcher Operation Duration (p99)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.99, sum by (type, le) (rate(queue:dispatcher:operation_duration_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "{{ type }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Dispatcher multi-step operation chain execution time at p99, by operation type.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 21
+              },
+              "id": 505,
+              "title": "State Get/Put Duration (p99)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.99, sum by (le) (rate(queue:state:get_duration_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "Get p99",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum by (le) (rate(queue:state:put_duration_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "Put p99",
+                  "refId": "B"
+                }
+              ],
+              "description": "In-memory state store operation latency. Backed by ScyllaDB persistence.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 21
+              },
+              "id": 506,
+              "title": "State Cache & Eventer",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "queue:state:active_states{namespace=\"$namespace\"}",
+                  "legendFormat": "Active states",
+                  "refId": "A"
+                },
+                {
+                  "expr": "queue:state:terminal_states{namespace=\"$namespace\"}",
+                  "legendFormat": "Terminal states",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(queue:eventer:record_action_errors{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Eventer errors",
+                  "refId": "C"
+                }
+              ],
+              "description": "Active/terminal state counts and eventer error rate. Eventer reports action status to executions service.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 29
+              },
+              "id": 507,
+              "title": "Worker Capacity",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "queue:scheduler:worker_capacity{namespace=\"$namespace\"}",
+                  "legendFormat": "{{ worker_name }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Remaining execution capacity per connected DP worker. Zero = worker saturated.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 29
+              },
+              "id": 508,
+              "title": "Dispatcher Failures by Type",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (type) (rate(queue:dispatcher:operation_failures{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{ type }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Failed dispatcher operations by Go type. Indicates internal queue service errors.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 29
+              },
+              "id": 509,
+              "title": "DB & Client Thread Pool",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "queue:db:free_threads{namespace=\"$namespace\"}",
+                  "legendFormat": "DB free threads",
+                  "refId": "A"
+                },
+                {
+                  "expr": "queue:queue_client:free_threads{namespace=\"$namespace\"}",
+                  "legendFormat": "Queue client free",
+                  "refId": "B"
+                },
+                {
+                  "expr": "queue:state_client:free_threads{namespace=\"$namespace\"}",
+                  "legendFormat": "State client free",
+                  "refId": "C"
+                }
+              ],
+              "description": "Idle worker goroutines in DB, queue-client, and state-client pools. Zero = all threads busy.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 600,
+          "title": "Cluster Service",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 14
+              },
+              "id": 601,
+              "title": "UpdateStatus / Heartbeat Rate",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(cluster:svc:update_status:updates_total{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "UpdateStatus",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(cluster:svc:heartbeat:success_ms_count{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Heartbeat",
+                  "refId": "B"
+                }
+              ],
+              "description": "Rate of DP cluster status updates and heartbeats received by the cluster service.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 14
+              },
+              "id": 602,
+              "title": "Cluster API Latency (p99)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "cluster:svc:update_status:success_ms{namespace=\"$namespace\", quantile=\"0.95\"} / 1000",
+                  "legendFormat": "UpdateStatus p95",
+                  "refId": "A"
+                },
+                {
+                  "expr": "cluster:svc:heartbeat:success_ms{namespace=\"$namespace\", quantile=\"0.99\"} / 1000",
+                  "legendFormat": "Heartbeat p95",
+                  "refId": "B"
+                }
+              ],
+              "description": "Cluster service RPC latency for UpdateStatus and Heartbeat calls.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 14
+              },
+              "id": 603,
+              "title": "Operator / Propeller Restarts (from DP)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "cluster:svc:update_status:operator_restarts{namespace=\"$namespace\"}",
+                  "legendFormat": "Operator restarts",
+                  "refId": "A"
+                },
+                {
+                  "expr": "cluster:svc:update_status:propeller_restarts{namespace=\"$namespace\"}",
+                  "legendFormat": "Propeller restarts",
+                  "refId": "B"
+                }
+              ],
+              "description": "DP-reported restart counts for operator and propeller pods. Set by DP on each UpdateStatus call.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 22
+              },
+              "id": 604,
+              "title": "DB Errors by Type",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(cluster:database:postgres:errors:gorm_error{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "gorm_error",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(cluster:database:postgres:errors:postgres_error{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "postgres_error",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(cluster:database:postgres:errors:not_found{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "not_found",
+                  "refId": "C"
+                }
+              ],
+              "description": "Cluster service Postgres error rates by type: gorm errors, native postgres errors, not-found.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "0": {
+                          "text": "Healthy",
+                          "color": "green"
+                        },
+                        "1": {
+                          "text": "Unhealthy",
+                          "color": "red"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 22
+              },
+              "id": 605,
+              "title": "Cluster Health Status",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "cluster:cluster_sync:health:unhealthy{namespace=\"$namespace\", subsystem=\"\"}",
+                  "legendFormat": "{{ org }}/{{ cluster_name }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Cluster health collector: 1=unhealthy, 0=healthy. Emitted per cluster on every Prometheus scrape.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 30
+              },
+              "id": 606,
+              "title": "Last Heartbeat Age (stale cluster detection)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "cluster:cluster_sync:health:last_update_age{namespace=\"$namespace\"}",
+                  "legendFormat": "{{ org }}/{{ cluster_name }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Seconds since each cluster last sent a heartbeat. High values = stale/disconnected cluster.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 30
+              },
+              "id": 607,
+              "title": "Managed Cluster Cache",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(cluster:managed_cluster_client_cache:get:hits{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Cache hits",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(cluster:managed_cluster_client_cache:get:miss{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Cache miss",
+                  "refId": "B"
+                }
+              ],
+              "description": "LRU cache hit/miss rate for managed cluster lookups. High miss rate = excessive DB queries.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 900,
+          "title": "CacheService",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 15
+              },
+              "id": 901,
+              "title": "Cache Hit / Miss Rate",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(flyte:cacheservice:cache:cache_hit_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Hits",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(flyte:cacheservice:cache:not_found_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Misses",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(flyte:cacheservice:cache:get_failure_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Get failures",
+                  "refId": "C"
+                }
+              ],
+              "description": "CacheService hit/miss rate. Hits = cached task output reused. Misses = task must execute. Get failures = storage errors. [Metrics pending: requires cloud service instrumentation to be deployed]",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 15
+              },
+              "id": 902,
+              "title": "Reservation Contention & Operations",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(flyte:cacheservice:cache:reservation_contention_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Contention",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(flyte:cacheservice:cache:get_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Reservation acquired",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(flyte:cacheservice:cache:release_reservation_success_unlabeled{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Reservation released",
+                  "refId": "C"
+                }
+              ],
+              "description": "Cache reservation contention: how often workers are blocked waiting for another worker's cache computation. High contention = many workers computing the same task. [Metrics pending: requires cloud service instrumentation to be deployed]",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 750,
+          "title": "Authorizer",
+          "type": "row",
+          "panels": [
+            {
+              "id": 760,
+              "title": "Authorizer Mode",
+              "type": "stat",
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 0,
+                "y": 37
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "textMode": "name",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                }
+              },
+              "targets": [
+                {
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authz_type_info{namespace=\"$namespace\"} == 1",
+                  "legendFormat": "{{type}}",
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 751,
+              "title": "Allow / Deny Rate",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 10,
+                "x": 4,
+                "y": 37
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "spanNulls": false
+                  },
+                  "noValue": "0",
+                  "unit": "ops",
+                  "decimals": 2
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*denied.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*allowed.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "allowed ({{identity_type}})",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "denied ({{identity_type}})",
+                  "refId": "B"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 753,
+              "title": "Deny Rate (%)",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 10,
+                "x": 14,
+                "y": 37
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.1
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.5
+                      }
+                    ]
+                  },
+                  "noValue": "0",
+                  "decimals": 1,
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "(sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval])) or vector(0)) / clamp_min((sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval])) + sum by (identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))), 1e-10)",
+                  "legendFormat": "{{identity_type}}",
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 752,
+              "title": "Authorize Latency (service)",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 45
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "ms",
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "noValue": "0",
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "red",
+                        "value": 200
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "legendFormat": "p90",
+                  "refId": "B"
+                },
+                {
+                  "expr": "authorizer:authorizer:cloudauthorizer:connect:authorize_duration_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 761,
+              "title": "Backend Latency",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 45
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "ms",
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "noValue": "0",
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "red",
+                        "value": 200
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.50, sum by (le) (rate(authorizer:authorizer:cloudauthorizer:connect:backend_authorize_duration_ms_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum by (le) (rate(authorizer:authorizer:cloudauthorizer:connect:backend_authorize_duration_ms_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p95",
+                  "refId": "B"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum by (le) (rate(authorizer:authorizer:cloudauthorizer:connect:backend_authorize_duration_ms_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 764,
+              "title": "Decisions by Action",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 45
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 50,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "noValue": "0",
+                  "unit": "ops",
+                  "decimals": 2
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (action, identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_allowed{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{action}} {{identity_type}} (allowed)",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum by (action, identity_type) (rate(authorizer:authorizer:cloudauthorizer:connect:authz_denied{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{action}} {{identity_type}} (denied)",
+                  "refId": "B"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 762,
+              "title": "Backend Errors",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 53
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "noValue": "0",
+                  "unit": "ops",
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.01
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (error_type) (rate(authorizer:authorizer:cloudauthorizer:connect:backend_authorize_errors{namespace=\"$namespace\"}[$__rate_interval])) or vector(0)",
+                  "legendFormat": "{{error_type}}",
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 765,
+              "title": "Error Attribution",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 53
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "noValue": "0",
+                  "unit": "ops",
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.01
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (error_source) (rate(authorizer:authorizer:cloudauthorizer:connect:authorize_errors_total{namespace=\"$namespace\"}[$__rate_interval])) or vector(0)",
+                  "legendFormat": "{{error_source}}",
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            },
+            {
+              "id": 763,
+              "title": "Fail-Open Activations",
+              "type": "timeseries",
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 53
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.001
+                      }
+                    ]
+                  },
+                  "noValue": "0",
+                  "unit": "ops",
+                  "decimals": 2
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                },
+                "tooltip": {
+                  "mode": "multi"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "rate(authorizer:authorizer:cloudauthorizer:connect:external:fail_open_activated{namespace=\"$namespace\"}[$__rate_interval]) or vector(0)",
+                  "legendFormat": "fail-open",
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 700,
+          "title": "Data Proxy",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 15
+              },
+              "id": 701,
+              "title": "Cache Hit/Miss Rates",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(dataproxy:domains:hits{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Domain hits",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(dataproxy:domains:miss{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Domain miss",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(dataproxy:clusterpoolcache:hits{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "ClusterPool hits",
+                  "refId": "C"
+                },
+                {
+                  "expr": "rate(dataproxy:clusterpoolcache:miss{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "ClusterPool miss",
+                  "refId": "D"
+                }
+              ],
+              "description": "DataProxy internal cache effectiveness for domain resolution, cluster pool routing, and namespace mapping.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "s"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 15
+              },
+              "id": 702,
+              "title": "Image Read Latency (p95)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.95, sum by (le) (rate(dataproxy:images:read:success_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "legendFormat": "Success p95",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum by (le) (rate(dataproxy:images:read:failure_ms_count{namespace=\"$namespace\"}[$__rate_interval]))) / 1000",
+                  "legendFormat": "Failure p95",
+                  "refId": "B"
+                }
+              ],
+              "description": "Time to read image metadata from the dataplane, proxied through DataProxy.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 23
+              },
+              "id": 703,
+              "title": "Secret Proxy Errors by Cluster",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (cluster, operation) (rate(dataproxy:secrets_service:cluster_errors{namespace=\"$namespace\"}[$__rate_interval]))",
+                  "legendFormat": "{{ cluster }} {{ operation }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Per-cluster secret proxy errors during fan-out operations. Identifies which dataplane cluster is causing failures. [Metrics pending: requires cloud service instrumentation to be deployed]",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 37
+          },
+          "id": 800,
+          "title": "Usage Service",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 16
+              },
+              "id": 801,
+              "title": "Billable Usage Reports",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(usage:svc:report_billable_usage{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Reports/s",
+                  "refId": "A"
+                }
+              ],
+              "description": "Rate of ReportBillableUsage calls from DP clusters. Each call reports resource consumption for billing.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 16
+              },
+              "id": 802,
+              "title": "Message Pipeline",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "rate(usage:messages:messages_received{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Received",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(usage:messages:messages_sent{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Sent",
+                  "refId": "B"
+                },
+                {
+                  "expr": "rate(usage:messages:messages_dropped{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Dropped",
+                  "refId": "C"
+                },
+                {
+                  "expr": "rate(usage:messages:messages_failed{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "Failed",
+                  "refId": "D"
+                }
+              ],
+              "description": "SQS/queue message processing: received, sent (success), failed, dropped (max retries exceeded).",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "ops"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 24
+              },
+              "id": 803,
+              "title": "Messages by Type (success)",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (message_type) (rate(usage:messages:messages_processed{namespace=\"$namespace\", outcome=\"success\"}[$__rate_interval]))",
+                  "legendFormat": "{{ message_type }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Successful message processing rate by type: node_execution, workflow_execution, billable_usage, serverless_billable_usage. [Metrics pending: requires cloud service instrumentation to be deployed]",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "ms"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 24
+              },
+              "id": 804,
+              "title": "Message Processing Latency",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.5\"}",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.9\"}",
+                  "legendFormat": "p90",
+                  "refId": "B"
+                },
+                {
+                  "expr": "usage:messages:processing_time_ms{namespace=\"$namespace\", quantile=\"0.99\"}",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "description": "Time to process individual queue messages. Slow processing may indicate backend API issues (Metronome, timestream). [Metrics pending: requires cloud service instrumentation to be deployed]",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 38
+          },
+          "id": 1100,
+          "title": "Infrastructure",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 17
+              },
+              "id": 1101,
+              "title": "CPU Usage by Service",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+                  "legendFormat": "{{ container }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "CPU usage in cores per container, stacked. Identifies resource-heavy services.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "bytes"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 17
+              },
+              "id": 1102,
+              "title": "Memory Usage by Service",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
+                  "legendFormat": "{{ container }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Working set memory per container, stacked. Watch for approaching limits.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 80,
+                    "lineWidth": 1,
+                    "showPoints": "never"
+                  },
+                  "unit": "short"
+                }
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 25
+              },
+              "id": 1103,
+              "title": "Pod Restart Count by Container",
+              "type": "timeseries",
+              "targets": [
+                {
+                  "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}[$__rate_interval])",
+                  "legendFormat": "{{ pod }}/{{ container }}",
+                  "refId": "A"
+                }
+              ],
+              "description": "Per-container restart events. Spikes indicate crashes or OOM kills.",
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "calcs": [
+                    "min",
+                    "max",
+                    "lastNotNull"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [
+        "union",
+        "controlplane"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data Source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "union",
+              "value": "union"
+            },
+            "hide": 2,
+            "label": "Namespace",
+            "name": "namespace",
+            "options": [
+              {
+                "selected": true,
+                "text": "union",
+                "value": "union"
+              }
+            ],
+            "query": "union",
+            "type": "constant"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Union Controlplane Overview",
+      "uid": "union-controlplane-overview",
+      "version": 2
+    }
+    
+
+---
+# Source: controlplane/templates/scylla/storageclass.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: scylladb
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+
+---
+# Source: controlplane/charts/flyte/templates/admin/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: union-flyteadmin
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: 
+    - ""
+    - flyte.lyft.com
+    - rbac.authorization.k8s.io
+  resources: 
+    - configmaps
+    - flyteworkflows
+    - namespaces
+    - pods
+    - resourcequotas
+    - roles
+    - rolebindings
+    - secrets
+    - services
+    - serviceaccounts
+    - spark-role
+    - limitranges
+  verbs: 
+    - '*'
+---
+# Source: controlplane/charts/ingress-nginx/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+  name: controlplane-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
+      - get
+
+---
+# Source: controlplane/charts/scylla-operator/templates/edit_clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scyllacluster-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scyllaclusters
+  - scylladbmonitorings
+  - scylladbdatacenters
+  - scylladbclusters
+  - scylladbmanagerclusterregistrations
+  - scylladbmanagertasks
+  verbs:
+  - create
+  - patch
+  - update
+  - delete
+  - deletecollection
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator.clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:controller:operator
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.operator.scylladb.com/aggregate-to-scylla-operator: "true"
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator.clusterrole_def.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:controller:aggregate-to-operator
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylla-operator: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/scale
+  verbs:
+  - update
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scyllaclusters
+  - scylladbmonitorings
+  - scylladbdatacenters
+  - remotekubernetesclusters
+  - scylladbclusters
+  - scylladbmanagerclusterregistrations
+  - scylladbmanagertasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scyllaclusters/status
+  - scylladbmonitorings/status
+  - scylladbdatacenters/status
+  - remotekubernetesclusters/status
+  - scylladbclusters/status
+  - scylladbmanagerclusterregistrations/status
+  - scylladbmanagertasks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - nodeconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - nodeconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scyllaoperatorconfigs
+  - scyllaoperatorconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheuses
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/finalizers
+  - secrets/finalizers
+  - pods/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scyllaclusters/finalizers
+  - scylladbdatacenters/finalizers
+  - scylladbmonitorings/finalizers
+  - scylladbmanagerclusterregistrations/finalizers
+  - scylladbmanagertasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - nodeconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/finalizers
+  - secrets/finalizers
+  - pods/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator.clusterrole_def_openshift.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:controller:aggregate-to-operator-openshift
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylla-operator: "true"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator_remote.clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:controller:operator-remote
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.operator.scylladb.com/aggregate-to-scylla-operator-remote: "true"
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator_remote.clusterrole_def.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:controller:aggregate-to-operator-remote
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylla-operator-remote: "true"
+rules:
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scylladbdatacenters
+  - remoteowners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scylladbdatacenters/status
+  - remoteowners/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - namespaces
+  - services
+  - secrets
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scyllacluster_member_clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scyllacluster-member
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.operator.scylladb.com/aggregate-to-scylla-member: "true"
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:aggregate-to-scyllacluster-member
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylla-member: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/finalizers
+  - secrets/finalizers
+  verbs:
+  - update
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scyllacluster_member_clusterrole_def_openshift.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:aggregate-to-scyllacluster-member-openshift
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylla-member: "true"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scylladbmonitoring_grafana_clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:monitoring:grafana
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.operator.scylladb.com/aggregate-to-scylladb-monitoring-grafana: "true"
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scylladbmonitoring_grafana_clusterrole_def_openshift.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:aggregate-to-scylladb-monitoring-grafana-openshift
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylladb-monitoring-grafana: "true"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scylladbmonitoring_prometheus_clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:monitoring:prometheus
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.operator.scylladb.com/aggregate-to-scylladb-monitoring-prometheus: "true"
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scylladbmonitoring_prometheus_clusterrole_def.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:aggregate-to-scylladb-monitoring-prometheus
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylladb-monitoring-prometheus: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+
+---
+# Source: controlplane/charts/scylla-operator/templates/scylladbmonitoring_prometheus_clusterrole_def_openshift.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylladb:aggregate-to-scylladb-monitoring-prometheus-openshift
+  labels:
+    rbac.operator.scylladb.com/aggregate-to-scylladb-monitoring-prometheus: "true"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+
+---
+# Source: controlplane/charts/scylla-operator/templates/view_clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scyllacluster-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - scyllaclusters
+  - scylladbmonitorings
+  - scylladbdatacenters
+  - scylladbclusters
+  - scylladbmanagerclusterregistrations
+  - scylladbmanagertasks
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Source: controlplane/charts/flyte/templates/admin/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: union-flyteadmin-binding
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: union-flyteadmin
+subjects:
+- kind: ServiceAccount
+  name: flyteadmin
+  namespace: union
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+  name: controlplane-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: controlplane-nginx
+subjects:
+  - kind: ServiceAccount
+    name: controlplane-nginx
+    namespace: union
+
+---
+# Source: controlplane/charts/scylla-operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scylladb:controller:operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scylladb:controller:operator
+subjects:
+- kind: ServiceAccount
+  name: scylla-operator
+  namespace: scylla-operator
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx
+  namespace: union
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  # Omit Ingress status permissions if `--update-status` is disabled.
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - controlplane-nginx-leader
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
+      - get
+
+---
+# Source: controlplane/templates/actions/coordination.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: actions-coordination
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+  resourceNames: ["actions-coordination"]
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flyteadmin
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    #app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+      - flyte.lyft.com
+      - rbac.authorization.k8s.io
+    resources:
+      - configmaps
+      - flyteworkflows
+      - namespaces
+      - pods
+      - resourcequotas
+      - roles
+      - rolebindings
+      - secrets
+      - services
+      - serviceaccounts
+      - spark-role
+    verbs:
+      - '*'
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx
+  namespace: union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controlplane-nginx
+subjects:
+  - kind: ServiceAccount
+    name: controlplane-nginx
+    namespace: union
+
+---
+# Source: controlplane/templates/actions/coordination.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: actions-coordination
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: actions-coordination
+subjects:
+- kind: ServiceAccount
+  name: actions
+  namespace: union
+
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flyteadmin-binding
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    #app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flyteadmin
+subjects:
+  - kind: ServiceAccount
+    name: flyteadmin
+    namespace: union
+---
+# Source: controlplane/charts/flyte/templates/admin/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteadmin
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8088
+    - name: grpc
+      port: 81
+      protocol: TCP
+      # intentionally set to TCP instead of grpc
+      targetPort: 8089
+    - name: redoc
+      protocol: TCP
+      port: 87
+      targetPort: 8087
+    - name: http-metrics
+      protocol: TCP
+      port: 10254
+  selector: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+
+---
+# Source: controlplane/charts/flyte/templates/console/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: flyteconsole
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteconsole
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+  annotations: 
+    external-dns.alpha.kubernetes.io/hostname: flyte.example.com
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "600"
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector: 
+    app.kubernetes.io/name: flyteconsole
+    app.kubernetes.io/instance: release-name
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-service-metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx-controller-metrics
+  namespace: union
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 10254
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: controller
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx-controller
+  namespace: union
+spec:
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+    - IPv4
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      appProtocol: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: controller
+
+---
+# Source: controlplane/charts/scylla-operator/templates/webhookserver.service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: scylla-operator
+  name: scylla-operator-webhook
+  labels:
+    app.kubernetes.io/name: webhook-server
+    app.kubernetes.io/instance: webhook-server
+spec:
+  ports:
+  - port: 443
+    targetPort: 5000
+    name: webhook
+  selector:
+    app.kubernetes.io/name: webhook-server
+    app.kubernetes.io/instance: webhook-server
+
+---
+# Source: controlplane/templates/actions/router-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: admin
+      port: 9901
+      protocol: TCP
+      targetPort: 9901
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: 8089
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: router
+
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-0-f288b103
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "0"
+    shard-hash: f288b103
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "0"
+    shard-hash: f288b103
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-1-f6a76bed
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "1"
+    shard-hash: f6a76bed
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "1"
+    shard-hash: f6a76bed
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-2-44d51338
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "2"
+    shard-hash: 44d51338
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "2"
+    shard-hash: 44d51338
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-3-0e2fc543
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "3"
+    shard-hash: 0e2fc543
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "3"
+    shard-hash: 0e2fc543
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-4-b7f95723
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "4"
+    shard-hash: b7f95723
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "4"
+    shard-hash: b7f95723
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-5-3d7905f8
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "5"
+    shard-hash: 3d7905f8
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "5"
+    shard-hash: 3d7905f8
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-6-a7e57068
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "6"
+    shard-hash: a7e57068
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "6"
+    shard-hash: a7e57068
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-7-a5084d4e
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "7"
+    shard-hash: a5084d4e
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "7"
+    shard-hash: a5084d4e
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-8-2e085e60
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "8"
+    shard-hash: 2e085e60
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "8"
+    shard-hash: 2e085e60
+---
+# Source: controlplane/templates/actions/service-shard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: actions-9-cf8e9eab
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "9"
+    shard-hash: cf8e9eab
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: http
+      port: 8089
+      protocol: TCP
+      targetPort: 8089
+    - name: debug
+      port: 10254
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    shard-index: "9"
+    shard-hash: cf8e9eab
+
+---
+# Source: controlplane/templates/cacheservice/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cacheservice
+  namespace: union
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 88
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 89
+    protocol: TCP
+    targetPort: grpc
+  - name: http-metrics
+    protocol: TCP
+    port: 10254
+  selector: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+
+---
+# Source: controlplane/templates/console/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: unionconsole
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: unionconsole
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  - port: 8081
+    targetPort: http-metrics
+    protocol: TCP
+    name: http-metrics
+  selector:
+    app.kubernetes.io/name: unionconsole
+    app.kubernetes.io/instance: release-name
+
+---
+# Source: controlplane/templates/service.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authorizer
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dataproxy
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: executions
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: leasor
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: leasor
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: leasor
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: organizations
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: queue
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: queue
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: queue
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: run-scheduler
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: run-scheduler
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: run-scheduler
+    app.kubernetes.io/instance: release-name
+---
+# Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: usage
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: connect
+    - name: grpc-native
+      port: 8080
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+
+---
+# Source: controlplane/charts/flyte/templates/admin/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flyteadmin
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: flyteadmin
+      app.kubernetes.io/instance: release-name
+  strategy: 
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        configChecksum: "a47f70dd39aa636afb5d25ffe53ec0785c33272fcc33b02d5f2066d8e65eeeb"
+        kubectl.kubernetes.io/default-container: flyteadmin
+      labels: 
+        app.kubernetes.io/name: flyteadmin
+        app.kubernetes.io/instance: release-name
+        helm.sh/chart: flyte-v1.16.1
+        #app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext: 
+        fsGroup: 65534
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        runAsUser: 1001
+        seLinuxOptions:
+          type: spc_t
+      initContainers:
+        - command:
+          - flyteadmin
+          - --config
+          - /etc/flyte/*/*.yaml
+          - migrate
+          - run
+          image: "registry.unionai.cloud/controlplane/services:"
+          imagePullPolicy: "IfNotPresent"
+          name: run-migrations
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+          - mountPath: /etc/db
+            name: union-controlplane-secrets
+          - mountPath: /etc/flyte/config
+            name: base-config-volume
+        - command:
+          - flyteadmin
+          - --config
+          - /etc/flyte/*/*.yaml
+          - migrate
+          - seed-projects
+          - union-health-monitoring
+          - flytesnacks
+          image: "registry.unionai.cloud/controlplane/services:"
+          imagePullPolicy: "IfNotPresent"
+          name: seed-projects
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+          - mountPath: /etc/db
+            name: union-controlplane-secrets
+          - mountPath: /etc/flyte/config
+            name: base-config-volume
+        - name: generate-secrets
+          image: "registry.unionai.cloud/controlplane/services:"
+          imagePullPolicy: "IfNotPresent"
+          command: ["/bin/sh", "-c"]
+          args:
+            [
+                "flyteadmin --config=/etc/flyte/*/*.yaml secrets init --localPath /etc/scratch/secrets && flyteadmin --config=/etc/flyte/config/*.yaml secrets create --name flyte-admin-secrets --fromPath /etc/scratch/secrets",
+            ]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - mountPath: /etc/flyte/config
+              name: base-config-volume
+            - mountPath: /etc/scratch
+              name: scratch
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      containers:
+      - command:
+        - flyteadmin
+        - --config
+        - /etc/flyte/*/*.yaml
+        - serve
+        image: "registry.unionai.cloud/controlplane/services:"
+        imagePullPolicy: "IfNotPresent"
+        name: flyteadmin
+        ports:
+        - containerPort: 8088
+        - containerPort: 8089
+        - containerPort: 10254
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8088
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8088
+          initialDelaySeconds: 20
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 2
+            ephemeral-storage: 500Mi
+            memory: 3Gi
+          requests:
+            cpu: 50m
+            ephemeral-storage: 200Mi
+            memory: 500Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - mountPath: /etc/db
+          name: union-controlplane-secrets
+        - mountPath: /srv/flyte
+          name: shared-data
+        - mountPath: /etc/flyte/config
+          name: clusters-config-volume
+        - mountPath: /etc/secrets/
+          name: admin-secrets
+        - mountPath: /etc/secrets/union
+          name: union-secrets
+          readOnly: true
+        - mountPath: /etc/flyte/private
+          name: private-config
+          readOnly: true
+      serviceAccountName: flyteadmin
+      volumes:
+      - name: union-controlplane-secrets
+        secret:
+          secretName: union-controlplane-secrets
+      - emptyDir: {}
+        name: shared-data
+      - emptyDir: {}
+        name: scratch
+      - projected:
+          sources:
+            - configMap:
+                name: flyte-admin-base-config
+        name: base-config-volume
+      - projected:
+          sources:
+            - configMap:
+                name: flyte-admin-base-config
+            - configMap:
+                name: flyte-admin-clusters-config
+        name: clusters-config-volume
+      - name: admin-secrets
+        secret:
+          secretName: flyte-admin-secrets
+      - name: union-secrets
+        secret:
+          secretName: ''
+      - configMap:
+          name: flyte-admin-private-config
+        name: private-config
+
+---
+# Source: controlplane/charts/flyte/templates/console/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flyteconsole
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteconsole
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: flyteconsole
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        configChecksum: "2620ed20cf30d64460b231bbcf13fc096a23b6d373b46e69ab5f2e051f3d3d1"
+        linkerd.io/inject: disabled
+        prometheus.io/scrape: "false"
+      labels: 
+        app.kubernetes.io/name: flyteconsole
+        app.kubernetes.io/instance: release-name
+        helm.sh/chart: flyte-v1.16.1
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      securityContext: 
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+        runAsUser: 1000
+        seLinuxOptions:
+          type: spc_t
+      containers:
+      - image: "registry.unionai.cloud/controlplane/flyteconsole:"
+        imagePullPolicy: "IfNotPresent"
+        name: flyteconsole
+        envFrom:
+        - configMapRef:
+            name: flyte-console-config
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ENABLE_GA
+          value: "true"
+        - name: GA_TRACKING_ID
+          value: ""
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources: 
+          limits:
+            cpu: 250m
+            ephemeral-storage: 200Mi
+            memory: 250Mi
+          requests:
+            cpu: 10m
+            ephemeral-storage: 20Mi
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /srv/flyte
+          name: shared-data
+      volumes:
+      - emptyDir: {}
+        name: shared-data
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane-nginx-controller
+  namespace: union
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/component: controller
+  replicas: 1
+  revisionHistoryLimit: 10
+  minReadySeconds: 0
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: ingress-nginx-4.12.3
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/version: "1.12.3"
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: controller
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: controller
+          image: registry.k8s.io/ingress-nginx/controller:v1.12.3@sha256:ac444cd9515af325ba577b596fe4f27a34be1aa330538e8b317ad9d6c8fb94ee
+          imagePullPolicy: IfNotPresent
+          lifecycle: 
+            preStop:
+              exec:
+                command:
+                - /wait-shutdown
+          args: 
+            - /nginx-ingress-controller
+            - --publish-service=$(POD_NAMESPACE)/controlplane-nginx-controller
+            - --election-id=controlplane-nginx-leader
+            - --controller-class=union.ai/controlplane
+            - --ingress-class=nginx
+            - --configmap=$(POD_NAMESPACE)/controlplane-nginx-controller
+            - --enable-metrics=true
+          securityContext: 
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 82
+            allowPrivilegeEscalation: false
+            seccompProfile: 
+              type: RuntimeDefault
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - NET_BIND_SERVICE
+            readOnlyRootFilesystem: false
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
+          livenessProbe: 
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe: 
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            - name: metrics
+              containerPort: 10254
+              protocol: TCP
+          resources: 
+            requests:
+              cpu: 100m
+              memory: 90Mi
+      nodeSelector: 
+        kubernetes.io/os: linux
+      serviceAccountName: controlplane-nginx
+      terminationGracePeriodSeconds: 300
+
+---
+# Source: controlplane/charts/scylla-operator/templates/operator.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scylla-operator
+  namespace: scylla-operator
+  labels:
+    app.kubernetes.io/name: scylla-operator
+    app.kubernetes.io/instance: scylla-operator
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scylla-operator
+      app.kubernetes.io/instance: scylla-operator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: scylla-operator
+        app.kubernetes.io/instance: scylla-operator
+    spec:
+      serviceAccountName: scylla-operator
+      containers:
+      - name: scylla-operator
+        image: scylladb/scylla-operator:1.18.1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: SCYLLA_OPERATOR_IMAGE
+          value: scylladb/scylla-operator:1.18.1
+        args:
+        - operator
+        - --loglevel=2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: scylla-operator
+                  app.kubernetes.io/name: scylla-operator
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+
+---
+# Source: controlplane/charts/scylla-operator/templates/webhookserver.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: scylla-operator
+  name: webhook-server
+  labels:
+    app.kubernetes.io/name: webhook-server
+    app.kubernetes.io/instance: webhook-server
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook-server
+      app.kubernetes.io/instance: webhook-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: webhook-server
+        app.kubernetes.io/instance: webhook-server
+    spec:
+      serviceAccountName: "webhook-server"
+      containers:
+      - name: webhook-server
+        image: scylladb/scylla-operator:1.18.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - run-webhook-server
+        - --loglevel=2
+        - --tls-cert-file=/tmp/serving-certs/tls.crt
+        - --tls-private-key-file=/tmp/serving-certs/tls.key
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 5000
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 5000
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/bin/sleep
+              - 15s
+        ports:
+        - containerPort: 5000
+          name: webhook-server
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /tmp/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 75
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: scylla-operator-serving-cert
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: webhook-server
+                  app.kubernetes.io/name: webhook-server
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-0-f288b103
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "0"
+    shard-hash: f288b103
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "0"
+      shard-hash: f288b103
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "0"
+        shard-hash: f288b103
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "0"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-1-f6a76bed
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "1"
+    shard-hash: f6a76bed
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "1"
+      shard-hash: f6a76bed
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "1"
+        shard-hash: f6a76bed
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "1"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-2-44d51338
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "2"
+    shard-hash: 44d51338
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "2"
+      shard-hash: 44d51338
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "2"
+        shard-hash: 44d51338
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "2"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-3-0e2fc543
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "3"
+    shard-hash: 0e2fc543
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "3"
+      shard-hash: 0e2fc543
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "3"
+        shard-hash: 0e2fc543
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "3"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-4-b7f95723
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "4"
+    shard-hash: b7f95723
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "4"
+      shard-hash: b7f95723
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "4"
+        shard-hash: b7f95723
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "4"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-5-3d7905f8
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "5"
+    shard-hash: 3d7905f8
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "5"
+      shard-hash: 3d7905f8
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "5"
+        shard-hash: 3d7905f8
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "5"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-6-a7e57068
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "6"
+    shard-hash: a7e57068
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "6"
+      shard-hash: a7e57068
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "6"
+        shard-hash: a7e57068
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "6"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-7-a5084d4e
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "7"
+    shard-hash: a5084d4e
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "7"
+      shard-hash: a5084d4e
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "7"
+        shard-hash: a5084d4e
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "7"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-8-2e085e60
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "8"
+    shard-hash: 2e085e60
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "8"
+      shard-hash: 2e085e60
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "8"
+        shard-hash: 2e085e60
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "8"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-9-cf8e9eab
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "9"
+    shard-hash: cf8e9eab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "9"
+      shard-hash: cf8e9eab
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "9"
+        shard-hash: cf8e9eab
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.6.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "9"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+
+---
+# Source: controlplane/templates/actions/router-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-router
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: router
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/component: router
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/router-bootstrap: 1c2e26c6e262800262fda890a936b453e5bd23cdf5d4a0edf506c59b7118450f
+        checksum/router-cds: c41bb826f84979f3c112c7fb483555a2147b1d845865d6221ac4374d0682413c
+        checksum/router-lds: adfeb49aa22059f0546881e99c454aa77932e50caf0be9c7b43df6e6530a45e2
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "9901"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: router
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: envoy-bootstrap
+          configMap:
+            name: actions-router
+            items:
+            - key: envoy.yaml
+              path: envoy.yaml
+        - name: envoy-cds
+          configMap:
+            name: actions-router-cds
+            items:
+            - key: cds.yaml
+              path: cds.yaml
+        - name: envoy-lds
+          configMap:
+            name: actions-router-lds
+            items:
+            - key: lds.yaml
+              path: lds.yaml
+      containers:
+        - name: envoy
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - envoy
+            - -c
+            - /etc/envoy/envoy.yaml
+            - --service-cluster
+            - actions-service-router
+            - --service-node
+            - $(THIS_POD_NAME)
+          env:
+            - name: THIS_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: admin
+              containerPort: 9901
+              protocol: TCP
+          volumeMounts:
+            - name: envoy-bootstrap
+              mountPath: /etc/envoy/envoy.yaml
+              subPath: envoy.yaml
+            - name: envoy-cds
+              mountPath: /etc/envoy/cds.yaml
+              subPath: cds.yaml
+            - name: envoy-lds
+              mountPath: /etc/envoy/lds.yaml
+              subPath: lds.yaml
+          resources:
+            limits:
+              cpu: 2
+              memory: 2Gi
+            requests:
+              cpu: 1
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: admin
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: router
+              topologyKey: "kubernetes.io/hostname"
+
+---
+# Source: controlplane/templates/cacheservice/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cacheservice
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: cacheservice
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: cacheservice
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        configChecksum: "813b3a9c178c54928714e56eaf830d8862d800931fa82435b7d654bad5c29bd"
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        
+        app.kubernetes.io/name: cacheservice
+        app.kubernetes.io/instance: release-name
+        helm.sh/chart: controlplane-2026.6.1
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext: 
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+        runAsUser: 1001
+        seLinuxOptions:
+          type: spc_t
+      initContainers:
+      - command:
+        - cacheservice
+        - --config
+        - /etc/cacheservice/config/*.yaml
+        - migrate
+        - run
+        image: "registry.unionai.cloud/controlplane/services:"
+        imagePullPolicy: "IfNotPresent"
+        name: run-migrations
+        volumeMounts:
+        - mountPath: /etc/db
+          name: union-controlplane-secrets
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      containers:
+      - command:
+        - cacheservice
+        - --config
+        - /etc/cacheservice/config/*.yaml
+        - serve
+        image: "registry.unionai.cloud/controlplane/services:"
+        imagePullPolicy: "IfNotPresent"
+        name: cacheservice
+        ports:
+        - name: http
+          containerPort: 8088
+        - name: grpc
+          containerPort: 8089
+        - name: http-metrics
+          containerPort: 10254
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: 1
+            ephemeral-storage: 200Mi
+          requests:
+            cpu: 500m
+            ephemeral-storage: 200Mi
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/db
+          name: union-controlplane-secrets
+        - mountPath: /etc/cacheservice/config
+          name: config-volume
+        - mountPath: /etc/secrets/union
+          name: union-secrets
+          readOnly: true
+      serviceAccountName: cacheservice
+      volumes:
+      - name: union-controlplane-secrets
+        secret:
+          secretName: union-controlplane-secrets
+      - emptyDir: {}
+        name: shared-data
+      - configMap:
+          name: cacheservice-config
+        name: config-volume
+      - name: union-secrets
+        secret:
+          secretName: ''
+      affinity: 
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cacheservice
+            topologyKey: kubernetes.io/hostname
+
+---
+# Source: controlplane/templates/console/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unionconsole
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: unionconsole
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unionconsole
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: unionconsole
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: unionconsole
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: unionconsole
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+        runAsUser: 1000
+        seLinuxOptions:
+          type: spc_t
+      containers:
+      - name: unionconsole
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.0"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        - name: http-metrics
+          containerPort: 8081
+          protocol: TCP
+        env:
+          - name: UNION_ORG_OVERRIDE
+            value: 'test-org'
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 250Mi
+
+---
+# Source: controlplane/templates/deployment.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authorizer
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: authorizer
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authorizer
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: authorizer
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: authorizer
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: authorizer
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: authorizer
+      containers:
+        - name: authorizer
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - authorizer
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: authorizer
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: cluster
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: cluster
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: cluster
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: cluster
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: cluster
+      initContainers:
+        - name: cluster-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudcluster
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: cluster
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudcluster
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: cluster
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dataproxy
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: dataproxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dataproxy
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: dataproxy
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: dataproxy
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: dataproxy
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: dataproxy
+      containers:
+        - name: dataproxy
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - dataproxy
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: dataproxy
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: executions
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: executions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: executions
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: executions
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: executions
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: executions
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: executions
+      initContainers:
+        - name: executions-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudpropeller
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: executions
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudpropeller
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: executions
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: identity
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: identity
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: identity
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: identity
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: identity
+      containers:
+        - name: identity
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudidentity
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: identity
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: leasor
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: leasor
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: leasor
+      app.kubernetes.io/instance: release-name
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: leasor
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: leasor
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: leasor
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: leasor
+      initContainers:
+        - name: leasor-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - leasor
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: leasor
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - leasor
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 2
+                memory: 4Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: leasor
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: organizations
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: organizations
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: organizations
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: organizations
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: organizations
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: organizations
+      initContainers:
+        - name: organizations-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+        - name: organizations-bootstrap
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudorganizations
+          - bootstrap-tenant
+          - organizations
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: organizations
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudorganizations
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: organizations
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: queue
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: queue
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: queue
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: queue
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: queue
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: queue
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: queue
+      initContainers:
+        - name: queue-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - queue
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: queue
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - queue
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: queue
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: run-scheduler
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: run-scheduler
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: run-scheduler
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: run-scheduler
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: run-scheduler
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: run-scheduler
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: run-scheduler
+      initContainers:
+        - name: run-scheduler-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - cloudpropeller
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: run-scheduler
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - cloudpropeller
+            - scheduler
+            - start
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: run-scheduler
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usage
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: usage
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: usage
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: usage
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        app.kubernetes.io/name: usage
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: usage
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: usage
+      containers:
+        - name: usage
+          image: registry.unionai.cloud/controlplane/services:2026.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - usage
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+            - name: connect
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 3
+                memory: 512Mi
+              requests:
+                cpu: 500m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: usage
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
+
+---
+# Source: controlplane/charts/flyte/templates/admin/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: flyteadmin
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: flyteadmin
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    #app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: flyteadmin
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+
+---
+# Source: controlplane/templates/console/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: unionconsole
+  labels:
+    helm.sh/chart: controlplane-2026.6.1
+    app.kubernetes.io/name: unionconsole
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: unionconsole
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+
+---
+# Source: controlplane/templates/hpa.yaml
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authorizer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: authorizer
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cluster
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cluster
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: dataproxy
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: dataproxy
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: executions
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: executions
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: identity
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: identity
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: organizations
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: organizations
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: run-scheduler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: run-scheduler
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: usage
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: usage
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-ingressclass.yaml
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.12.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "1.12.3"
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: controlplane
+spec:
+  controller: union.ai/controlplane
+
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-dataproxy
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /data/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /data
+            pathType: Prefix
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-usage-grpc
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /cloudidl.usage.UsageService(/(?!GetCustomMeasuresNames|GetMeasureGroup|GetMeasureGroups|GetBillableMeasures|GetBillingInfo|ReportBillableUsage|ReportServerlessBillableUsage|CreateCustomer|AttachBillingPlanToCustomer|GetCustomerCredits|EnqueueMetronomeRequest|EnqueueStripeRequest|GetOrgCheckoutSession).*|$)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-usage
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /usage/api/v1(/(?!custom_measures_names|measure_group|measure_groups|billable_measures|billing_info|report_billable_usage|customer_credits|checkout_session).*|$)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-protected
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /api
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /api/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /cloudadmin
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /cloudadmin/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /actor
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /actor/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /agent
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /agent/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /dataplane
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /dataplane/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /spark-history-server
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /spark-history-server/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /api/v1/dataproxy
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /api/v1/dataproxy/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: http
+          - path: /app
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /app/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /apps
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /apps/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: http
+          - path: /cluster
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /cluster/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterpool
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterpool/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterconfig
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /clusterconfig/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /org
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: http
+          - path: /org/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: http
+          - path: /managed_cluster
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /managed_cluster/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: http
+          - path: /authorizer
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: http
+          - path: /authorizer/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: http
+          - path: /oauth_app
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /oauth_app/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /users
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /users/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /members
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /members/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /roles
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /roles/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /policies
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /policies/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /identities
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /identities/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: http
+          - path: /echo
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /echo/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /execution
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /execution/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_registry
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_registry/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_instance
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /workspace_instance/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: execution
+                port:
+                  name: http
+          - path: /usage
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /usage/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-protected-grpc
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /cloudidl.execution.ExecutionService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.execution.ExecutionService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /flyteidl2.cluster.ClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterNodepoolService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ClusterNodepoolService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.apikey.APIKeyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.apikey.APIKeyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.AppsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.AppsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.org.OrgService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: grpc
+          - path: /cloudidl.org.OrgService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: organizations
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudaccounts.CloudAccountsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudaccounts.CloudAccountsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: grpc
+          - path: /cloudidl.cluster.ManagedClusterService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.cluster.ManagedClusterService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.identity.UserService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.UserService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.MemberService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.MemberService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.RoleService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.RoleService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.PolicyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.PolicyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: connect
+          - path: /cloudidl.identity.SelfServe/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.SelfServe
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.identity.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  name: grpc
+          - path: /cloudidl.clusterpool.ClusterPoolService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterpool.ClusterPoolService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterconfig.ClusterConfigService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.clusterconfig.ClusterConfigService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cluster
+                port:
+                  name: connect
+          - path: /cloudidl.authorizer.AuthorizerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: connect
+          - path: /cloudidl.authorizer.AuthorizerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: authorizer
+                port:
+                  name: connect
+          - path: /cloudidl.usage.UsageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+          - path: /cloudidl.usage.UsageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: connect
+          - path: /datacatalog.DataCatalog/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: datacatalog
+                port:
+                  name: grpc
+          - path: /datacatalog.DataCatalog
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: datacatalog
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.CacheService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.CacheService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.v2.CacheService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /flyteidl.cacheservice.v2.CacheService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cacheservice
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.agent.AgentService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.agent.AgentService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.secret.SecretService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.secret.SecretService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.secret.SecretService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.secret.SecretService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.support.SupportService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.clouddataproxy.CloudDataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.clouddataproxy.CloudDataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl.service.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl.service.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.dataproxy.DataProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.dataproxy.DataProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceRegistryService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceRegistryService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TriggerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TriggerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          
+          - path: /flyteidl2.workflow.RunService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.RunService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.TranslatorService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.TranslatorService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.trigger.TriggerService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.trigger.TriggerService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.imagebuilder.ImageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.imagebuilder.ImageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.imagebuilder.ImageService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.imagebuilder.ImageService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppLogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.ReplicaService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppLogsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.ReplicaService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-protected-grpc-streaming
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /flyteidl2.auth.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.project.ProjectService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.project.ProjectService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AdminService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AdminService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          
+          - path: /flyteidl.service.WatchService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          
+          - path: /flyteidl.service.WatchService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudadmin.CloudAdminService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.cloudadmin.CloudAdminService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.IdentityService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.IdentityService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.echo.EchoService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.echo.EchoService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl.service.SignalService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.SignalService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /cloudidl.actor.ActorEnvironmentService/Stream*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.execution.ExecutionService/GetExecutionOperation
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.RunService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/Record*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.InternalRunService/Update*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.TaskService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.LeaseService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.StateService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.QueueService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.LeaseService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          
+          # v2 leasor / actions / pluginState / eventsProxy — every gRPC service the
+          # leaseworker calls. Routed through the streaming ingress (long timeouts) so
+          # LeasorService.StreamLeases and ActionsService.WatchForUpdates work.
+          # Catch-all `Service` + `Service/*` pair mirrors the AdminService pattern
+          # higher up in this block.
+          - path: /cloudidl.workflow.v2.LeasorService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: leasor
+                port:
+                  name: grpc
+          - path: /cloudidl.workflow.v2.LeasorService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: leasor
+                port:
+                  name: grpc
+          - path: /flyteidl2.actions.ActionsService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: actions
+                port:
+                  name: grpc
+          - path: /flyteidl2.actions.ActionsService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: actions
+                port:
+                  name: grpc
+          - path: /cloudidl.pluginstate.PluginStateService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: actions
+                port:
+                  name: grpc
+          - path: /cloudidl.pluginstate.PluginStateService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: actions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.EventsProxyService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.EventsProxyService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          
+          - path: /flyteidl2.workflow.RunLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.RunService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.task.TaskService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/Heartbeat
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.StateService/Watch*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /flyteidl2.workflow.QueueService/StreamLeases
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: queue
+                port:
+                  name: grpc
+          - path: /cloudidl.logs.LogsService/TailTaskExecutionLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.workspace.WorkspaceInstanceService/WatchWorkspaceInstances
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/Watch
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppService/Lease
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /cloudidl.app.AppLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /cloudidl.app.ReplicaService/WatchReplicas
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/Watch
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppService/Lease
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: executions
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.AppLogsService/TailLogs
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+          - path: /flyteidl2.app.ReplicaService/WatchReplicas
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: dataproxy
+                port:
+                  name: grpc
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane
+  namespace: union
+  annotations: 
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          # Port 87 in FlyteAdmin maps to the redoc container.
+          - path: /openapi
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: redoc
+          - path: /healthcheck
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /healthz
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /me
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          # Port 87 in FlyteAdmin maps to the redoc container.
+          - path: /openapi/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: redoc
+          - path: /.well-known
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /.well-known/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /login
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /login/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /logout
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /logout/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /callback
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /callback/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /config
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /config/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /oauth2
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /oauth2/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /auth
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /auth/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: http
+          - path: /enqueue_metronome_request/v1
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_metronome_request/v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_stripe_request/v1
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+          - path: /enqueue_stripe_request/v1/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: usage
+                port:
+                  name: http
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+# Certain ingress controllers like nginx cannot serve HTTP 1 and GRPC with a single ingress because GRPC can only
+# enabled on the ingress object, not on backend services (GRPC annotation is set on the ingress, not on the services).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-grpc
+  namespace: union
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          # NOTE: Port 81 in flyteadmin is the GRPC server port for FlyteAdmin.
+          - path: /flyteidl.service.HealthService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.HealthService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AuthMetadataService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl.service.AuthMetadataService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.AuthMetadataService
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+          - path: /flyteidl2.auth.AuthMetadataService/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-grpc-streaming
+  namespace: union
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /flyteidl.service.WatchService/WatchExecutionStatusUpdates
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteadmin
+                port:
+                  name: grpc
+---
+# Source: controlplane/templates/flyte-core-app.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: controlplane-console-protected
+  namespace: union
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /v2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 32k
+    nginx.ingress.kubernetes.io/proxy-cookie-domain: ~^ .$host
+    nginx.ingress.kubernetes.io/server-alias: controlplane-nginx-controller.union.svc.cluster.local
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_timeout 604800;
+      client_body_timeout 604800;
+      # Increasing the default configuration from
+      #        client_header_buffer_size       1k;
+      #        large_client_header_buffers     4 8k;
+      # to default of 16k and 32k for large buffer sizes. These sizes are chosen as a short term mediation until we can collect data to reason
+      # about expected header sizs (PE-1101).
+      # Historically, we have seen is with the previous 8k max buffer size , the auth endpoint of /me would throw 400 Bad request and due to this ingress controller
+      # threw a 500 as it doesn't expect this status code on auth request expected range :  200 <= authcall.status(i.e status of /me call) <=300
+      # Code link for ref : https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/http/modules/ngx_http_auth_request_module.c#L170-L179
+      # Now the main reason we have seen 400 bad request is large size of the cookies which contribute to the header size.
+      # We should keep reducing the size of what headers are being sent meanwhile we increase this size to mitigate the long header issue.
+      client_header_buffer_size 16k;
+      large_client_header_buffers 64 32k;
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  ingressClassName: "controlplane"
+  tls:
+    - hosts:
+      - fake-host.domain
+      secretName: fake-host-tls-secret
+  rules:
+    - host: fake-host.domain
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          # NOTE: If you change this, you must update the BASE_URL value in flyteconsole.yaml
+          - path: /console
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /console/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /dashboard
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /dashboard/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /resources
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /resources/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /cost
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /cost/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /loading
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /loading/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flyteconsole
+                port:
+                  name: http
+          - path: /v2
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unionconsole
+                port:
+                  name: http
+          - path: /v2/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unionconsole
+                port:
+                  name: http
+---
+# Source: controlplane/charts/scylla-operator/templates/validatingwebhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: scylla-operator/scylla-operator-serving-cert
+  name: scylla-operator
+webhooks:
+- name: webhook.scylla.scylladb.com
+  clientConfig:
+    service:
+      name: scylla-operator-webhook
+      namespace: scylla-operator
+      path: /validate
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: Fail
+  rules:
+  - apiGroups:
+    - scylla.scylladb.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - scyllaclusters
+  - apiGroups:
+    - scylla.scylladb.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nodeconfigs
+    - scyllaoperatorconfigs
+    - scylladbdatacenters
+    - scylladbclusters
+    - scylladbmanagerclusterregistrations
+    - scylladbmanagertasks
+
+---
+# Source: controlplane/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+# PDB is not supported for DaemonSets.
+# https://github.com/kubernetes/kubernetes/issues/108124
+
+---
+# Source: controlplane/templates/configmap.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/pdb.yaml
+---
+---
+# Source: controlplane/templates/secret.yaml
+---
+---
+# Source: controlplane/templates/secret.yaml
+---
+---
+# Source: controlplane/templates/secret.yaml
+---
+---
+# Source: controlplane/templates/secret.yaml
+---
+---
+# Source: controlplane/templates/secret.yaml
+---
+---
+# Source: controlplane/charts/scylla-operator/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: scylla-operator-serving-cert
+  namespace: scylla-operator
+spec:
+  dnsNames:
+  - scylla-operator-webhook.scylla-operator.svc
+  issuerRef:
+    kind: Issuer
+    name: scylla-operator-selfsigned-issuer
+  secretName: scylla-operator-serving-cert
+
+---
+# Source: controlplane/charts/scylla-operator/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: scylla-operator-selfsigned-issuer
+  namespace: scylla-operator
+spec:
+  selfSigned: {}
+
+---
+# Source: controlplane/charts/scylla/templates/scyllacluster.yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylla
+  namespace: union
+spec:
+  version: 2025.1.5
+  agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
+  repository: scylladb/scylla
+  agentRepository: scylladb/scylla-manager-agent
+  developerMode: true
+  sysctls:
+    - fs.aio-max-nr=30000000
+  datacenter:
+    name: dc1
+    racks:
+    - agentResources:
+        requests:
+          cpu: 50m
+          memory: 10M
+      members: 3
+      name: rack1
+      placement:
+        nodeAffinity: {}
+        tolerations: []
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+      storage:
+        capacity: 100Gi
+        storageClassName: scylladb
+---
+# Source: controlplane/templates/image-builder-bootstrap/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  build_image_task.py: |
+    """build-image ContainerTask definition, registered automatically by the
+    controlplane chart's post-install / post-upgrade Helm hook Job
+    (see templates/image-builder-bootstrap/).
+    
+    Two env vars are required at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2
+                                 (set by the Job from .Chart.AppVersion).
+      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
+                                 frontend-v2 images live
+                                 (set by the Job from values.imageBuilder.bootstrap
+                                 .unionImageNamePrefix).
+    
+    Per-namespace defaults consumed at task execution time come from the
+    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
+    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    """
+    import os
+    
+    from kubernetes.client import (
+        V1PodSpec,
+        V1Container,
+        V1EnvVar,
+        V1VolumeMount,
+        V1EnvVarSource,
+        V1ObjectFieldSelector,
+        V1ConfigMapKeySelector,
+        V1Volume,
+        V1ProjectedVolumeSource,
+        V1VolumeProjection,
+        V1ServiceAccountTokenProjection,
+        V1ConfigMapVolumeSource,
+        V1KeyToPath,
+    )
+    
+    import flyte
+    from flyte.extras import ContainerTask
+    
+    
+    _DEFAULT_CONFIGMAP_NAME = "build-image-config"
+    _STORAGE_YAML_KEY = "storage.yaml"
+    _CONFIG_DIR = "/etc/union/config"
+    
+    config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
+    log_level = os.getenv("LOG_LEVEL", "5")
+    
+    union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
+    if not union_image_name_prefix:
+        raise ValueError("UNION_IMAGE_NAME_PREFIX environment variable must be set")
+    
+    app_version = os.getenv("APP_VERSION")
+    if not app_version:
+        raise ValueError("APP_VERSION environment variable must be set")
+    
+    build_image_task = ContainerTask(
+        name="build-image",
+        cache=flyte.Cache(behavior="auto"),
+        image=f"{union_image_name_prefix}/build-image:{app_version}",
+        inputs={"spec": str, "context": str, "target_image": str},
+        outputs={"fully_qualified_image": str},
+        pod_template=flyte.PodTemplate(
+            primary_container_name="main",
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="main",
+                        image_pull_policy="Always",
+                        termination_message_policy="FallbackToLogsOnError",
+                        volume_mounts=[
+                            V1VolumeMount(
+                                mount_path="/var/run/secrets/union/registry",
+                                name="registry-token",
+                                read_only=True,
+                            ),
+                            V1VolumeMount(
+                                name="config-volume",
+                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+                                sub_path=_STORAGE_YAML_KEY,
+                            ),
+                        ],
+                        env=[
+                            V1EnvVar(
+                                name="ORGANIZATION",
+                                value_from=V1EnvVarSource(
+                                    field_ref=V1ObjectFieldSelector(
+                                        field_path="metadata.labels['organization']"
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_BUILDKIT_URI",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="buildkit-uri",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_DEFAULT_REPOSITORY",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="default-repository",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_REGISTRY_AUTHENTICATION_TYPE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="authentication-type",
+                                    )
+                                ),
+                            ),
+                            V1EnvVar(
+                                name="UNION_IMAGE_NAME_PREFIX",
+                                value=union_image_name_prefix,
+                            ),
+                            V1EnvVar(
+                                name="FLYTE_INTERNAL_OPTIMIZE_IMAGE",
+                                value_from=V1EnvVarSource(
+                                    config_map_key_ref=V1ConfigMapKeySelector(
+                                        name=config_map_name,
+                                        key="enable-image-optimization",
+                                        optional=True,
+                                    )
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    V1Volume(
+                        name="registry-token",
+                        projected=V1ProjectedVolumeSource(
+                            sources=[
+                                V1VolumeProjection(
+                                    service_account_token=V1ServiceAccountTokenProjection(
+                                        audience="registry",
+                                        expiration_seconds=7200,
+                                        path="token",
+                                    )
+                                )
+                            ]
+                        ),
+                    ),
+                    V1Volume(
+                        name="config-volume",
+                        config_map=V1ConfigMapVolumeSource(
+                            name=config_map_name,
+                            items=[
+                                V1KeyToPath(
+                                    key=_STORAGE_YAML_KEY,
+                                    path=_STORAGE_YAML_KEY,
+                                )
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        command=[
+            "imagebuild",
+            "--logger.formatter.type=text",
+            f"--logger.level={log_level}",
+            "--context",
+            "{{.inputs.context}}",
+            "--frontend",
+            f"{union_image_name_prefix}/frontend-v2:{app_version}",
+            "--remote-outputs-prefix",
+            "{{.outputPrefix}}",
+            "--spec",
+            "{{.inputs.spec}}",
+            "--target-image",
+            "{{.inputs.target_image}}",
+            "--optimize",
+        ],
+    )
+    
+    build_image_task_env = flyte.TaskEnvironment.from_task(
+        "build_image_task", build_image_task
+    )
+    
+  flyte-config.yaml: |
+    admin:
+      authType: ClientSecret
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: 'test.example.com'
+      insecure: false
+    task:
+      org: "test-org"
+      project: "system"
+      domain: "production"
+
+---
+# Source: controlplane/templates/image-builder-bootstrap/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-build-image-bootstrap
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: union-registry-secret
+      containers:
+        - name: bootstrap
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.0"
+          env:
+            - name: APP_VERSION
+              value: "2026.6.0"
+            - name: UNION_IMAGE_NAME_PREFIX
+              value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
+            - name: FLYTECTL_CONFIG
+              value: /etc/flyte/config.yaml
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              flyte create project \
+                --id   "system" \
+                --name "Union system tasks" \
+                --description "Internal tasks registered by the controlplane chart" \
+                || echo "create project returned non-zero; continuing"
+
+              flyte deploy \
+                --version "${APP_VERSION}" \
+                --project "system" \
+                --domain  "production" \
+                /etc/build-image-task/build_image_task.py build_image_task_env
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/build-image-task
+              readOnly: true
+            - name: bootstrap-config
+              mountPath: /etc/flyte
+              readOnly: true
+            - name: client-secret
+              mountPath: /etc/secrets/union
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: build_image_task.py
+                path: build_image_task.py
+        - name: bootstrap-config
+          configMap:
+            name: release-name-build-image-bootstrap
+            items:
+              - key: flyte-config.yaml
+                path: config.yaml
+        - name: client-secret
+          secret:
+            # Same Secret all CP services mount at /etc/secrets/union/
+            # (where the INTERNAL_CLIENT_ID client_secret lives). Reuse the
+            # chart-wide defaults.secretName convention so per-env overrides
+            # of that value flow through automatically.
+            secretName: ""
+

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -9935,10 +9935,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10117,10 +10119,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10299,10 +10303,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10481,10 +10487,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10663,10 +10671,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10845,10 +10855,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11027,10 +11039,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11209,10 +11223,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11391,10 +11407,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11573,10 +11591,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -9916,10 +9916,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10098,10 +10100,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10280,10 +10284,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10462,10 +10468,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10644,10 +10652,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10826,10 +10836,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11008,10 +11020,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11190,10 +11204,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11372,10 +11388,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11554,10 +11572,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -9951,10 +9951,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10133,10 +10135,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10315,10 +10319,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10497,10 +10503,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10679,10 +10687,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10861,10 +10871,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11043,10 +11055,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11225,10 +11239,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11407,10 +11423,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11589,10 +11607,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -9934,10 +9934,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10116,10 +10118,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10298,10 +10302,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10480,10 +10486,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10662,10 +10670,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10844,10 +10854,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11026,10 +11038,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11208,10 +11222,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11390,10 +11406,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11572,10 +11590,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -9921,10 +9921,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10103,10 +10105,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10285,10 +10289,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10467,10 +10473,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10649,10 +10657,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10831,10 +10841,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11013,10 +11025,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11195,10 +11209,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11377,10 +11393,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11559,10 +11577,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -9914,10 +9914,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10096,10 +10098,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10278,10 +10282,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10460,10 +10466,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10642,10 +10650,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10824,10 +10834,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11006,10 +11018,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11188,10 +11202,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11370,10 +11386,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11552,10 +11570,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -10087,10 +10087,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10269,10 +10271,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10451,10 +10455,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10633,10 +10639,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10815,10 +10823,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -10997,10 +11007,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11179,10 +11191,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11361,10 +11375,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11543,10 +11559,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:
@@ -11725,10 +11743,12 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
+                  divisor: "1"
                   resource: limits.cpu
           resources:
             limits:

--- a/tests/values/controlplane.actions-leasor.yaml
+++ b/tests/values/controlplane.actions-leasor.yaml
@@ -1,0 +1,53 @@
+global:
+  UNION_HOST: "test.example.com"
+  UNION_ORG: "test-org"
+  INTERNAL_CLIENT_ID: "test-internal-client-id"
+  AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
+
+dbHost: "db-instance-url"
+# -- Set the DB Name used for the control plane services
+dbName: "dbName"
+# -- Set the DB user used for the control plane services
+dbUser: "dbUser"
+# -- Set the DB password used for the controlplane services
+dbPass: "dbPass"
+# -- Set the S3 bucket name used for flyte storage
+bucketName: "bucketName"
+# -- Set the S3 bucket name used for artifacts storage
+artifactsBucketName: "artifactsBucketName"
+
+configMap:
+  connection:
+    environment: staging
+    region: us-east-2
+    rootTenantURLPattern: dns:///fake-host.domain
+controlplane:
+  enabled: true
+ingress:
+  host: fake-host.domain
+  tls:
+    - hosts:
+        - fake-host.domain
+      secretName: fake-host-tls-secret
+flyte:
+  common:
+    ingress:
+      tls:
+        secretName: fake-host-tls-secret
+      host: fake-host.domain
+
+  configmap:
+    admin:
+      admin:
+        endpoint: dns:///fake-host.domain
+        insecure: false
+    # Auth disabled: the protected-ingress auth annotations must NOT render.
+    adminServer:
+      server:
+        security:
+          useAuth: false
+
+# actionsLeasor toggle on — opt this deployment's UNION_ORG into v2-actions
+# CreateRun routing and hard-reject sub-2.0.4 SDKs.
+actionsLeasor:
+  enabled: true


### PR DESCRIPTION
## Summary

Adds a deployment-wide `actionsLeasor.enabled` toggle (default `false`) to the controlplane chart. When flipped to `true`, the chart's `unionai.configMap` helper injects two opt-in values into the executions service's rendered ConfigMap:

- `useActionsServiceForOrgs: [<global.UNION_ORG>]` — the deployment's own org routes `CreateRun` through the v2 actions service.
- `rejectLegacySDKVersions: true` — sub-2.0.4 SDK `CreateRun` is hard-rejected, exercising the queue/executor decommissioning path.

This replaces the per-env hardcode in PR #426 (`runtime/selfhosted/head`'s overlay of `charts/controlplane/values.yaml`). Once this merges, fresh single-tenant selfhosted envs flip one line in their per-env `values-overrides.yaml` instead of duplicating the entire `services.executions.configMap.executions.task` block.

## Why this implementation

`useActionsServiceForOrgs` is a YAML list and `rejectLegacySDKVersions` is a YAML bool. Wiring them through a Helm template expression *inside* `values.yaml` (`'{{ .Values.actionsLeasor.enabled }}'`) would require either:

1. Encoding the bool as a quoted string (which the run service's Go YAML config parser would reject), or
2. Splitting the values out into a separate values fragment that the chart conditionally layers (which forces the operator to do two opt-ins).

Patching the unmarshalled Go map inside `unionai.configMap` keeps bool + list types native — no YAML/string coercion gymnastics — and keeps the existing `templates/configmap.yaml` rendering loop unchanged. The branch is intentionally scoped (`eq .key "executions"`) so the injection only fires for the one service that consumes these knobs.

## Migration / Deprecation Timeline

This toggle is a stepping stone toward `actionsLeasor` becoming the default and the legacy queue + executor services being removed:

| Date       | Phase                     | Customer-visible effect                                                                                                                                                                                                                         |
| ---------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 2026-06-30 | **Deprecation announced** | Queue + executor services formally marked deprecated. SDK <2.0.4 keeps working via the legacy queue path. `actionsLeasor.enabled` default remains `false`. Customers should plan to upgrade SDKs and (optionally) opt into the v2-actions path. |
| 2026-07-31 | **Complete switch-over**  | Chart default flips to `actionsLeasor.enabled: true`. Queue + executor templates/services are removed. SDK <2.0.4 `CreateRun` hard-fails. `actionsLeasor` knob retained for one more minor release for compatibility, then removed.             |

Per-audience action:

| Audience                 | Action                                                                                                                                                                                                                                                       |
| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| Managed multi-tenant CP  | None today. Track the 2026-06-30 announcement; coordinate SDK upgrade with customer base before 2026-07-31.                                                                                                                                                  |
| Selfhosted single-tenant | Set `actionsLeasor: { enabled: true }` in `values-overrides.yaml` (or via cloud-side `var.actions_leasor_enabled = true` on `union_extension/{aws,gcp}`). Confirm all in-use SDKs are >=2.0.4. After 2026-07-31, drop the override — it becomes the default. |
| BYOC                     | Coordinate SDK upgrade with operator. The chart default flip on 2026-07-31 will turn off the legacy path for any deployment that hasn't already migrated.                                                                                                    |

Full migration table lives in `charts/MIGRATION.md` (added in this PR).

## Stack

This PR targets `actions-leasor` (the in-flight PR #425 branch) so it ships alongside the rest of the actions/leasor refactor. After PR #425 merges to `main`, the toggle is on `main`.

## Test plan

- `make generate-expected` + `make test` — green.
- New fixture `tests/values/controlplane.actions-leasor.yaml` exercises the on-state with `UNION_ORG: test-org`. Generated `tests/generated/controlplane.actions-leasor.yaml` asserts:
  - `services.executions.configMap.executions.task.useActionsServiceForOrgs: [test-org]`
  - `services.executions.configMap.executions.task.rejectLegacySDKVersions: true`
- Existing off-state fixtures (`controlplane.no-auth.yaml`, `controlplane.aws.yaml`, etc.) — unchanged. Default `actionsLeasor.enabled: false` keeps the existing `[]` / `false` defaults.
- Validated end-to-end on runtime selfhosted env (cluster `runtime/selfhosted/head`): chart toggle + cloud `var.actions_leasor_enabled = true` together produce the expected configmap.

## Related

- PR #425 (`actions-leasor` → `main`): underlying v2-actions/leasor work.
- PR #426 (`runtime/selfhosted/head` → `actions-leasor`): the chart-default hardcode this toggle supersedes. **Closed** as superseded by this PR.
- Companion cloud PR <https://github.com/unionai/cloud/pull/16361> adds `var.actions_leasor_enabled` so selfmanaged envs opt in declaratively.

Slack: <https://unionai.slack.com/archives/C0A8PJ8HM2S/p1780608004132169>

- `main` <!-- branch-stack -->
  - \#425
    - **chart(controlplane): add actionsLeasor.enabled toggle** :point\_left:
