### PR TITLE
Release 2026.6.6: Update Union chart release to support offloaded trigger inputs

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,8 +3,8 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.3
-appVersion: 2026.6.3
+version: 2026.6.5
+appVersion: 2026.6.5
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,8 +3,8 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.5
-appVersion: 2026.6.5
+version: 2026.6.6
+appVersion: 2026.6.6
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -10,8 +10,8 @@ description: 'DEPRECATED. Use `crds/flyte-v1/` for FlyteWorkflow and `crds/kube-
 deprecated: true
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.5
-appVersion: 2026.6.5
+version: 2026.6.6
+appVersion: 2026.6.6
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: prometheus-operator-crds

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -10,8 +10,8 @@ description: 'DEPRECATED. Use `crds/flyte-v1/` for FlyteWorkflow and `crds/kube-
 deprecated: true
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.1
-appVersion: 2026.6.0
+version: 2026.6.5
+appVersion: 2026.6.5
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: prometheus-operator-crds

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.5
-appVersion: 2026.6.5
+version: 2026.6.6
+appVersion: 2026.6.6
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,8 +3,8 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.3
-appVersion: 2026.6.3
+version: 2026.6.5
+appVersion: 2026.6.5
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/knative-migration/Chart.yaml
+++ b/charts/knative-migration/Chart.yaml
@@ -1,13 +1,18 @@
 apiVersion: v2
 name: knative-migration
-description: |
-  One-shot cleanup of knative-operator residue (stuck KnativeServing finalizer,
+description: 'One-shot cleanup of knative-operator residue (stuck KnativeServing finalizer,
+
   operator CRDs, and operator ClusterRoles/Bindings) left behind after migrating
+
   the Union dataplane chart away from KnativeServing CR-based installation.
+
   Renders a Job + scoped RBAC; install mode (Helm hook, Argo hook, or plain
+
   resources) is chosen by the caller via annotations.
+
+  '
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.5.0
-appVersion: "0.1.0"
-kubeVersion: ">= 1.28.0-0"
+version: 2026.6.5
+appVersion: 0.1.0
+kubeVersion: '>= 1.28.0-0'

