### PR TITLE
dataplane: guard knative serving pre-delete hook against missing CRD

### DIFF
--- a/charts/dataplane/templates/serving/pre-delete-hook.yaml
+++ b/charts/dataplane/templates/serving/pre-delete-hook.yaml
@@ -31,6 +31,32 @@ subjects:
   name: {{ .Release.Name }}-pre-delete
   namespace: {{ .Release.Namespace }}
 ---
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-pre-delete-{{ .Release.Namespace }}
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-pre-delete-{{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-pre-delete-{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-pre-delete
+  namespace: {{ .Release.Namespace }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -53,8 +79,11 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            {{ include "serving.fullname" . }} \
-            --ignore-not-found=true \
-            -n {{ .Release.Namespace }}
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving {{ include "serving.fullname" . }} \
+              --ignore-not-found=true \
+              --namespace {{ .Release.Namespace }}
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 {{- end }}

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -4675,6 +4675,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4843,6 +4857,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7256,10 +7284,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -4707,6 +4707,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4875,6 +4889,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7278,10 +7306,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -4875,6 +4875,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5043,6 +5057,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/dcgm-exporter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7873,10 +7901,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -4675,6 +4675,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4843,6 +4857,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7367,10 +7395,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -4802,6 +4802,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4970,6 +4984,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/dcgm-exporter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7743,10 +7771,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -4742,6 +4742,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4910,6 +4924,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7318,10 +7346,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -4742,6 +4742,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4910,6 +4924,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7318,10 +7346,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -5060,6 +5060,20 @@ rules:
       - update
       - delete
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/templates/webhook/serviceaccount.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5352,6 +5366,20 @@ subjects:
   - kind: ServiceAccount
     name: union-system
     namespace: union
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/templates/webhook/serviceaccount.yaml
 # Create a binding from Role -> ServiceAccount
@@ -7435,10 +7463,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -4692,6 +4692,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4860,6 +4874,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7263,10 +7291,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -4817,6 +4817,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4985,6 +4999,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/dcgm-exporter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7626,10 +7654,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -4697,6 +4697,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4865,6 +4879,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7336,10 +7364,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -4690,6 +4690,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4858,6 +4872,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7261,10 +7289,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -4715,6 +4715,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4883,6 +4897,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7286,10 +7314,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -5862,6 +5862,20 @@ rules:
 
 
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6126,6 +6140,20 @@ subjects:
     namespace: union
 
 
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -13879,10 +13907,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -4710,6 +4710,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4878,6 +4892,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7413,10 +7441,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -4730,6 +4730,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4898,6 +4912,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7372,10 +7400,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -4699,6 +4699,20 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+# Cluster-scoped get on CRDs so the cleanup Job can check whether the
+# knativeservings CRD exists before attempting to delete the CR (see the
+# guard in the Job below). Cluster-scoped, so the name is namespace-qualified
+# to avoid collisions between releases.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-pre-delete-union
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4867,6 +4881,20 @@ subjects:
   - kind: ServiceAccount
     name: knative-operator
     namespace: "union"
+---
+# Source: dataplane/templates/serving/pre-delete-hook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-pre-delete-union
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-pre-delete-union
+subjects:
+- kind: ServiceAccount
+  name: release-name-pre-delete
+  namespace: union
 ---
 # Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
 # Copyright 2022 The Knative Authors
@@ -7270,10 +7298,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          kubectl delete knativeserving \
-            union-operator-serving \
-            --ignore-not-found=true \
-            -n union
+          if kubectl get crd knativeservings.operator.knative.dev >/dev/null 2>&1; then
+            kubectl delete knativeserving union-operator-serving \
+              --ignore-not-found=true \
+              --namespace union
+          else
+            echo "knativeservings CRD not installed; nothing to clean up"
+          fi
 
 ---
 # Source: dataplane/templates/webhook/pre-upgrade-cleanup.yaml


### PR DESCRIPTION
## Problem

`helm uninstall` fails on the knative serving `pre-delete` hook when the `knativeservings` CRD was never installed.

The cleanup Job ran `kubectl delete knativeserving --ignore-not-found`, but `--ignore-not-found` does **not** suppress `the server doesn't have a resource type "knativeserving"` — that's what kubectl returns when the CRD is absent (the exact state after a failed initial deployment, before the knative-operator subchart applied its CRDs). The Job fails → the hook fails → the uninstall aborts, stranding the release.

## Fix

- Guard the delete behind `kubectl get crd knativeservings.operator.knative.dev` — if the CRD is absent there's no CR to clean up, so skip with a log line.
- Add a `ClusterRole`/`ClusterRoleBinding` granting `get` on `customresourcedefinitions` so the Job's SA can run the check.

Mirrors the pattern already documented and used in `charts/knative-migration/files/cleanup.sh`.

## Testing

`make helm-test` and `make kubeconform-test` pass. Snapshots regenerated with Helm v4.2.0 (the CI-pinned version).