### PR TITLE
dataplane: render operator connection_config ConfigMap for self-reporting on UpdateStatus

### DIFF
--- a/charts/controlplane/examples/values.aws.intracluster.yaml
+++ b/charts/controlplane/examples/values.aws.intracluster.yaml
@@ -16,7 +16,6 @@
 # ============================================================================
 
 global:
-  # CP -> DP HTTP traffic dials the DP nginx Service directly. Bypasses the
-  # public LB and works without any additional DNS resolution outside the
-  # cluster.
-  DATAPLANE_HOST: "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
+  # CP→DP routing is handled by Phase 2 DP self-registration — the dataplane
+  # operator self-reports its CP-dial endpoint on every UpdateStatus, and the
+  # CP reads it from cluster.Spec.ConnectionConfig. No DATAPLANE_HOST needed.

--- a/charts/controlplane/examples/values.gcp.intracluster.yaml
+++ b/charts/controlplane/examples/values.gcp.intracluster.yaml
@@ -16,7 +16,6 @@
 # ============================================================================
 
 global:
-  # CP -> DP HTTP traffic dials the DP nginx Service directly. Bypasses the
-  # public LB and works without any additional DNS resolution outside the
-  # cluster.
-  DATAPLANE_HOST: "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
+  # CP→DP routing is handled by Phase 2 DP self-registration — the dataplane
+  # operator self-reports its CP-dial endpoint on every UpdateStatus, and the
+  # CP reads it from cluster.Spec.ConnectionConfig. No DATAPLANE_HOST needed.

--- a/charts/controlplane/templates/leasor/configmap.yaml
+++ b/charts/controlplane/templates/leasor/configmap.yaml
@@ -3,12 +3,23 @@
 Bespoke ConfigMap for leasor. Mirrors what the generic services renderer
 (templates/configmap.yaml) would produce — same name, same labels, same
 unionai.configMap-style merge of global .Values.configMap with
-.Values.services.leasor.configMap — and then auto-generates
-queueSync.queues from .Values.global.DATAPLANE_CLUSTER_NAME: one `default`
-queue + one per-cluster queue, both containing that single cluster name. The
-auto-generation is skipped if services.leasor.configMap.leasor.queueSync.queues
-is already set explicitly (full override — use that to enumerate clusters in
-the rare multi-DP case).
+.Values.services.leasor.configMap — then defaults each entry of
+queueSync.queues so callers can write terser overlays.
+
+Per-queue defaults injected when the field is absent from an entry:
+  org:               .Values.global.UNION_ORG  (single-tenant CP convention)
+  name:              "default"
+  priority:          50  (PriorityMedium — see cloud/leasor/config:Priority)
+  fairnessAlgorithm: 1   (FairnessRoundRobin)
+
+The caller still owns `clusters: [...]` (required — there is no sensible
+default) and any other QueueSpec field (project / domain / status /
+maxDepth / maxActionConcurrency / maxRunConcurrency).
+
+Backward compat: if `queueSync.queues` is empty AND
+.Values.global.DATAPLANE_CLUSTER_NAME is non-empty, we auto-generate a
+2-entry list ({name: default, clusters: [X]}, {name: X, clusters: [X]}).
+This path is DEPRECATED — new installs should configure queues directly.
 */ -}}
 {{- $service := dict "config" .Values.services.leasor "key" "leasor" "Release" .Release "Values" .Values "Chart" .Chart -}}
 
@@ -20,20 +31,32 @@ the rare multi-DP case).
   {{- $_ := set $merged "logger" (omit .Values.logging "pythonLevel") -}}
 {{- end -}}
 
-{{- /* Auto-generate queueSync.queues unless explicitly set. */ -}}
+{{- /* Normalize queueSync.queues. */ -}}
 {{- $leasor    := index $merged "leasor"    | default dict -}}
 {{- $queueSync := index $leasor "queueSync" | default dict -}}
 {{- $existing  := index $queueSync "queues" | default list -}}