--- a/charts/knative-migration/Chart.yaml
+++ b/charts/knative-migration/Chart.yaml
@@ -13,6 +13,6 @@ description: 'One-shot cleanup of knative-operator residue (stuck KnativeServing
   '
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.5
+version: 2026.6.6
 appVersion: 0.1.0
 kubeVersion: '>= 1.28.0-0'

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.3
-appVersion: 2026.6.3
+version: 2026.6.5
+appVersion: 2026.6.5
 kubeVersion: '>= 1.28.0'

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.5
-appVersion: 2026.6.5
+version: 2026.6.6
+appVersion: 2026.6.6
 kubeVersion: '>= 1.28.0'

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -93,10 +93,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,10 +121,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -135,10 +135,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -147,10 +147,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -159,10 +159,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -171,10 +171,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -183,10 +183,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -195,10 +195,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -207,10 +207,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -219,10 +219,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -231,10 +231,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -243,10 +243,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -257,10 +257,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -519,10 +519,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -622,10 +622,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -696,10 +696,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1385,10 +1385,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1419,10 +1419,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1774,7 +1774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1842,10 +1842,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1941,10 +1941,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2032,10 +2032,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2223,10 +2223,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2339,10 +2339,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2423,10 +2423,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2514,10 +2514,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2598,10 +2598,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2683,10 +2683,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2878,7 +2878,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2894,10 +2894,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8191,10 +8191,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8214,7 +8214,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8267,10 +8267,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8291,7 +8291,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8454,10 +8454,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8488,10 +8488,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8525,10 +8525,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8562,10 +8562,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8599,10 +8599,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8636,10 +8636,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8673,10 +8673,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8710,10 +8710,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8747,10 +8747,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8784,10 +8784,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8821,10 +8821,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8861,7 +8861,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8889,10 +8889,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8918,10 +8918,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8957,10 +8957,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8996,10 +8996,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9031,10 +9031,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9066,10 +9066,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9101,10 +9101,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9136,10 +9136,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9175,10 +9175,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9210,10 +9210,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9245,10 +9245,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9796,10 +9796,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9856,7 +9856,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9907,7 +9907,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9980,10 +9980,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10040,7 +10040,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10091,7 +10091,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10164,10 +10164,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10224,7 +10224,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10275,7 +10275,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10348,10 +10348,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10408,7 +10408,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10459,7 +10459,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10532,10 +10532,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10592,7 +10592,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10643,7 +10643,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10716,10 +10716,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10776,7 +10776,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10827,7 +10827,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10900,10 +10900,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10960,7 +10960,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11011,7 +11011,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11084,10 +11084,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11144,7 +11144,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11195,7 +11195,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11268,10 +11268,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11328,7 +11328,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11379,7 +11379,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11452,10 +11452,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11512,7 +11512,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11563,7 +11563,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11637,10 +11637,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11655,9 +11655,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 505becbb20df964e96bdc9ca840b377e401c6938b9c18e152c2a5ca1d5eb3c9d
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 332b6c8a3ca0cfeb86381e697a03fad46a1042ebe2d399a61da8f33608733e31
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11690,7 +11690,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11766,7 +11766,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11777,7 +11777,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
+        configChecksum: "0498dbc7216c1af99a51f390acbb269e3d05901b36807fbd942fe64683e5c7a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11786,7 +11786,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11879,10 +11879,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11922,7 +11922,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11950,10 +11950,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11991,7 +11991,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12065,10 +12065,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12106,7 +12106,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12122,7 +12122,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12196,10 +12196,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12237,7 +12237,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12308,10 +12308,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12349,7 +12349,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12365,7 +12365,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12436,10 +12436,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12477,7 +12477,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12551,10 +12551,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12590,7 +12590,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12606,7 +12606,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12677,10 +12677,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12718,7 +12718,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12733,7 +12733,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12750,7 +12750,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12824,10 +12824,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12866,7 +12866,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12882,7 +12882,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12953,10 +12953,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12994,7 +12994,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13010,7 +13010,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13082,10 +13082,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13123,7 +13123,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13232,10 +13232,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16062,10 +16062,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -93,10 +93,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,10 +121,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -135,10 +135,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -147,10 +147,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -159,10 +159,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -171,10 +171,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -183,10 +183,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -195,10 +195,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -207,10 +207,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -219,10 +219,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -231,10 +231,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -243,10 +243,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -257,10 +257,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -519,10 +519,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -622,10 +622,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -696,10 +696,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1385,10 +1385,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1419,10 +1419,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1774,7 +1774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1842,10 +1842,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1941,10 +1941,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2032,10 +2032,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2223,10 +2223,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2339,10 +2339,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2423,10 +2423,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2514,10 +2514,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2598,10 +2598,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2683,10 +2683,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2878,7 +2878,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2894,10 +2894,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8191,10 +8191,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8214,7 +8214,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8267,10 +8267,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8291,7 +8291,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8454,10 +8454,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8488,10 +8488,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8525,10 +8525,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8562,10 +8562,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8599,10 +8599,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8636,10 +8636,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8673,10 +8673,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8710,10 +8710,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8747,10 +8747,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8784,10 +8784,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8821,10 +8821,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8861,7 +8861,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8889,10 +8889,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8918,10 +8918,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8957,10 +8957,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8996,10 +8996,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9031,10 +9031,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9066,10 +9066,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9101,10 +9101,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9136,10 +9136,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9175,10 +9175,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9210,10 +9210,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9245,10 +9245,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9796,10 +9796,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9856,7 +9856,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9907,7 +9907,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9980,10 +9980,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10040,7 +10040,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10091,7 +10091,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10164,10 +10164,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10224,7 +10224,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10275,7 +10275,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10348,10 +10348,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10408,7 +10408,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10459,7 +10459,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10532,10 +10532,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10592,7 +10592,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10643,7 +10643,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10716,10 +10716,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10776,7 +10776,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10827,7 +10827,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10900,10 +10900,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10960,7 +10960,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11011,7 +11011,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11084,10 +11084,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11144,7 +11144,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11195,7 +11195,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11268,10 +11268,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11328,7 +11328,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11379,7 +11379,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11452,10 +11452,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11512,7 +11512,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11563,7 +11563,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11637,10 +11637,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11655,9 +11655,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: 7a3f346a2843d00d2acb4d42b854b31ffeccf74872fd38ad7575d73b80bd77c7
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 505becbb20df964e96bdc9ca840b377e401c6938b9c18e152c2a5ca1d5eb3c9d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11690,7 +11690,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11766,7 +11766,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11777,7 +11777,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d934993192c57461c36f5a1ea7e11e7d13831f60b8f4d47a881f202b36d4019"
+        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11786,7 +11786,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11879,10 +11879,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11922,7 +11922,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11950,10 +11950,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11991,7 +11991,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12065,10 +12065,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12106,7 +12106,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12122,7 +12122,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12196,10 +12196,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12237,7 +12237,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12308,10 +12308,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12349,7 +12349,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12365,7 +12365,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12436,10 +12436,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12477,7 +12477,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12551,10 +12551,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12590,7 +12590,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12606,7 +12606,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12677,10 +12677,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12718,7 +12718,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12733,7 +12733,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12750,7 +12750,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12824,10 +12824,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12866,7 +12866,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12882,7 +12882,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12953,10 +12953,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12994,7 +12994,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13010,7 +13010,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13082,10 +13082,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13123,7 +13123,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13232,10 +13232,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16062,10 +16062,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -95,10 +95,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,10 +123,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -137,10 +137,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -149,10 +149,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -161,10 +161,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -173,10 +173,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -185,10 +185,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -197,10 +197,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -209,10 +209,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -221,10 +221,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -233,10 +233,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -245,10 +245,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -259,10 +259,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -521,10 +521,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -624,10 +624,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -698,10 +698,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1387,10 +1387,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1421,10 +1421,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1756,7 +1756,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1824,10 +1824,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1923,10 +1923,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2014,10 +2014,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2205,10 +2205,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2320,10 +2320,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2404,10 +2404,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2495,10 +2495,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2579,10 +2579,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2664,10 +2664,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2859,7 +2859,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2875,10 +2875,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8172,10 +8172,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8195,7 +8195,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8248,10 +8248,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8272,7 +8272,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8435,10 +8435,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8469,10 +8469,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8506,10 +8506,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8543,10 +8543,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8580,10 +8580,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8617,10 +8617,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8654,10 +8654,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8691,10 +8691,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8728,10 +8728,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8765,10 +8765,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8802,10 +8802,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8842,7 +8842,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8870,10 +8870,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8899,10 +8899,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8938,10 +8938,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8977,10 +8977,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9012,10 +9012,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9047,10 +9047,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9082,10 +9082,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9117,10 +9117,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9156,10 +9156,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9191,10 +9191,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9226,10 +9226,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9777,10 +9777,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9837,7 +9837,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9888,7 +9888,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9961,10 +9961,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10021,7 +10021,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10072,7 +10072,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10145,10 +10145,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10205,7 +10205,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10256,7 +10256,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10329,10 +10329,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10389,7 +10389,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10440,7 +10440,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10513,10 +10513,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10573,7 +10573,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10624,7 +10624,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10697,10 +10697,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10757,7 +10757,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10808,7 +10808,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10881,10 +10881,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10941,7 +10941,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10992,7 +10992,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11065,10 +11065,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11125,7 +11125,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11176,7 +11176,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11249,10 +11249,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11309,7 +11309,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11360,7 +11360,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11433,10 +11433,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11493,7 +11493,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11544,7 +11544,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11618,10 +11618,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11636,9 +11636,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: c2d7c6bc6e7e74deffd1981573ecde23c69d2000053efa1a3d87f4662f066e13
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11671,7 +11671,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11747,7 +11747,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11758,7 +11758,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d934993192c57461c36f5a1ea7e11e7d13831f60b8f4d47a881f202b36d4019"
+        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11767,7 +11767,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11860,10 +11860,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11903,7 +11903,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11931,10 +11931,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11972,7 +11972,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12046,10 +12046,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12087,7 +12087,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12103,7 +12103,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12177,10 +12177,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12218,7 +12218,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12289,10 +12289,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12330,7 +12330,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12346,7 +12346,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12417,10 +12417,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12458,7 +12458,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12532,10 +12532,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12571,7 +12571,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12587,7 +12587,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12658,10 +12658,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12699,7 +12699,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12714,7 +12714,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12731,7 +12731,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12805,10 +12805,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12847,7 +12847,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12863,7 +12863,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12934,10 +12934,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12975,7 +12975,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12991,7 +12991,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13063,10 +13063,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13104,7 +13104,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13213,10 +13213,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16146,10 +16146,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -95,10 +95,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,10 +123,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -137,10 +137,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -149,10 +149,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -161,10 +161,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -173,10 +173,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -185,10 +185,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -197,10 +197,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -209,10 +209,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -221,10 +221,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -233,10 +233,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -245,10 +245,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -259,10 +259,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -521,10 +521,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -624,10 +624,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -698,10 +698,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1387,10 +1387,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1421,10 +1421,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1756,7 +1756,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1824,10 +1824,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1923,10 +1923,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2014,10 +2014,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2205,10 +2205,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2320,10 +2320,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2404,10 +2404,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2495,10 +2495,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2579,10 +2579,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2664,10 +2664,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2859,7 +2859,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2875,10 +2875,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8172,10 +8172,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8195,7 +8195,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8248,10 +8248,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8272,7 +8272,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8435,10 +8435,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8469,10 +8469,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8506,10 +8506,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8543,10 +8543,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8580,10 +8580,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8617,10 +8617,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8654,10 +8654,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8691,10 +8691,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8728,10 +8728,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8765,10 +8765,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8802,10 +8802,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8842,7 +8842,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8870,10 +8870,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8899,10 +8899,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8938,10 +8938,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8977,10 +8977,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9012,10 +9012,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9047,10 +9047,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9082,10 +9082,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9117,10 +9117,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9156,10 +9156,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9191,10 +9191,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9226,10 +9226,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9777,10 +9777,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9837,7 +9837,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9888,7 +9888,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9961,10 +9961,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10021,7 +10021,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10072,7 +10072,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10145,10 +10145,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10205,7 +10205,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10256,7 +10256,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10329,10 +10329,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10389,7 +10389,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10440,7 +10440,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10513,10 +10513,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10573,7 +10573,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10624,7 +10624,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10697,10 +10697,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10757,7 +10757,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10808,7 +10808,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10881,10 +10881,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10941,7 +10941,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10992,7 +10992,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11065,10 +11065,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11125,7 +11125,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11176,7 +11176,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11249,10 +11249,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11309,7 +11309,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11360,7 +11360,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11433,10 +11433,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11493,7 +11493,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11544,7 +11544,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11618,10 +11618,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11636,9 +11636,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 592948fc7be077e254c88c9790a26825a62a8631b9b1f9a0d5714168174b118d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11671,7 +11671,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11747,7 +11747,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11758,7 +11758,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
+        configChecksum: "0498dbc7216c1af99a51f390acbb269e3d05901b36807fbd942fe64683e5c7a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11767,7 +11767,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11860,10 +11860,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11903,7 +11903,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11931,10 +11931,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11972,7 +11972,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12046,10 +12046,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12087,7 +12087,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12103,7 +12103,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12177,10 +12177,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12218,7 +12218,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12289,10 +12289,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12330,7 +12330,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12346,7 +12346,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12417,10 +12417,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12458,7 +12458,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12532,10 +12532,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12571,7 +12571,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12587,7 +12587,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12658,10 +12658,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12699,7 +12699,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12714,7 +12714,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12731,7 +12731,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12805,10 +12805,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12847,7 +12847,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12863,7 +12863,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12934,10 +12934,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12975,7 +12975,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12991,7 +12991,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13063,10 +13063,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13104,7 +13104,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13213,10 +13213,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16146,10 +16146,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -95,10 +95,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,10 +123,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -137,10 +137,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -149,10 +149,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -161,10 +161,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -173,10 +173,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -185,10 +185,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -197,10 +197,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -209,10 +209,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -221,10 +221,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -233,10 +233,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -245,10 +245,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -259,10 +259,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -521,10 +521,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -624,10 +624,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -698,10 +698,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1387,10 +1387,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1421,10 +1421,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1776,7 +1776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1844,10 +1844,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1943,10 +1943,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2034,10 +2034,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2225,10 +2225,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2340,10 +2340,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2424,10 +2424,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2515,10 +2515,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2599,10 +2599,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2684,10 +2684,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2879,7 +2879,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2895,10 +2895,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8207,10 +8207,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8230,7 +8230,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8283,10 +8283,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8307,7 +8307,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8470,10 +8470,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8504,10 +8504,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8541,10 +8541,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8578,10 +8578,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8615,10 +8615,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8652,10 +8652,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8689,10 +8689,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8726,10 +8726,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8763,10 +8763,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8800,10 +8800,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8837,10 +8837,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8877,7 +8877,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8905,10 +8905,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8934,10 +8934,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8973,10 +8973,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9012,10 +9012,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9047,10 +9047,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9082,10 +9082,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9117,10 +9117,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9152,10 +9152,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9191,10 +9191,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9226,10 +9226,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9261,10 +9261,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9812,10 +9812,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9872,7 +9872,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9923,7 +9923,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9996,10 +9996,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10056,7 +10056,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10107,7 +10107,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10180,10 +10180,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10240,7 +10240,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10291,7 +10291,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10364,10 +10364,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10424,7 +10424,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10475,7 +10475,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10548,10 +10548,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10608,7 +10608,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10659,7 +10659,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10732,10 +10732,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10792,7 +10792,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10843,7 +10843,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10916,10 +10916,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10976,7 +10976,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11027,7 +11027,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11100,10 +11100,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11160,7 +11160,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11211,7 +11211,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11284,10 +11284,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11344,7 +11344,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11395,7 +11395,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11468,10 +11468,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11528,7 +11528,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11579,7 +11579,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11653,10 +11653,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11671,9 +11671,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: 7a3f346a2843d00d2acb4d42b854b31ffeccf74872fd38ad7575d73b80bd77c7
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 505becbb20df964e96bdc9ca840b377e401c6938b9c18e152c2a5ca1d5eb3c9d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11706,7 +11706,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11782,7 +11782,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11793,7 +11793,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d934993192c57461c36f5a1ea7e11e7d13831f60b8f4d47a881f202b36d4019"
+        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11803,7 +11803,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11896,10 +11896,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11940,7 +11940,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11968,10 +11968,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12010,7 +12010,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12084,10 +12084,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12126,7 +12126,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12142,7 +12142,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12216,10 +12216,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12258,7 +12258,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12329,10 +12329,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12371,7 +12371,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12387,7 +12387,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12458,10 +12458,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12500,7 +12500,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12574,10 +12574,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12614,7 +12614,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12630,7 +12630,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12701,10 +12701,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12743,7 +12743,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12758,7 +12758,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12775,7 +12775,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12849,10 +12849,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12892,7 +12892,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12908,7 +12908,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12979,10 +12979,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13021,7 +13021,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13037,7 +13037,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13109,10 +13109,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13151,7 +13151,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13254,10 +13254,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -19815,10 +19815,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -95,10 +95,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,10 +123,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -137,10 +137,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -149,10 +149,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -161,10 +161,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -173,10 +173,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -185,10 +185,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -197,10 +197,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -209,10 +209,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -221,10 +221,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -233,10 +233,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -245,10 +245,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -259,10 +259,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -521,10 +521,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -624,10 +624,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -698,10 +698,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1387,10 +1387,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1421,10 +1421,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1776,7 +1776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1844,10 +1844,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1943,10 +1943,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2034,10 +2034,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2225,10 +2225,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2340,10 +2340,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2424,10 +2424,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2515,10 +2515,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2599,10 +2599,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2684,10 +2684,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2879,7 +2879,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2895,10 +2895,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8207,10 +8207,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8230,7 +8230,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8283,10 +8283,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8307,7 +8307,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8470,10 +8470,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8504,10 +8504,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8541,10 +8541,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8578,10 +8578,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8615,10 +8615,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8652,10 +8652,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8689,10 +8689,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8726,10 +8726,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8763,10 +8763,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8800,10 +8800,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8837,10 +8837,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8877,7 +8877,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8905,10 +8905,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8934,10 +8934,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8973,10 +8973,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9012,10 +9012,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9047,10 +9047,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9082,10 +9082,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9117,10 +9117,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9152,10 +9152,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9191,10 +9191,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9226,10 +9226,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9261,10 +9261,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9812,10 +9812,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9872,7 +9872,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9923,7 +9923,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9996,10 +9996,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10056,7 +10056,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10107,7 +10107,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10180,10 +10180,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10240,7 +10240,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10291,7 +10291,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10364,10 +10364,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10424,7 +10424,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10475,7 +10475,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10548,10 +10548,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10608,7 +10608,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10659,7 +10659,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10732,10 +10732,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10792,7 +10792,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10843,7 +10843,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10916,10 +10916,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10976,7 +10976,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11027,7 +11027,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11100,10 +11100,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11160,7 +11160,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11211,7 +11211,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11284,10 +11284,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11344,7 +11344,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11395,7 +11395,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11468,10 +11468,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11528,7 +11528,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11579,7 +11579,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11653,10 +11653,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11671,9 +11671,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 505becbb20df964e96bdc9ca840b377e401c6938b9c18e152c2a5ca1d5eb3c9d
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 332b6c8a3ca0cfeb86381e697a03fad46a1042ebe2d399a61da8f33608733e31
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11706,7 +11706,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11782,7 +11782,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11793,7 +11793,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
+        configChecksum: "0498dbc7216c1af99a51f390acbb269e3d05901b36807fbd942fe64683e5c7a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11803,7 +11803,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11896,10 +11896,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11940,7 +11940,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11968,10 +11968,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12010,7 +12010,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12084,10 +12084,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12126,7 +12126,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12142,7 +12142,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12216,10 +12216,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12258,7 +12258,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12329,10 +12329,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12371,7 +12371,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12387,7 +12387,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12458,10 +12458,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12500,7 +12500,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12574,10 +12574,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12614,7 +12614,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12630,7 +12630,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12701,10 +12701,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12743,7 +12743,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12758,7 +12758,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12775,7 +12775,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12849,10 +12849,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12892,7 +12892,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12908,7 +12908,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12979,10 +12979,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13021,7 +13021,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13037,7 +13037,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13109,10 +13109,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13151,7 +13151,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13254,10 +13254,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -19815,10 +19815,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -95,10 +95,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -125,10 +125,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -139,10 +139,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -151,10 +151,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -163,10 +163,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -175,10 +175,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -187,10 +187,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -199,10 +199,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -211,10 +211,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -223,10 +223,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -235,10 +235,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -247,10 +247,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -261,10 +261,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -531,10 +531,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -634,10 +634,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -708,10 +708,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1397,10 +1397,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1431,10 +1431,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1766,7 +1766,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1839,10 +1839,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1938,10 +1938,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2029,10 +2029,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2220,10 +2220,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2335,10 +2335,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2419,10 +2419,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2510,10 +2510,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2594,10 +2594,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2679,10 +2679,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2874,7 +2874,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2890,10 +2890,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8190,10 +8190,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8213,7 +8213,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8266,10 +8266,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8290,7 +8290,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8453,10 +8453,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8487,10 +8487,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8524,10 +8524,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8561,10 +8561,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8598,10 +8598,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8635,10 +8635,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8672,10 +8672,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8709,10 +8709,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8746,10 +8746,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8783,10 +8783,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8820,10 +8820,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8860,7 +8860,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8888,10 +8888,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8917,10 +8917,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8956,10 +8956,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8995,10 +8995,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9030,10 +9030,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9065,10 +9065,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9100,10 +9100,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9135,10 +9135,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9174,10 +9174,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9209,10 +9209,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9244,10 +9244,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9795,10 +9795,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9855,7 +9855,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9906,7 +9906,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9979,10 +9979,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10039,7 +10039,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10090,7 +10090,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10163,10 +10163,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10223,7 +10223,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10274,7 +10274,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10347,10 +10347,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10407,7 +10407,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10458,7 +10458,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10531,10 +10531,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10591,7 +10591,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10642,7 +10642,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10715,10 +10715,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10775,7 +10775,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10826,7 +10826,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10899,10 +10899,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10959,7 +10959,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11010,7 +11010,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11083,10 +11083,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11143,7 +11143,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11194,7 +11194,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11267,10 +11267,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11327,7 +11327,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11378,7 +11378,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11451,10 +11451,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11511,7 +11511,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11562,7 +11562,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11636,10 +11636,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11654,9 +11654,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: c2d7c6bc6e7e74deffd1981573ecde23c69d2000053efa1a3d87f4662f066e13
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11689,7 +11689,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11765,7 +11765,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11776,7 +11776,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5a69973bf69844c66dfa560d3511bd767571f1075b4f2d5672f4b23c04435c7"
+        configChecksum: "6f168a84560fea83a846a64114850c2caf0df334b5e0cd763b4dc4e19b9efa8"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11785,7 +11785,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11878,10 +11878,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11921,7 +11921,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11949,10 +11949,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11990,7 +11990,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12064,10 +12064,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12105,7 +12105,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12121,7 +12121,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12195,10 +12195,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12236,7 +12236,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12307,10 +12307,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12348,7 +12348,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12364,7 +12364,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12435,10 +12435,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12476,7 +12476,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12550,10 +12550,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12589,7 +12589,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12605,7 +12605,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12676,10 +12676,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12717,7 +12717,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12732,7 +12732,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12749,7 +12749,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12823,10 +12823,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12865,7 +12865,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12881,7 +12881,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12952,10 +12952,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12993,7 +12993,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13009,7 +13009,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13081,10 +13081,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13122,7 +13122,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13231,10 +13231,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16150,10 +16150,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -95,10 +95,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -125,10 +125,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -139,10 +139,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -151,10 +151,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -163,10 +163,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -175,10 +175,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -187,10 +187,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -199,10 +199,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -211,10 +211,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -223,10 +223,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -235,10 +235,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -247,10 +247,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -261,10 +261,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -531,10 +531,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -634,10 +634,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -708,10 +708,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1397,10 +1397,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1431,10 +1431,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1766,7 +1766,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1839,10 +1839,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1938,10 +1938,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2029,10 +2029,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2220,10 +2220,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2335,10 +2335,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2419,10 +2419,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2510,10 +2510,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2594,10 +2594,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2679,10 +2679,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2874,7 +2874,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2890,10 +2890,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8190,10 +8190,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8213,7 +8213,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8266,10 +8266,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8290,7 +8290,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8453,10 +8453,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8487,10 +8487,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8524,10 +8524,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8561,10 +8561,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8598,10 +8598,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8635,10 +8635,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8672,10 +8672,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8709,10 +8709,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8746,10 +8746,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8783,10 +8783,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8820,10 +8820,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8860,7 +8860,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8888,10 +8888,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8917,10 +8917,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8956,10 +8956,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8995,10 +8995,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9030,10 +9030,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9065,10 +9065,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9100,10 +9100,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9135,10 +9135,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9174,10 +9174,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9209,10 +9209,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9244,10 +9244,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9795,10 +9795,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9855,7 +9855,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9906,7 +9906,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9979,10 +9979,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10039,7 +10039,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10090,7 +10090,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10163,10 +10163,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10223,7 +10223,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10274,7 +10274,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10347,10 +10347,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10407,7 +10407,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10458,7 +10458,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10531,10 +10531,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10591,7 +10591,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10642,7 +10642,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10715,10 +10715,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10775,7 +10775,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10826,7 +10826,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10899,10 +10899,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10959,7 +10959,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11010,7 +11010,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11083,10 +11083,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11143,7 +11143,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11194,7 +11194,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11267,10 +11267,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11327,7 +11327,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11378,7 +11378,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11451,10 +11451,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11511,7 +11511,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11562,7 +11562,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11636,10 +11636,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11654,9 +11654,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 592948fc7be077e254c88c9790a26825a62a8631b9b1f9a0d5714168174b118d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11689,7 +11689,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11765,7 +11765,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11776,7 +11776,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f168a84560fea83a846a64114850c2caf0df334b5e0cd763b4dc4e19b9efa8"
+        configChecksum: "745f9d51a6aa8b19a885e017c9b27843b28e376563f7650ccdc1460830372f6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11785,7 +11785,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11878,10 +11878,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11921,7 +11921,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11949,10 +11949,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11990,7 +11990,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12064,10 +12064,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12105,7 +12105,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12121,7 +12121,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12195,10 +12195,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12236,7 +12236,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12307,10 +12307,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12348,7 +12348,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12364,7 +12364,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12435,10 +12435,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12476,7 +12476,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12550,10 +12550,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12589,7 +12589,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12605,7 +12605,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12676,10 +12676,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12717,7 +12717,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12732,7 +12732,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12749,7 +12749,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12823,10 +12823,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12865,7 +12865,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12881,7 +12881,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12952,10 +12952,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12993,7 +12993,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13009,7 +13009,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13081,10 +13081,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13122,7 +13122,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13231,10 +13231,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16150,10 +16150,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -93,10 +93,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,10 +121,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -135,10 +135,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -147,10 +147,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -159,10 +159,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -171,10 +171,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -183,10 +183,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -195,10 +195,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -207,10 +207,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -219,10 +219,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -231,10 +231,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -243,10 +243,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -257,10 +257,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -522,10 +522,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -625,10 +625,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -699,10 +699,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1388,10 +1388,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1422,10 +1422,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1757,7 +1757,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1825,10 +1825,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1928,10 +1928,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2019,10 +2019,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2210,10 +2210,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2325,10 +2325,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2409,10 +2409,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2500,10 +2500,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2584,10 +2584,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2669,10 +2669,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2864,7 +2864,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2880,10 +2880,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8177,10 +8177,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8200,7 +8200,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8253,10 +8253,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8277,7 +8277,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8440,10 +8440,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8474,10 +8474,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8511,10 +8511,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8548,10 +8548,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8585,10 +8585,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8622,10 +8622,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8659,10 +8659,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8696,10 +8696,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8733,10 +8733,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8770,10 +8770,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8807,10 +8807,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8847,7 +8847,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8875,10 +8875,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8904,10 +8904,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8943,10 +8943,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8982,10 +8982,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9017,10 +9017,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9052,10 +9052,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9087,10 +9087,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9122,10 +9122,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9161,10 +9161,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9196,10 +9196,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9231,10 +9231,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9782,10 +9782,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9842,7 +9842,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9893,7 +9893,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9966,10 +9966,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10026,7 +10026,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10077,7 +10077,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10150,10 +10150,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10210,7 +10210,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10261,7 +10261,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10334,10 +10334,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10394,7 +10394,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10445,7 +10445,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10518,10 +10518,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10578,7 +10578,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10629,7 +10629,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10702,10 +10702,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10762,7 +10762,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10813,7 +10813,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10886,10 +10886,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10946,7 +10946,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10997,7 +10997,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11070,10 +11070,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11130,7 +11130,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11181,7 +11181,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11254,10 +11254,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11314,7 +11314,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11365,7 +11365,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11438,10 +11438,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11498,7 +11498,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11549,7 +11549,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11623,10 +11623,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11641,9 +11641,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: c2d7c6bc6e7e74deffd1981573ecde23c69d2000053efa1a3d87f4662f066e13
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11676,7 +11676,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11752,7 +11752,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11763,7 +11763,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f0cf4d4ea2e6e51fd0bd4623e2f1df7107c07d3357326647417740b79b8e0f9"
+        configChecksum: "973ca12c13c86029dc0e4e69294403689165aefad2e5fd3932337c324b2bba2"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11772,7 +11772,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11865,10 +11865,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11908,7 +11908,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11936,10 +11936,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11977,7 +11977,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12051,10 +12051,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12092,7 +12092,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12108,7 +12108,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12182,10 +12182,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12223,7 +12223,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12294,10 +12294,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12335,7 +12335,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12351,7 +12351,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12422,10 +12422,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12463,7 +12463,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12537,10 +12537,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12576,7 +12576,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12592,7 +12592,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12663,10 +12663,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12704,7 +12704,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12719,7 +12719,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12736,7 +12736,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12810,10 +12810,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12852,7 +12852,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12868,7 +12868,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12939,10 +12939,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12980,7 +12980,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12996,7 +12996,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13068,10 +13068,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13109,7 +13109,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13218,10 +13218,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16137,10 +16137,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -93,10 +93,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,10 +121,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -135,10 +135,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -147,10 +147,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -159,10 +159,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -171,10 +171,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -183,10 +183,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -195,10 +195,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -207,10 +207,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -219,10 +219,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -231,10 +231,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -243,10 +243,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -257,10 +257,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -522,10 +522,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -625,10 +625,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -699,10 +699,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1388,10 +1388,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1422,10 +1422,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1757,7 +1757,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1825,10 +1825,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1928,10 +1928,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2019,10 +2019,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2210,10 +2210,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2325,10 +2325,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2409,10 +2409,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2500,10 +2500,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2584,10 +2584,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2669,10 +2669,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2864,7 +2864,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2880,10 +2880,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8177,10 +8177,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8200,7 +8200,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8253,10 +8253,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8277,7 +8277,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8440,10 +8440,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8474,10 +8474,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8511,10 +8511,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8548,10 +8548,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8585,10 +8585,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8622,10 +8622,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8659,10 +8659,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8696,10 +8696,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8733,10 +8733,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8770,10 +8770,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8807,10 +8807,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8847,7 +8847,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8875,10 +8875,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8904,10 +8904,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8943,10 +8943,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8982,10 +8982,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9017,10 +9017,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9052,10 +9052,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9087,10 +9087,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9122,10 +9122,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9161,10 +9161,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9196,10 +9196,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9231,10 +9231,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9782,10 +9782,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9842,7 +9842,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9893,7 +9893,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9966,10 +9966,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10026,7 +10026,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10077,7 +10077,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10150,10 +10150,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10210,7 +10210,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10261,7 +10261,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10334,10 +10334,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10394,7 +10394,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10445,7 +10445,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10518,10 +10518,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10578,7 +10578,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10629,7 +10629,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10702,10 +10702,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10762,7 +10762,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10813,7 +10813,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10886,10 +10886,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10946,7 +10946,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10997,7 +10997,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11070,10 +11070,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11130,7 +11130,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11181,7 +11181,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11254,10 +11254,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11314,7 +11314,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11365,7 +11365,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11438,10 +11438,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11498,7 +11498,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11549,7 +11549,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11623,10 +11623,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11641,9 +11641,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 592948fc7be077e254c88c9790a26825a62a8631b9b1f9a0d5714168174b118d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11676,7 +11676,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11752,7 +11752,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11763,7 +11763,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "973ca12c13c86029dc0e4e69294403689165aefad2e5fd3932337c324b2bba2"
+        configChecksum: "19319effa9d18ce0527d4cc97511eb29076f5ab938672a21b90e05cd232f64d"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11772,7 +11772,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11865,10 +11865,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11908,7 +11908,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11936,10 +11936,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11977,7 +11977,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12051,10 +12051,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12092,7 +12092,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12108,7 +12108,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12182,10 +12182,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12223,7 +12223,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12294,10 +12294,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12335,7 +12335,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12351,7 +12351,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12422,10 +12422,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12463,7 +12463,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12537,10 +12537,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12576,7 +12576,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12592,7 +12592,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12663,10 +12663,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12704,7 +12704,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12719,7 +12719,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12736,7 +12736,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12810,10 +12810,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12852,7 +12852,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12868,7 +12868,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12939,10 +12939,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12980,7 +12980,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12996,7 +12996,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13068,10 +13068,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13109,7 +13109,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13218,10 +13218,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16137,10 +16137,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -93,10 +93,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,10 +121,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -135,10 +135,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -147,10 +147,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -159,10 +159,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -171,10 +171,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -183,10 +183,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -195,10 +195,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -207,10 +207,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -219,10 +219,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -231,10 +231,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -243,10 +243,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -257,10 +257,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -519,10 +519,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -622,10 +622,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -696,10 +696,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1385,10 +1385,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1419,10 +1419,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1754,7 +1754,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1822,10 +1822,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1921,10 +1921,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2012,10 +2012,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2203,10 +2203,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2318,10 +2318,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2402,10 +2402,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2493,10 +2493,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2577,10 +2577,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2662,10 +2662,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2857,7 +2857,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2873,10 +2873,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8170,10 +8170,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8193,7 +8193,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8246,10 +8246,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8270,7 +8270,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8433,10 +8433,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8467,10 +8467,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8504,10 +8504,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8541,10 +8541,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8578,10 +8578,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8615,10 +8615,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8652,10 +8652,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8689,10 +8689,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8726,10 +8726,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8763,10 +8763,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8800,10 +8800,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8840,7 +8840,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8868,10 +8868,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8897,10 +8897,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8936,10 +8936,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8975,10 +8975,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9010,10 +9010,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9045,10 +9045,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9080,10 +9080,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9115,10 +9115,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9154,10 +9154,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9189,10 +9189,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9224,10 +9224,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9775,10 +9775,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9835,7 +9835,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9886,7 +9886,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9959,10 +9959,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10019,7 +10019,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10070,7 +10070,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10143,10 +10143,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10203,7 +10203,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10254,7 +10254,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10327,10 +10327,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10387,7 +10387,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10438,7 +10438,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10511,10 +10511,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10571,7 +10571,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10622,7 +10622,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10695,10 +10695,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10755,7 +10755,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10806,7 +10806,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10879,10 +10879,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10939,7 +10939,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10990,7 +10990,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11063,10 +11063,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11123,7 +11123,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11174,7 +11174,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11247,10 +11247,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11307,7 +11307,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11358,7 +11358,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11431,10 +11431,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11491,7 +11491,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11542,7 +11542,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11616,10 +11616,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11634,9 +11634,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 592948fc7be077e254c88c9790a26825a62a8631b9b1f9a0d5714168174b118d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11669,7 +11669,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11745,7 +11745,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11756,7 +11756,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
+        configChecksum: "0498dbc7216c1af99a51f390acbb269e3d05901b36807fbd942fe64683e5c7a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11765,7 +11765,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11858,10 +11858,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11901,7 +11901,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11929,10 +11929,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11970,7 +11970,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12044,10 +12044,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12085,7 +12085,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12101,7 +12101,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12175,10 +12175,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12216,7 +12216,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12287,10 +12287,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12328,7 +12328,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12344,7 +12344,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12415,10 +12415,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12456,7 +12456,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12530,10 +12530,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12569,7 +12569,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12585,7 +12585,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12656,10 +12656,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12697,7 +12697,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12712,7 +12712,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12729,7 +12729,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12803,10 +12803,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12845,7 +12845,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12861,7 +12861,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12932,10 +12932,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12973,7 +12973,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12989,7 +12989,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13061,10 +13061,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13102,7 +13102,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13211,10 +13211,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16041,10 +16041,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -93,10 +93,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,10 +121,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -135,10 +135,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -147,10 +147,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -159,10 +159,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -171,10 +171,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -183,10 +183,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -195,10 +195,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -207,10 +207,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -219,10 +219,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -231,10 +231,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -243,10 +243,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -257,10 +257,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -519,10 +519,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -622,10 +622,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -696,10 +696,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1385,10 +1385,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1419,10 +1419,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1754,7 +1754,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1822,10 +1822,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1921,10 +1921,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2012,10 +2012,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2203,10 +2203,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2318,10 +2318,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2402,10 +2402,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2493,10 +2493,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2577,10 +2577,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2662,10 +2662,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2857,7 +2857,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2873,10 +2873,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8170,10 +8170,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8193,7 +8193,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8246,10 +8246,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8270,7 +8270,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8433,10 +8433,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8467,10 +8467,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8504,10 +8504,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8541,10 +8541,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8578,10 +8578,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8615,10 +8615,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8652,10 +8652,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8689,10 +8689,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8726,10 +8726,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8763,10 +8763,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8800,10 +8800,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8840,7 +8840,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8868,10 +8868,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8897,10 +8897,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8936,10 +8936,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8975,10 +8975,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9010,10 +9010,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9045,10 +9045,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9080,10 +9080,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9115,10 +9115,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9154,10 +9154,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9189,10 +9189,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9224,10 +9224,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9775,10 +9775,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9835,7 +9835,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9886,7 +9886,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9959,10 +9959,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10019,7 +10019,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10070,7 +10070,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10143,10 +10143,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10203,7 +10203,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10254,7 +10254,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10327,10 +10327,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10387,7 +10387,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10438,7 +10438,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10511,10 +10511,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10571,7 +10571,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10622,7 +10622,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10695,10 +10695,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10755,7 +10755,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10806,7 +10806,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10879,10 +10879,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10939,7 +10939,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10990,7 +10990,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11063,10 +11063,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11123,7 +11123,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11174,7 +11174,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11247,10 +11247,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11307,7 +11307,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11358,7 +11358,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11431,10 +11431,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11491,7 +11491,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11542,7 +11542,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11616,10 +11616,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11634,9 +11634,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: c2d7c6bc6e7e74deffd1981573ecde23c69d2000053efa1a3d87f4662f066e13
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 02eca2c99f0046aedf35bb8cbce10d80b01e26ee77025997132ba6226fc952ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11669,7 +11669,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11745,7 +11745,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11756,7 +11756,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d934993192c57461c36f5a1ea7e11e7d13831f60b8f4d47a881f202b36d4019"
+        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11765,7 +11765,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11858,10 +11858,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11901,7 +11901,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11929,10 +11929,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11970,7 +11970,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12044,10 +12044,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12085,7 +12085,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12101,7 +12101,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12175,10 +12175,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12216,7 +12216,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12287,10 +12287,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12328,7 +12328,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12344,7 +12344,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12415,10 +12415,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12456,7 +12456,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12530,10 +12530,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12569,7 +12569,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12585,7 +12585,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12656,10 +12656,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12697,7 +12697,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12712,7 +12712,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12729,7 +12729,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12803,10 +12803,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12845,7 +12845,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12861,7 +12861,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12932,10 +12932,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12973,7 +12973,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12989,7 +12989,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13061,10 +13061,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13102,7 +13102,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13211,10 +13211,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16041,10 +16041,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -39,10 +39,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -114,10 +114,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -127,10 +127,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -143,7 +143,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -155,10 +155,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -169,10 +169,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -181,10 +181,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -193,10 +193,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -205,10 +205,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -217,10 +217,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -229,10 +229,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -241,10 +241,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -253,10 +253,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -265,10 +265,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -277,10 +277,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -291,10 +291,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -553,10 +553,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -656,10 +656,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -730,10 +730,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1419,10 +1419,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1453,10 +1453,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1805,10 +1805,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1855,7 +1855,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1923,10 +1923,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2034,10 +2034,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2125,10 +2125,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2316,10 +2316,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2431,10 +2431,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2515,10 +2515,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2606,10 +2606,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2690,10 +2690,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2775,10 +2775,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2970,7 +2970,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2986,10 +2986,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8283,10 +8283,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8303,10 +8303,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -8322,7 +8322,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8375,10 +8375,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8396,10 +8396,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8420,7 +8420,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8583,10 +8583,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8617,10 +8617,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8654,10 +8654,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8691,10 +8691,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8728,10 +8728,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8765,10 +8765,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8802,10 +8802,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8839,10 +8839,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8876,10 +8876,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8913,10 +8913,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8950,10 +8950,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8986,10 +8986,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9013,7 +9013,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9041,10 +9041,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9070,10 +9070,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9109,10 +9109,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9148,10 +9148,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9183,10 +9183,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9218,10 +9218,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9253,10 +9253,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9288,10 +9288,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9327,10 +9327,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9362,10 +9362,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9397,10 +9397,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9948,10 +9948,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -10008,7 +10008,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10059,7 +10059,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10132,10 +10132,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10192,7 +10192,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10243,7 +10243,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10316,10 +10316,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10376,7 +10376,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10427,7 +10427,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10500,10 +10500,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10560,7 +10560,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10611,7 +10611,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10684,10 +10684,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10744,7 +10744,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10795,7 +10795,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10868,10 +10868,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10928,7 +10928,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10979,7 +10979,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11052,10 +11052,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -11112,7 +11112,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11163,7 +11163,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11236,10 +11236,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11296,7 +11296,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11347,7 +11347,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11420,10 +11420,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11480,7 +11480,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11531,7 +11531,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11604,10 +11604,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11664,7 +11664,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11715,7 +11715,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11789,10 +11789,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11807,9 +11807,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4a3ea9253e23a4aa16ab457653bfa75d93e82ccfc36cdea42045fd4d52feca92
-        checksum/router-cds: 3fa07499e2754611a58f13bf418d3990ca6be61bde7f1ed9a0daf8e94e44a203
-        checksum/router-lds: 7a3f346a2843d00d2acb4d42b854b31ffeccf74872fd38ad7575d73b80bd77c7
+        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
+        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
+        checksum/router-lds: 505becbb20df964e96bdc9ca840b377e401c6938b9c18e152c2a5ca1d5eb3c9d
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11842,7 +11842,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.3
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11915,10 +11915,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11933,7 +11933,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c22cf7a6094856b59f9142a2b9103bf39d729878c5566cfffd0bd2ed50dca8ad
+        checksum/config: 8d4cd7fa6621f57699fcd8ffdc54f9c12fbd9ec39d3e0ca3e1a1036bc12b2c05
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11959,7 +11959,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -12035,7 +12035,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12046,7 +12046,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d934993192c57461c36f5a1ea7e11e7d13831f60b8f4d47a881f202b36d4019"
+        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -12055,7 +12055,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.3
+        helm.sh/chart: controlplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12148,10 +12148,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -12191,7 +12191,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.3"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -12219,10 +12219,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12260,7 +12260,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12334,10 +12334,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12375,7 +12375,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12391,7 +12391,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12465,10 +12465,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12506,7 +12506,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12577,10 +12577,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12618,7 +12618,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12634,7 +12634,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12705,10 +12705,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12746,7 +12746,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12820,10 +12820,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12859,7 +12859,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12875,7 +12875,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12946,10 +12946,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12987,7 +12987,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -13002,7 +13002,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -13019,7 +13019,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -13093,10 +13093,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -13135,7 +13135,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -13151,7 +13151,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -13222,10 +13222,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13263,7 +13263,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13279,7 +13279,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13351,10 +13351,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13392,7 +13392,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.3
+          image: registry.unionai.cloud/controlplane/services:2026.6.5
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13495,10 +13495,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -13522,10 +13522,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.3
+    helm.sh/chart: controlplane-2026.6.5
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16441,10 +16441,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.3"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
           env:
             - name: APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -39,10 +39,10 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -114,10 +114,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -127,10 +127,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -143,7 +143,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -155,10 +155,10 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -169,10 +169,10 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -181,10 +181,10 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -193,10 +193,10 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -205,10 +205,10 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -217,10 +217,10 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -229,10 +229,10 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -241,10 +241,10 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -253,10 +253,10 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -265,10 +265,10 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -277,10 +277,10 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -291,10 +291,10 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -553,10 +553,10 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -656,10 +656,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -730,10 +730,10 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1419,10 +1419,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1453,10 +1453,10 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1805,10 +1805,10 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1855,7 +1855,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1923,10 +1923,10 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2034,10 +2034,10 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2125,10 +2125,10 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2316,10 +2316,10 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2431,10 +2431,10 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2515,10 +2515,10 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2606,10 +2606,10 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2690,10 +2690,10 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2775,10 +2775,10 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2970,7 +2970,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2986,10 +2986,10 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8283,10 +8283,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8303,10 +8303,10 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -8322,7 +8322,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8375,10 +8375,10 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8396,10 +8396,10 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8420,7 +8420,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8583,10 +8583,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8617,10 +8617,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8654,10 +8654,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8691,10 +8691,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8728,10 +8728,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8765,10 +8765,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8802,10 +8802,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8839,10 +8839,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8876,10 +8876,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8913,10 +8913,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8950,10 +8950,10 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8986,10 +8986,10 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9013,7 +9013,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9041,10 +9041,10 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9070,10 +9070,10 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9109,10 +9109,10 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9148,10 +9148,10 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9183,10 +9183,10 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9218,10 +9218,10 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9253,10 +9253,10 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9288,10 +9288,10 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9327,10 +9327,10 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9362,10 +9362,10 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9397,10 +9397,10 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9948,10 +9948,10 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -10008,7 +10008,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10059,7 +10059,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10132,10 +10132,10 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10192,7 +10192,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10243,7 +10243,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10316,10 +10316,10 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10376,7 +10376,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10427,7 +10427,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10500,10 +10500,10 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10560,7 +10560,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10611,7 +10611,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10684,10 +10684,10 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10744,7 +10744,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10795,7 +10795,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10868,10 +10868,10 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10928,7 +10928,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10979,7 +10979,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11052,10 +11052,10 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -11112,7 +11112,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11163,7 +11163,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11236,10 +11236,10 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11296,7 +11296,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11347,7 +11347,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11420,10 +11420,10 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11480,7 +11480,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11531,7 +11531,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11604,10 +11604,10 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11664,7 +11664,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11715,7 +11715,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11789,10 +11789,10 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11807,9 +11807,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 1f4fc103b5b27e6f62a3981380937559ccc5e8a4b48cf71543945561d2445922
-        checksum/router-cds: e0e8ed3e46dba20552a857fa66c1fed5e603c9c56b92c7cebae8eb16f5067366
-        checksum/router-lds: 505becbb20df964e96bdc9ca840b377e401c6938b9c18e152c2a5ca1d5eb3c9d
+        checksum/router-bootstrap: b461552209964add79f7bf2680382200683514a5ecadded548a3077c19c134d7
+        checksum/router-cds: 5346003e6e45bcd94c697a6f30b83c513ad0740b54f2c1967628599abdcde981
+        checksum/router-lds: 332b6c8a3ca0cfeb86381e697a03fad46a1042ebe2d399a61da8f33608733e31
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11842,7 +11842,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.5
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11915,10 +11915,10 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11933,7 +11933,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8d4cd7fa6621f57699fcd8ffdc54f9c12fbd9ec39d3e0ca3e1a1036bc12b2c05
+        checksum/config: aa36d198fb4ef5148c584c0120090a22d68811469ca3b3b45e69b98555ac15b3
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11959,7 +11959,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -12035,7 +12035,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12046,7 +12046,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aa00694eb6a0575a9ca17d619f09658362fedd10c7ed4c4ed3c6b61e3d7ea06"
+        configChecksum: "0498dbc7216c1af99a51f390acbb269e3d05901b36807fbd942fe64683e5c7a"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -12055,7 +12055,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.5
+        helm.sh/chart: controlplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12148,10 +12148,10 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -12191,7 +12191,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.5"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.6"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -12219,10 +12219,10 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12260,7 +12260,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12334,10 +12334,10 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12375,7 +12375,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12391,7 +12391,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12465,10 +12465,10 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12506,7 +12506,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12577,10 +12577,10 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12618,7 +12618,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12634,7 +12634,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12705,10 +12705,10 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12746,7 +12746,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12820,10 +12820,10 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12859,7 +12859,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12875,7 +12875,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12946,10 +12946,10 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12987,7 +12987,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -13002,7 +13002,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -13019,7 +13019,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -13093,10 +13093,10 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -13135,7 +13135,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -13151,7 +13151,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -13222,10 +13222,10 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13263,7 +13263,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13279,7 +13279,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13351,10 +13351,10 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13392,7 +13392,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.5
+          image: registry.unionai.cloud/controlplane/services:2026.6.6
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13495,10 +13495,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -13522,10 +13522,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.5
+    helm.sh/chart: controlplane-2026.6.6
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16441,10 +16441,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.5"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.6"
           env:
             - name: APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -6483,7 +6483,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6586,7 +6586,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6696,7 +6696,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6764,7 +6764,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6834,7 +6834,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6851,9 +6851,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6950,7 +6950,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7240,10 +7240,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7290,10 +7290,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -6483,7 +6483,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6586,7 +6586,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6696,7 +6696,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6764,7 +6764,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6834,7 +6834,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6851,9 +6851,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6950,7 +6950,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7240,10 +7240,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7290,10 +7290,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -6513,7 +6513,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6614,7 +6614,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6722,7 +6722,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6790,7 +6790,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6858,7 +6858,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6875,9 +6875,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6972,7 +6972,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7262,10 +7262,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7312,10 +7312,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -6513,7 +6513,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6614,7 +6614,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6722,7 +6722,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6790,7 +6790,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6858,7 +6858,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6875,9 +6875,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6972,7 +6972,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7262,10 +7262,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7312,10 +7312,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -7019,7 +7019,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -7120,7 +7120,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7228,7 +7228,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7296,7 +7296,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7364,7 +7364,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7381,9 +7381,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7478,7 +7478,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7857,10 +7857,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7907,10 +7907,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -7019,7 +7019,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -7120,7 +7120,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7228,7 +7228,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7296,7 +7296,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7364,7 +7364,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7381,9 +7381,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7478,7 +7478,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7857,10 +7857,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7907,10 +7907,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -6481,7 +6481,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6582,7 +6582,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6690,7 +6690,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6758,7 +6758,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6826,7 +6826,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6843,9 +6843,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6940,7 +6940,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7351,10 +7351,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7401,10 +7401,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -6481,7 +6481,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6582,7 +6582,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6690,7 +6690,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6758,7 +6758,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6826,7 +6826,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6843,9 +6843,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6940,7 +6940,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7351,10 +7351,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7401,10 +7401,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -6946,7 +6946,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -7047,7 +7047,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7155,7 +7155,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7223,7 +7223,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7291,7 +7291,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7308,9 +7308,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7405,7 +7405,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7727,10 +7727,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7777,10 +7777,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -6946,7 +6946,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -7047,7 +7047,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7155,7 +7155,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7223,7 +7223,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7291,7 +7291,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7308,9 +7308,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7405,7 +7405,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7727,10 +7727,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7777,10 +7777,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -131,7 +131,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -160,7 +160,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -174,7 +174,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -212,7 +212,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -895,7 +895,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1131,7 +1131,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1346,7 +1346,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1420,7 +1420,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1580,7 +1580,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1719,7 +1719,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1788,7 +1788,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2047,7 +2047,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2151,7 +2151,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2239,7 +2239,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2305,7 +2305,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2390,7 +2390,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2600,7 +2600,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2724,7 +2724,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5847,7 +5847,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5880,7 +5880,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5917,7 +5917,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5933,7 +5933,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5974,7 +5974,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5994,7 +5994,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6014,7 +6014,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6045,7 +6045,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6113,7 +6113,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6138,7 +6138,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6196,7 +6196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6218,7 +6218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6239,7 +6239,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6260,7 +6260,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6412,7 +6412,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6850,7 +6850,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7252,7 +7252,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7287,7 +7287,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7314,7 +7314,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7344,7 +7344,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7374,7 +7374,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7403,7 +7403,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7427,7 +7427,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7454,7 +7454,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8363,7 +8363,7 @@ spec:
         - name: dataproxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8512,7 +8512,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8641,7 +8641,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8745,7 +8745,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8858,7 +8858,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8957,7 +8957,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -8973,7 +8973,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.6.5