-{{- $cluster   := .Values.global.DATAPLANE_CLUSTER_NAME | default "" -}}
-{{- $org       := .Values.global.UNION_ORG | default "" -}}
-{{- if and (eq (len $existing) 0) (ne $cluster "") (ne $org "") -}}
-  {{- $queues := list -}}
-  {{- /* default queue pointing at the attached cluster */ -}}
-  {{- $queues = append $queues (dict "org" $org "name" "default"  "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $cluster)) -}}
-  {{- /* per-cluster queue with the same name as the cluster */ -}}
-  {{- $queues = append $queues (dict "org" $org "name" $cluster   "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $cluster)) -}}
-  {{- $_ := set $queueSync "queues" $queues -}}
+{{- $defaultOrg := .Values.global.UNION_ORG | default "" -}}
+
+{{- /* DEPRECATED auto-generation from DATAPLANE_CLUSTER_NAME. */ -}}
+{{- $deprecatedCluster := .Values.global.DATAPLANE_CLUSTER_NAME | default "" -}}
+{{- if and (eq (len $existing) 0) (ne $deprecatedCluster "") (ne $defaultOrg "") -}}
+  {{- $existing = list -}}
+  {{- $existing = append $existing (dict "name" "default"          "clusters" (list $deprecatedCluster)) -}}
+  {{- $existing = append $existing (dict "name" $deprecatedCluster "clusters" (list $deprecatedCluster)) -}}
   {{- if not (hasKey $queueSync "source") -}}{{- $_ := set $queueSync "source" "static" -}}{{- end -}}
+{{- end -}}
+
+{{- if gt (len $existing) 0 -}}
+  {{- $defaulted := list -}}
+  {{- range $q := $existing -}}
+    {{- $entry := deepCopy $q -}}
+    {{- if not (hasKey $entry "org")               -}}{{- $_ := set $entry "org"               $defaultOrg -}}{{- end -}}
+    {{- if not (hasKey $entry "name")              -}}{{- $_ := set $entry "name"              "default"   -}}{{- end -}}
+    {{- if not (hasKey $entry "priority")          -}}{{- $_ := set $entry "priority"          50          -}}{{- end -}}
+    {{- if not (hasKey $entry "fairnessAlgorithm") -}}{{- $_ := set $entry "fairnessAlgorithm" 1           -}}{{- end -}}
+    {{- $defaulted = append $defaulted $entry -}}
+  {{- end -}}
+  {{- $_ := set $queueSync "queues" $defaulted -}}
   {{- $_ := set $leasor "queueSync" $queueSync -}}
   {{- $_ := set $merged "leasor" $leasor -}}
 {{- end -}}

--- a/charts/controlplane/values.aws.yaml
+++ b/charts/controlplane/values.aws.yaml
@@ -17,9 +17,6 @@ global:
   ARTIFACTS_BUCKET_NAME: ""   # S3 bucket for artifacts
   KUBERNETES_SECRET_NAME: ""  # K8s secret with DB password under key "pass.txt"
 
-  # --- DP entrypoint (CP -> DP) ---
-  DATAPLANE_HOST: ""          # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
-
   # --- Images ---
   IMAGE_REPOSITORY_PREFIX: "registry.unionai.cloud/controlplane"
 
@@ -102,11 +99,6 @@ services:
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: "{{ .Values.global.ARTIFACT_IAM_ROLE_ARN }}"
-  dataproxy:
-    configMap:
-      dataproxy:
-        # Falls back to DATAPLANE_HOST when DATAPLANE_ENDPOINT is unset.
-        secureTunnelTenantURLPattern: '{{ default .Values.global.DATAPLANE_HOST .Values.global.DATAPLANE_ENDPOINT }}'
 
 scylla:
   storageClass:

--- a/charts/controlplane/values.gcp.yaml
+++ b/charts/controlplane/values.gcp.yaml
@@ -18,9 +18,6 @@ global:
   ARTIFACTS_BUCKET_NAME: ""   # GCS bucket for artifacts
   KUBERNETES_SECRET_NAME: ""  # K8s secret with DB password under key "pass.txt"
 
-  # --- DP entrypoint (CP -> DP) ---
-  DATAPLANE_HOST: ""          # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
-
   # --- Images ---
   IMAGE_REPOSITORY_PREFIX: "registry.unionai.cloud/controlplane"
 
@@ -107,12 +104,6 @@ services:
               config:
                 projectId: '{{ .Values.global.GOOGLE_PROJECT_ID }}'
             type: stow
-
-  dataproxy:
-    configMap:
-      dataproxy:
-        # Falls back to DATAPLANE_HOST when DATAPLANE_ENDPOINT is unset.
-        secureTunnelTenantURLPattern: '{{ default .Values.global.DATAPLANE_HOST .Values.global.DATAPLANE_ENDPOINT }}'
 
 scylla:
   storageClass:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -15,37 +15,22 @@ global:
   ARTIFACTS_BUCKET_NAME: ""
   KUBERNETES_SECRET_NAME: "" # K8s secret with DB password under key "pass.txt"
 
-  # --- DP entrypoint (CP -> DP) ---
-  DATAPLANE_HOST: ""        # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
-  DATAPLANE_ENDPOINT: ""    # Deprecated alias — falls back to DATAPLANE_HOST when unset.
-
-  # --- Leasor: attached dataplane cluster identifier ---
-  # TEMPORARY. The ship-today way to tell leasor which dataplane cluster its
-  # queues should target. A future control-plane queue/cluster CRUD service
-  # will own this state and deprecate this knob — plan to migrate when that
-  # lands.
+  # --- Leasor: attached dataplane cluster identifier (DEPRECATED) ---
+  # Kept for single-DP backward compatibility. New installs should configure
+  # services.leasor.configMap.leasor.queueSync.queues directly — see that
+  # section below for the multi-cluster shape.
   #
-  # The cluster identifier — same value the corresponding dataplane chart
-  # install sets in its own global.CLUSTER_NAME, which is what leaseworker
-  # reports on StreamLeases and what leasor matches queues against. The
-  # common self-hosted shape is one CP fronting one DP (often intracluster on
-  # the same K8s), so a single string fits. For the rare multi-DP case,
-  # override services.leasor.configMap.leasor.queueSync.queues directly to
-  # enumerate every dataplane.
-  #
-  # Used to auto-generate services.leasor.configMap.leasor.queueSync.queues
-  # (one `default` queue + one per-cluster queue, both containing this name).
-  # No reasonable default — set explicitly.
-  #
-  # NOT the same as flyte.configmap.clusters.clusterConfigs. That is
-  # flyteadmin's routing registry (name + endpoint + auth per cluster) used
-  # by RandomClusterSelector for v1 execution dispatch; populate that only
-  # when you actually need flyteadmin v1 multi-cluster routing. This knob is
-  # leasor-only and just carries a name. Empty by default; per-env overlay
-  # populates from the dataplane's cluster_name. The leasor configmap
-  # auto-queue-gen is a no-op when this is empty (see
-  # templates/leasor/configmap.yaml).
+  # When set AND services.leasor.configMap.leasor.queueSync.queues is empty,
+  # templates/leasor/configmap.yaml auto-generates a 2-entry queue list:
+  #   - { name: default,                clusters: [<this value>] }
+  #   - { name: <DATAPLANE_CLUSTER_NAME>, clusters: [<this value>] }
+  # No reasonable default; empty disables auto-gen.
   DATAPLANE_CLUSTER_NAME: ""
+
+  # NOTE: global.DATAPLANE_HOST + global.DATAPLANE_ENDPOINT were removed in
+  # the Phase 2 DP self-registration cleanup. CP→DP routing now reads the
+  # DP's self-reported endpoint from cluster.Spec.ConnectionConfig (the
+  # operator self-reports on every UpdateStatus). See cloud #16362.
 
   # --- Images ---
   # Customer-facing registry default; internal deployments override to private ECR/GCR.
@@ -1305,11 +1290,57 @@ services:
   # router is needed — leasor rides the generic services renderer like queue.
   #
   # ConfigMap special-cased: leasor's ConfigMap is NOT produced by the generic
-  # services renderer. templates/leasor/configmap.yaml builds it instead so
-  # that queueSync.queues can be auto-generated from
-  # global.DATAPLANE_CLUSTER_NAME (one `default` queue + one per-cluster
-  # queue, both containing that name). To bypass auto-generation entirely,
-  # set configMap.leasor.queueSync.queues below explicitly.
+  # services renderer. templates/leasor/configmap.yaml builds it instead so it
+  # can inject per-queue defaults onto each entry of queueSync.queues — see
+  # below for the supported shape and the QueueSpec field reference.
+  #
+  # queueSync.queues — list of leasor.config.QueueSpec entries
+  # (cloud/leasor/config/config.go:121). Each entry routes Actions queued
+  # under (org, project, domain) to one or more dataplane clusters.
+  #
+  # Per-entry defaults (template-injected when the field is absent):
+  #
+  #   org:               global.UNION_ORG     (single-tenant CP convention)
+  #   name:              "default"
+  #   priority:          50  (PriorityMedium — 0=Low, 50=Medium, 100=High)
+  #   fairnessAlgorithm: 1   (FairnessRoundRobin; 0=None=FIFO, 2=Shuffle)
+  #
+  # Caller-owned fields:
+  #
+  #   clusters:         REQUIRED — list of DP cluster_name strings this queue
+  #                     dispatches to. ["*"] matches every connected DP.
+  #
+  # Optional fields (omit unless you need to scope or shape the queue):
+  #
+  #   project:          scope to a single Flyte project (default: "" = all)
+  #   domain:           scope to a single Flyte domain (default: "" = all)
+  #   status:           0=Active (default), 1=Draining, 2=Drained
+  #   maxDepth:         max queued leases (0 = unlimited)
+  #   maxActionConcurrency: max concurrent in-flight actions (0 = unlimited)
+  #   maxRunConcurrency:    max concurrent runs (0 = unlimited)
+  #
+  # Single-DP example (matches what DATAPLANE_CLUSTER_NAME auto-generated):
+  #
+  #   services:
+  #     leasor:
+  #       configMap:
+  #         leasor:
+  #           queueSync:
+  #             source: static
+  #             queues:
+  #               - { clusters: [dp-1] }            # → name=default
+  #               - { name: dp-1, clusters: [dp-1] }
+  #
+  # Multi-DP example (one default that fans out + one per-cluster):
+  #
+  #   queues:
+  #     - { clusters: [dp-east, dp-west] }
+  #     - { name: dp-east, clusters: [dp-east] }
+  #     - { name: dp-west, clusters: [dp-west] }
+  #
+  # Backward compat: if queues is empty AND global.DATAPLANE_CLUSTER_NAME
+  # is set, the template auto-generates the 2-entry single-DP shape. This
+  # path is DEPRECATED — migrate to explicit `queues` above.
   leasor:
     fullnameOverride: "leasor"
     replicaCount: 1

--- a/charts/dataplane/templates/_connection.tpl
+++ b/charts/dataplane/templates/_connection.tpl
@@ -38,3 +38,33 @@ spelling varies across config schemas (insecure vs insecure-skip-verify
 vs insecureSkipVerify) and YAML/Go-config bool coercion through helm
 template strings is fragile, so callers write the booleans inline.
 */}}
+
+{{/*
+Self-reporting helpers for the data-plane → control-plane Heartbeat /
+UpdateStatus.connection_config field. The operator reads the rendered
+JSON file at startup and ships it on every UpdateStatus so the CP can
+dial back without anyone having to admin-set DataplaneIngressURL.
+
+Override surface (.Values.updateStatus.connectionConfig):
+  host                bare DP-reachable hostname (no scheme, no port).
+                      Empty falls back to .Values.ingress.host — the
+                      dataplane's own ingress hostname — so most installs
+                      don't need to set this explicitly.
+  insecure            CP dials with plain HTTP/2 (no TLS) when true
+  insecureSkipVerify  CP skips cert validation (self-signed cert envs)
+
+dataplane.dp.endpoint formats host as `dns:///<host>:443` — the same
+scheme used for CP→DP DP→CP and CP-to-DP gRPC dials elsewhere in the
+chart. Empty host returns empty string; callers gate emission on this.
+*/}}
+
+{{- define "dataplane.dp.host" -}}
+{{- $explicit := tpl (default "" .Values.updateStatus.connectionConfig.host) . -}}
+{{- $derived := tpl (default "" .Values.ingress.host) . -}}
+{{- default $derived $explicit -}}
+{{- end -}}
+
+{{- define "dataplane.dp.endpoint" -}}
+{{- $host := include "dataplane.dp.host" . -}}
+{{- if $host -}}{{- printf "dns:///%s:443" $host -}}{{- end -}}
+{{- end -}}

--- a/charts/dataplane/templates/operator/configmap-connection.yaml
+++ b/charts/dataplane/templates/operator/configmap-connection.yaml
@@ -1,0 +1,26 @@
+{{- if include "dataplane.dp.host" . }}
+{{/*
+ConfigMap rendering the DP's self-reported connection_config as a JSON
+file the operator reads at startup and ships in every UpdateStatus to
+the controlplane (UpdateStatusRequest.connection_config). The CP prefers
+this over the legacy admin-set DataplaneIngressURL when present.
+
+Gated on .Values.updateStatus.connectionConfig.host being non-empty so
+charts consumed by envs that don't set it (BYOC, self-managed, legacy
+selfhosted with admin-set URL) emit no resource.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "union-operator.fullname" . }}-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+data:
+  connection_config.json: |
+    {
+      "endpoint": "{{ include "dataplane.dp.endpoint" . }}",
+      "insecure": {{ .Values.updateStatus.connectionConfig.insecure }},
+      "insecureSkipVerify": {{ .Values.updateStatus.connectionConfig.insecureSkipVerify }}
+    }
+{{- end }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -27,6 +27,11 @@ data:
     operator:
       enabled: {{ .Values.config.operator.enabled }}
       enableTunnelService: {{ .Values.config.operator.enableTunnelService }}
+      {{- if include "dataplane.dp.host" . }}
+      # Path to the chart-rendered connection_config JSON the operator
+      # self-reports on every UpdateStatus call. Empty path = disabled.
+      connectionConfigPath: /etc/union/connection-config/connection_config.json
+      {{- end }}
       #  enableDepot: {{ include "operator.enableDepot" . | default "false" }}
       tunnel:
         enableDirectToAppIngress: {{ and .Values.serving.enabled .Values.tunnelService.apps.enableGlobalIngress }}

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           secret:
             secretName: {{ .Values.operator.secretName }}
         {{- end }}
+        {{- if include "dataplane.dp.host" . }}
+        - name: connection-config-volume
+          configMap:
+            name: {{ include "union-operator.fullname" . }}-connection
+        {{- end }}
       {{- with .Values.operator.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
@@ -59,6 +64,11 @@ spec:
             {{- if .Values.secrets.admin.enable }}
             - mountPath: /etc/union/secret
               name: secret-volume
+            {{- end }}
+            {{- if include "dataplane.dp.host" . }}
+            - mountPath: /etc/union/connection-config
+              name: connection-config-volume
+              readOnly: true
             {{- end }}
           {{- with .Values.operator.additionalVolumeMounts -}}
           {{ tpl (toYaml .) $ | nindent 12 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -38,6 +38,24 @@ clusterName: "{{ .Values.global.CLUSTER_NAME }}"
 # -- Organization name (provided by Union).
 orgName: "{{ .Values.global.ORG_NAME }}"
 
+# -- Self-reported CP-client-construction data the operator ships in every
+# UpdateStatus call (UpdateStatusRequest.connection_config). The controlplane
+# prefers this over the legacy admin-set DataplaneIngressURL when present.
+# Empty host disables self-reporting; CP falls back to the legacy URL.
+updateStatus:
+  connectionConfig:
+    # -- DP-reachable hostname the CP should dial back. e.g.
+    # "dp-1.internal.<full_domain>". Bare hostname only — no scheme, no port.
+    # Chart helper derives the gRPC endpoint as `dns:///<host>:443`.
+    # Empty falls back to `Values.ingress.host` (the dataplane's own ingress
+    # hostname), so most installs don't need to set this explicitly —
+    # the chart already knows where the DP is reachable.
+    host: ""
+    # -- CP dials this DP with plain HTTP/2 (no TLS) when true. Default false.
+    insecure: false
+    # -- CP skips cert validation on the TLS handshake (self-signed CP cert envs).
+    insecureSkipVerify: false
+
 # -- Define additional pod environment variables for all of the Union pods.
 additionalPodEnvVars: { }
 #  key1: "value1"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2062,7 +2062,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: ''
+      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
       taskMetrics:
         agentQuery:
           mappings:


### PR DESCRIPTION
## Summary

When `updateStatus.connectionConfig.host` is set on the dataplane chart, render a ConfigMap with the JSON the operator self-reports on every `UpdateStatus`, and mount it into the operator pod. Companion to controlplane changes in unionai/cloud#16362.

## Changes

- `charts/dataplane/templates/_connection.tpl` — new `dataplane.dp.host` and `dataplane.dp.endpoint` helpers, symmetric with the existing `dataplane.cp.*` helpers.
- `charts/dataplane/templates/operator/configmap-connection.yaml` (new) — renders a `{fullname}-connection` ConfigMap carrying `connection_config.json` with `{ endpoint, insecure, insecureSkipVerify }`. Gated on `host` non-empty.
- `charts/dataplane/templates/operator/deployment.yaml` — mounts the new ConfigMap at `/etc/union/connection-config`, gated the same way.
- `charts/dataplane/templates/operator/configmap.yaml` — sets `operator.connectionConfigPath` in the operator's main config.
- `charts/dataplane/values.yaml` — new `updateStatus.connectionConfig` block. Defaults: `host=""`, `insecure=false`, `insecureSkipVerify=false`.

## Backward compatibility

Pure no-op for envs that don't set `updateStatus.connectionConfig.host`. The gate is on the host helper, so existing installs render no new resources and the controlplane keeps using its legacy admin-set `DataplaneIngressURL`.

Snapshot tests unchanged — no fixture sets the host, so no template output drifts.

## Test plan

- `make generate-expected` — clean (no expected diff).
- `make test` — green.
- `helm template foo charts/dataplane --set updateStatus.connectionConfig.host=dp-1.internal.example.com --set secrets.admin.clientSecret=foo --set secrets.admin.clientId=foo` produces the new ConfigMap, mount, and `operator.connectionConfigPath`.