+        helm.sh/chart: dataplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -8984,14 +8984,14 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 166bd60fe45cf605d06bc7685b4fd598e1d9470fdebec94db9a55087af28e097
+        checksum/bootstrap-config: f3c2bcf79d021f692138592a149e70b9919897dddeb3c28fcfc296c34c247649
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
         - name: kourier-gateway
-          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.5
+          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.6
           args:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
@@ -9100,7 +9100,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9125,7 +9125,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.6.5
+        helm.sh/chart: dataplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9134,7 +9134,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5
+          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6
           command:
             - /bin/kourier
           env:
@@ -9232,7 +9232,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9484,7 +9484,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9585,7 +9585,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9693,7 +9693,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9803,7 +9803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9820,9 +9820,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9917,7 +9917,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10038,7 +10038,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10073,7 +10073,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10118,7 +10118,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10305,7 +10305,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10512,7 +10512,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10557,7 +10557,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10749,7 +10749,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10784,7 +10784,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -131,7 +131,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -160,7 +160,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -174,7 +174,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -212,7 +212,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -895,7 +895,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1131,7 +1131,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1346,7 +1346,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1420,7 +1420,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1580,7 +1580,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1719,7 +1719,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1788,7 +1788,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2047,7 +2047,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2151,7 +2151,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2239,7 +2239,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2305,7 +2305,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2390,7 +2390,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2600,7 +2600,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2724,7 +2724,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5847,7 +5847,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5880,7 +5880,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5917,7 +5917,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5933,7 +5933,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5974,7 +5974,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5994,7 +5994,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6014,7 +6014,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6045,7 +6045,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6113,7 +6113,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6138,7 +6138,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6196,7 +6196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6218,7 +6218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6239,7 +6239,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6260,7 +6260,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6412,7 +6412,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6850,7 +6850,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7252,7 +7252,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7287,7 +7287,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7314,7 +7314,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7344,7 +7344,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7374,7 +7374,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7403,7 +7403,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7427,7 +7427,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7454,7 +7454,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8363,7 +8363,7 @@ spec:
         - name: dataproxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8512,7 +8512,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8641,7 +8641,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8745,7 +8745,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8858,7 +8858,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8957,7 +8957,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -8973,7 +8973,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.6.3
+        helm.sh/chart: dataplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -8984,14 +8984,14 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: e19511e4fb8a2d81e71aacfa21a5c0c89fb3ddb178e6e91c6d65d5dd077f002a
+        checksum/bootstrap-config: 166bd60fe45cf605d06bc7685b4fd598e1d9470fdebec94db9a55087af28e097
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
         - name: kourier-gateway
-          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.3
+          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.5
           args:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
@@ -9100,7 +9100,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9125,7 +9125,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.6.3
+        helm.sh/chart: dataplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9134,7 +9134,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3
+          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5
           command:
             - /bin/kourier
           env:
@@ -9232,7 +9232,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9484,7 +9484,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9585,7 +9585,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9693,7 +9693,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9803,7 +9803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9820,9 +9820,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9917,7 +9917,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10038,7 +10038,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10073,7 +10073,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10118,7 +10118,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10305,7 +10305,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10512,7 +10512,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10557,7 +10557,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10749,7 +10749,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10784,7 +10784,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -131,7 +131,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -160,7 +160,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -174,7 +174,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -212,7 +212,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -895,7 +895,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1131,7 +1131,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1346,7 +1346,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1420,7 +1420,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1580,7 +1580,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1719,7 +1719,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1788,7 +1788,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2047,7 +2047,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2151,7 +2151,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2239,7 +2239,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2305,7 +2305,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2390,7 +2390,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2600,7 +2600,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2724,7 +2724,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5847,7 +5847,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5880,7 +5880,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5917,7 +5917,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5933,7 +5933,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5974,7 +5974,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5994,7 +5994,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6014,7 +6014,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6045,7 +6045,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6113,7 +6113,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6138,7 +6138,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6196,7 +6196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6218,7 +6218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6239,7 +6239,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6260,7 +6260,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6412,7 +6412,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6850,7 +6850,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7252,7 +7252,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7287,7 +7287,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7314,7 +7314,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7344,7 +7344,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7374,7 +7374,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7403,7 +7403,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7427,7 +7427,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7454,7 +7454,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8363,7 +8363,7 @@ spec:
         - name: dataproxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8512,7 +8512,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8641,7 +8641,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8745,7 +8745,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8858,7 +8858,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8957,7 +8957,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -8973,7 +8973,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.6.5
+        helm.sh/chart: dataplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -8984,14 +8984,14 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: da6a5e0b524092c9c05b2296015617342886e571eb55aa8714b9d5ba2af72c83
+        checksum/bootstrap-config: f6c1da38caadab033a507ce7d7a972fff7add686179f59c94b59f2f9c9c3a1d5
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
         - name: kourier-gateway
-          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.5
+          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.6
           args:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
@@ -9100,7 +9100,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9125,7 +9125,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.6.5
+        helm.sh/chart: dataplane-2026.6.6
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9134,7 +9134,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5
+          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6
           command:
             - /bin/kourier
           env:
@@ -9232,7 +9232,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9484,7 +9484,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9585,7 +9585,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9693,7 +9693,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9803,7 +9803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9820,9 +9820,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9917,7 +9917,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10038,7 +10038,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10073,7 +10073,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10118,7 +10118,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10305,7 +10305,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10512,7 +10512,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10557,7 +10557,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10749,7 +10749,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10784,7 +10784,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -131,7 +131,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -160,7 +160,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -174,7 +174,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -212,7 +212,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -895,7 +895,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1131,7 +1131,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1346,7 +1346,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1420,7 +1420,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1580,7 +1580,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1719,7 +1719,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1788,7 +1788,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2047,7 +2047,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2151,7 +2151,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2239,7 +2239,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2305,7 +2305,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2390,7 +2390,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2600,7 +2600,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2724,7 +2724,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5847,7 +5847,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5880,7 +5880,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5917,7 +5917,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5933,7 +5933,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5974,7 +5974,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5994,7 +5994,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6014,7 +6014,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6045,7 +6045,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6113,7 +6113,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6138,7 +6138,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6196,7 +6196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6218,7 +6218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6239,7 +6239,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6260,7 +6260,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6412,7 +6412,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6850,7 +6850,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7252,7 +7252,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7287,7 +7287,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7314,7 +7314,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7344,7 +7344,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7374,7 +7374,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7403,7 +7403,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7427,7 +7427,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7454,7 +7454,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8363,7 +8363,7 @@ spec:
         - name: dataproxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8512,7 +8512,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8641,7 +8641,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8745,7 +8745,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8858,7 +8858,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8957,7 +8957,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -8973,7 +8973,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.6.3
+        helm.sh/chart: dataplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -8984,14 +8984,14 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 3894f5e103c46904a368152e35c2b6bd8fdc07434f6155abf630b91f1f4e08f7
+        checksum/bootstrap-config: da6a5e0b524092c9c05b2296015617342886e571eb55aa8714b9d5ba2af72c83
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
         - name: kourier-gateway
-          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.3
+          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.5
           args:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
@@ -9100,7 +9100,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9125,7 +9125,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.6.3
+        helm.sh/chart: dataplane-2026.6.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9134,7 +9134,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3
+          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5
           command:
             - /bin/kourier
           env:
@@ -9232,7 +9232,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9484,7 +9484,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9585,7 +9585,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9693,7 +9693,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9803,7 +9803,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9820,9 +9820,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9917,7 +9917,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -10038,7 +10038,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10073,7 +10073,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10118,7 +10118,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10305,7 +10305,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10512,7 +10512,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10557,7 +10557,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10749,7 +10749,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10784,7 +10784,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -6549,7 +6549,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6651,7 +6651,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6760,7 +6760,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6828,7 +6828,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6897,7 +6897,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6914,9 +6914,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7012,7 +7012,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7302,10 +7302,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7352,10 +7352,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -6549,7 +6549,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6651,7 +6651,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6760,7 +6760,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6828,7 +6828,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6897,7 +6897,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6914,9 +6914,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7012,7 +7012,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7302,10 +7302,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7352,10 +7352,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -6549,7 +6549,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6651,7 +6651,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6760,7 +6760,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6828,7 +6828,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6897,7 +6897,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6914,9 +6914,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7012,7 +7012,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7302,10 +7302,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7352,10 +7352,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -6549,7 +6549,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6651,7 +6651,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6760,7 +6760,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6828,7 +6828,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6897,7 +6897,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6914,9 +6914,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7012,7 +7012,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7302,10 +7302,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7352,10 +7352,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -6427,7 +6427,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -6682,7 +6682,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6783,7 +6783,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6893,7 +6893,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6961,7 +6961,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7029,7 +7029,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7046,9 +7046,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7143,7 +7143,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7419,10 +7419,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7469,10 +7469,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -6427,7 +6427,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -6682,7 +6682,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6783,7 +6783,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6893,7 +6893,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6961,7 +6961,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7029,7 +7029,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7046,9 +7046,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7143,7 +7143,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7419,10 +7419,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7469,10 +7469,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -6498,7 +6498,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6599,7 +6599,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6707,7 +6707,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6775,7 +6775,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6843,7 +6843,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6860,9 +6860,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6957,7 +6957,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7247,10 +7247,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7297,10 +7297,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -6498,7 +6498,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6599,7 +6599,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6707,7 +6707,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6775,7 +6775,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6843,7 +6843,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6860,9 +6860,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6957,7 +6957,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7247,10 +7247,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7297,10 +7297,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -6829,7 +6829,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6930,7 +6930,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7038,7 +7038,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7106,7 +7106,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7174,7 +7174,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7191,9 +7191,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7288,7 +7288,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7610,10 +7610,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7660,10 +7660,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -6829,7 +6829,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6930,7 +6930,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7038,7 +7038,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7106,7 +7106,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7174,7 +7174,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7191,9 +7191,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7288,7 +7288,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7610,10 +7610,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7660,10 +7660,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -6497,7 +6497,7 @@ spec:
             name: leaseworker
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6588,7 +6588,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6689,7 +6689,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6794,7 +6794,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6809,9 +6809,9 @@ spec:
               name: config-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6906,7 +6906,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7320,10 +7320,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7370,10 +7370,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -6497,7 +6497,7 @@ spec:
             name: leaseworker
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6588,7 +6588,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6689,7 +6689,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6794,7 +6794,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6809,9 +6809,9 @@ spec:
               name: config-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6906,7 +6906,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7320,10 +7320,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7370,10 +7370,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -6496,7 +6496,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6597,7 +6597,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6705,7 +6705,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6773,7 +6773,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6841,7 +6841,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6858,9 +6858,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6955,7 +6955,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7245,10 +7245,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7295,10 +7295,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -6496,7 +6496,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6597,7 +6597,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6705,7 +6705,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6773,7 +6773,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6841,7 +6841,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6858,9 +6858,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6955,7 +6955,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7245,10 +7245,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7295,10 +7295,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -6521,7 +6521,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6622,7 +6622,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6730,7 +6730,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6798,7 +6798,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6866,7 +6866,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6883,9 +6883,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6980,7 +6980,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7270,10 +7270,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7320,10 +7320,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -6521,7 +6521,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6622,7 +6622,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6730,7 +6730,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6798,7 +6798,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6866,7 +6866,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6883,9 +6883,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6980,7 +6980,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7270,10 +7270,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7320,10 +7320,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -8635,7 +8635,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -8736,7 +8736,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -8844,7 +8844,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8912,7 +8912,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -8980,7 +8980,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8997,9 +8997,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9094,7 +9094,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -13863,10 +13863,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -13913,10 +13913,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -8635,7 +8635,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -8736,7 +8736,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -8844,7 +8844,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8912,7 +8912,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -8980,7 +8980,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8997,9 +8997,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9094,7 +9094,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -13863,10 +13863,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -13913,10 +13913,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -5946,7 +5946,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6648,7 +6648,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6749,7 +6749,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6857,7 +6857,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6925,7 +6925,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6993,7 +6993,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7010,9 +7010,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7107,7 +7107,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7397,10 +7397,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7447,10 +7447,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -5946,7 +5946,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6648,7 +6648,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6749,7 +6749,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6857,7 +6857,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6925,7 +6925,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6993,7 +6993,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7010,9 +7010,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7107,7 +7107,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7397,10 +7397,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7447,10 +7447,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -6542,7 +6542,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6656,7 +6656,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6777,7 +6777,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6851,7 +6851,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6926,7 +6926,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6943,9 +6943,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7053,7 +7053,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7356,10 +7356,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7406,10 +7406,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -6542,7 +6542,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6656,7 +6656,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6777,7 +6777,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6851,7 +6851,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6926,7 +6926,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6943,9 +6943,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7053,7 +7053,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7356,10 +7356,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7406,10 +7406,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -6505,7 +6505,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6606,7 +6606,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6714,7 +6714,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6782,7 +6782,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6850,7 +6850,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6867,9 +6867,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: HELM_APP_VERSION
-              value: "2026.6.5"
+              value: "2026.6.6"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6964,7 +6964,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.6"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7254,10 +7254,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.5
+    helm.sh/chart: dataplane-2026.6.6
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.5"
+    app.kubernetes.io/version: "2026.6.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7304,10 +7304,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.5
+      helm.sh/chart: dataplane-2026.6.6
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.5"
+      app.kubernetes.io/version: "2026.6.6"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -6505,7 +6505,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6606,7 +6606,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6714,7 +6714,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6782,7 +6782,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6850,7 +6850,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6867,9 +6867,9 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: HELM_APP_VERSION
-              value: "2026.6.3"
+              value: "2026.6.5"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6964,7 +6964,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.3"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.5"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7254,10 +7254,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.3
+    helm.sh/chart: dataplane-2026.6.5
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.3"
+    app.kubernetes.io/version: "2026.6.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7304,10 +7304,10 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.3
+      helm.sh/chart: dataplane-2026.6.5
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.3"
+      app.kubernetes.io/version: "2026.6.5"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/knative-migration.adoption.yaml
+++ b/tests/generated/knative-migration.adoption.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.5.0
+        helm.sh/chart: knative-migration-2026.6.5
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.adoption.yaml
+++ b/tests/generated/knative-migration.adoption.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.6.5
+        helm.sh/chart: knative-migration-2026.6.6
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.argocd-presync.yaml
+++ b/tests/generated/knative-migration.argocd-presync.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -76,7 +76,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -96,7 +96,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -120,7 +120,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -135,7 +135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.5.0
+        helm.sh/chart: knative-migration-2026.6.5
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.argocd-presync.yaml
+++ b/tests/generated/knative-migration.argocd-presync.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -76,7 +76,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -96,7 +96,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -120,7 +120,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -135,7 +135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.6.5
+        helm.sh/chart: knative-migration-2026.6.6
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.default.yaml
+++ b/tests/generated/knative-migration.default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.5.0
+    helm.sh/chart: knative-migration-2026.6.5
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.5.0
+        helm.sh/chart: knative-migration-2026.6.5
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.default.yaml
+++ b/tests/generated/knative-migration.default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.5
+    helm.sh/chart: knative-migration-2026.6.6
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.6.5
+        helm.sh/chart: knative-migration-2026.6.6
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Also support 'metal' type managed cluster installations.