### PR TITLE
FAB-241: consolidate image-pull-secrets into podInject + build-image push wiring

### DIFF
--- a/charts/controlplane/files/build_image_task.py
+++ b/charts/controlplane/files/build_image_task.py
@@ -2,17 +2,17 @@
 controlplane chart's post-install / post-upgrade Helm hook Job
 (see templates/image-builder-bootstrap/).
 
-Two env vars are required at registration time:
-  APP_VERSION              — image tag for build-image + frontend-v2
-                             (set by the Job from .Chart.AppVersion).
-  UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                             frontend-v2 images live
-                             (set by the Job from values.imageBuilder.bootstrap
-                             .unionImageNamePrefix).
+Required env vars at registration time:
+  APP_VERSION              — image tag for build-image + frontend-v2.
+  UNION_IMAGE_NAME_PREFIX  — registry prefix.
 
-Per-namespace defaults consumed at task execution time come from the
-`build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+Optional env vars:
+  IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                   (kubernetes.io/dockerconfigjson) at
+                                   /etc/flyte/secrets/dockerconfigjson so
+                                   the build image's getDockerCredentials
+                                   picks it up alongside legacy Flyte
+                                   secrets in the same directory.
 """
 import os
 
@@ -29,6 +29,7 @@ from kubernetes.client import (
     V1VolumeProjection,
     V1ServiceAccountTokenProjection,
     V1ConfigMapVolumeSource,
+    V1SecretVolumeSource,
     V1KeyToPath,
 )
 
@@ -39,9 +40,12 @@ from flyte.extras import ContainerTask
 _DEFAULT_CONFIGMAP_NAME = "build-image-config"
 _STORAGE_YAML_KEY = "storage.yaml"
 _CONFIG_DIR = "/etc/union/config"
+_PUSH_CREDS_DIR = "/etc/flyte/secrets"
+_PUSH_CREDS_FILE = "dockerconfigjson"
 
 config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
 log_level = os.getenv("LOG_LEVEL", "5")
+push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
 
 union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
 if not union_image_name_prefix:
@@ -50,6 +54,71 @@ if not union_image_name_prefix:
 app_version = os.getenv("APP_VERSION")
 if not app_version:
     raise ValueError("APP_VERSION environment variable must be set")
+
+
+_volume_mounts = [
+    V1VolumeMount(
+        mount_path="/var/run/secrets/union/registry",
+        name="registry-token",
+        read_only=True,
+    ),
+    V1VolumeMount(
+        name="config-volume",
+        mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+        sub_path=_STORAGE_YAML_KEY,
+    ),
+]
+
+_volumes = [
+    V1Volume(
+        name="registry-token",
+        projected=V1ProjectedVolumeSource(
+            sources=[
+                V1VolumeProjection(
+                    service_account_token=V1ServiceAccountTokenProjection(
+                        audience="registry",
+                        expiration_seconds=7200,
+                        path="token",
+                    )
+                )
+            ]
+        ),
+    ),
+    V1Volume(
+        name="config-volume",
+        config_map=V1ConfigMapVolumeSource(
+            name=config_map_name,
+            items=[
+                V1KeyToPath(
+                    key=_STORAGE_YAML_KEY,
+                    path=_STORAGE_YAML_KEY,
+                )
+            ],
+        ),
+    ),
+]
+
+if push_secret_name:
+    # Key default for kubernetes.io/dockerconfigjson Secrets is
+    # ".dockerconfigjson" (leading dot). The build-image consumer skips
+    # hidden files, so remap to dockerconfigjson without the dot.
+    _volume_mounts.append(
+        V1VolumeMount(
+            name="image-builder-push-creds",
+            mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+            sub_path=_PUSH_CREDS_FILE,
+            read_only=True,
+        )
+    )
+    _volumes.append(
+        V1Volume(
+            name="image-builder-push-creds",
+            secret=V1SecretVolumeSource(
+                secret_name=push_secret_name,
+                items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+            ),
+        )
+    )
 
 build_image_task = ContainerTask(
     name="build-image",
@@ -65,18 +134,7 @@ build_image_task = ContainerTask(
                     name="main",
                     image_pull_policy="Always",
                     termination_message_policy="FallbackToLogsOnError",
-                    volume_mounts=[
-                        V1VolumeMount(
-                            mount_path="/var/run/secrets/union/registry",
-                            name="registry-token",
-                            read_only=True,
-                        ),
-                        V1VolumeMount(
-                            name="config-volume",
-                            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                            sub_path=_STORAGE_YAML_KEY,
-                        ),
-                    ],
+                    volume_mounts=_volume_mounts,
                     env=[
                         V1EnvVar(
                             name="ORGANIZATION",
@@ -130,34 +188,7 @@ build_image_task = ContainerTask(
                     ],
                 ),
             ],
-            volumes=[
-                V1Volume(
-                    name="registry-token",
-                    projected=V1ProjectedVolumeSource(
-                        sources=[
-                            V1VolumeProjection(
-                                service_account_token=V1ServiceAccountTokenProjection(
-                                    audience="registry",
-                                    expiration_seconds=7200,
-                                    path="token",
-                                )
-                            )
-                        ]
-                    ),
-                ),
-                V1Volume(
-                    name="config-volume",
-                    config_map=V1ConfigMapVolumeSource(
-                        name=config_map_name,
-                        items=[
-                            V1KeyToPath(
-                                key=_STORAGE_YAML_KEY,
-                                path=_STORAGE_YAML_KEY,
-                            )
-                        ],
-                    ),
-                ),
-            ],
+            volumes=_volumes,
         ),
     ),
     command=[

--- a/charts/controlplane/templates/image-builder-bootstrap/job.yaml
+++ b/charts/controlplane/templates/image-builder-bootstrap/job.yaml
@@ -43,6 +43,10 @@ spec:
               value: {{ .Values.imageBuilder.bootstrap.unionImageNamePrefix | quote }}
             - name: FLYTECTL_CONFIG
               value: /etc/flyte/config.yaml
+            {{- with .Values.imageBuilder.bootstrap.pushSecretName }}
+            - name: IMAGE_BUILDER_PUSH_SECRET_NAME
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.imageBuilder.bootstrap.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -162,15 +162,9 @@ imageBuilder:
     # mirroring to a private registry.
     unionImageNamePrefix: public.ecr.aws/g1m2l3c1/imagebuilder-staging
 
-    # Name of the K8s Secret (kubernetes.io/dockerconfigjson type) the
-    # build-image task should mount as its push credential. When set,
-    # the bootstrap Job passes the name through to build_image_task.py
-    # via the IMAGE_BUILDER_PUSH_SECRET_NAME env var; the rendered task
-    # mounts the Secret's .dockerconfigjson key at
-    # /etc/flyte/secrets/dockerconfigjson so getDockerCredentials picks
-    # it up. The Secret must exist in every NS the task runs in (the
-    # dataplane chart's operator-mirror puts it there when
-    # secrets.imageBuilder.push is enabled).
+    # -- Name of a kubernetes.io/dockerconfigjson Secret the build-image
+    # task mounts as its registry push credential. Must exist in every
+    # namespace the task runs in. Empty disables the push-credential mount.
     pushSecretName: ""
 
     # Where the build-image task is registered. Convention is system/production.

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -162,6 +162,17 @@ imageBuilder:
     # mirroring to a private registry.
     unionImageNamePrefix: public.ecr.aws/g1m2l3c1/imagebuilder-staging
 
+    # Name of the K8s Secret (kubernetes.io/dockerconfigjson type) the
+    # build-image task should mount as its push credential. When set,
+    # the bootstrap Job passes the name through to build_image_task.py
+    # via the IMAGE_BUILDER_PUSH_SECRET_NAME env var; the rendered task
+    # mounts the Secret's .dockerconfigjson key at
+    # /etc/flyte/secrets/dockerconfigjson so getDockerCredentials picks
+    # it up. The Secret must exist in every NS the task runs in (the
+    # dataplane chart's operator-mirror puts it there when
+    # secrets.imageBuilder.push is enabled).
+    pushSecretName: ""
+
     # Where the build-image task is registered. Convention is system/production.
     # The Job creates the project if it doesn't already exist.
     project: system

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1556,12 +1556,25 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
-{{/* FAB-241 file-mount: list-of-corev1-Volume/VolumeMount pairs the
-flytepropeller webhook injects onto matching task pods. Two unconditional
-entries (config.yaml ConfigMap + client_secret Secret) plus a conditional
-ca.crt Secret when secrets.internalCaCert is enabled. Mirror-presence in
-the target NS (managedByLabelValue) is what gates injection at admission
-time; no magic Flyte-secret-key string. */}}
+{{/* file-mount block lives on the leaseworker and executor configs
+(see "dataplane.fileMountConfig" below). The webhook no longer carries
+fileMount; controllers inject at pod-creation time. */}}
+{{- if include "singleNamespace" . }}
+propeller:
+  limit-namespace: {{ .Release.Namespace }}
+{{- end }}
+webhook:
+{{- tpl (toYaml $webhook) . | nindent 2 }}
+{{- end -}}
+
+{{/*
+  Controller-side fileMount block, included by both leaseworker and
+  executor configs. Replaces the legacy webhook fileMount path.
+
+  Unconditional entries: config.yaml ConfigMap + client_secret Secret.
+  Conditional ca.crt Secret when secrets.internalCaCert is enabled.
+*/}}
+{{- define "dataplane.fileMountConfig" -}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
 {{- $mounts := list
     (dict
@@ -1605,16 +1618,10 @@ time; no magic Flyte-secret-key string. */}}
     )
 }}
 {{- end }}
-{{- $_ := set $webhook "fileMount" (dict
-    "enabled" true
-    "managedByLabelValue" (.Values.mirroring.managedByLabelValue | default "union-operator")
-    "mounts" $mounts
-) }}
+fileMount:
+  enabled: true
+  managedByLabelValue: {{ .Values.mirroring.managedByLabelValue | default "union-operator" | quote }}
+  mounts:
+{{ toYaml $mounts | indent 4 }}
 {{- end }}
-{{- if include "singleNamespace" . }}
-propeller:
-  limit-namespace: {{ .Release.Namespace }}
-{{- end }}
-webhook:
-{{- tpl (toYaml $webhook) . | nindent 2 }}
 {{- end -}}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1546,6 +1546,22 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
+{{/* FAB-241 file-mount: when eagerClientCreds is enabled, switch the webhook
+to inject the ConfigMap + Secret as volume mounts instead of env vars for
+matching SecurityContext.Secrets entries. Pre-check is wired by mirrorcheck
+inside flyte. Single customer-facing flag (secrets.eagerClientCreds.enabled)
+auto-derives the entire file-mount path. */}}
+{{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $_ := set $webhook "fileMount" (dict
+    "enabled" true
+    "secretKeyMatch" "EAGER_API_KEY"
+    "configMapName" (include "secrets.eagerOAuthConfig.configMapName" .)
+    "secretName" (include "secrets.eagerClientCreds.secretName" .)
+    "configMapMountPath" (.Values.mirroring.eagerOAuth.configMapMountPath | default "/etc/flyte/config.yaml")
+    "secretMountPath" (.Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret")
+    "managedByLabelValue" (.Values.mirroring.managedByLabelValue | default "union-operator")
+) }}
+{{- end }}
 {{- if include "singleNamespace" . }}
 propeller:
   limit-namespace: {{ .Release.Namespace }}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1546,20 +1546,59 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
-{{/* FAB-241 file-mount: when eagerClientCreds is enabled, switch the webhook
-to inject the ConfigMap + Secret as volume mounts instead of env vars for
-matching SecurityContext.Secrets entries. Pre-check is wired by mirrorcheck
-inside flyte. Single customer-facing flag (secrets.eagerClientCreds.enabled)
-auto-derives the entire file-mount path. */}}
+{{/* FAB-241 file-mount: list-of-corev1-Volume/VolumeMount pairs the
+flytepropeller webhook injects onto matching task pods. Two unconditional
+entries (config.yaml ConfigMap + client_secret Secret) plus a conditional
+ca.crt Secret when secrets.internalCaCert is enabled. Mirror-presence in
+the target NS (managedByLabelValue) is what gates injection at admission
+time; no magic Flyte-secret-key string. */}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $mounts := list
+    (dict
+      "volume" (dict
+        "name" "union-eager-auth-config"
+        "configMap" (dict "name" (include "secrets.eagerOAuthConfig.configMapName" .))
+      )
+      "volumeMount" (dict
+        "name" "union-eager-auth-config"
+        "mountPath" "/etc/flyte/config.yaml"
+        "subPath" "config.yaml"
+        "readOnly" true
+      )
+    )
+    (dict
+      "volume" (dict
+        "name" "union-eager-client-secret"
+        "secret" (dict "secretName" (include "secrets.eagerClientCreds.secretName" .))
+      )
+      "volumeMount" (dict
+        "name" "union-eager-client-secret"
+        "mountPath" "/etc/flyte/credentials/client_secret"
+        "subPath" "client_secret"
+        "readOnly" true
+      )
+    )
+}}
+{{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
+{{- $mounts = append $mounts
+    (dict
+      "volume" (dict
+        "name" "union-internal-ca"
+        "secret" (dict "secretName" (include "secrets.internalCaCert.secretName" .))
+      )
+      "volumeMount" (dict
+        "name" "union-internal-ca"
+        "mountPath" "/etc/flyte/credentials/ca.crt"
+        "subPath" "ca.crt"
+        "readOnly" true
+      )
+    )
+}}
+{{- end }}
 {{- $_ := set $webhook "fileMount" (dict
     "enabled" true
-    "secretKeyMatch" "EAGER_API_KEY"
-    "configMapName" (include "secrets.eagerOAuthConfig.configMapName" .)
-    "secretName" (include "secrets.eagerClientCreds.secretName" .)
-    "configMapMountPath" (.Values.mirroring.eagerOAuth.configMapMountPath | default "/etc/flyte/config.yaml")
-    "secretMountPath" (.Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret")
     "managedByLabelValue" (.Values.mirroring.managedByLabelValue | default "union-operator")
+    "mounts" $mounts
 ) }}
 {{- end }}
 {{- if include "singleNamespace" . }}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -783,6 +783,16 @@ plugins:
       {{ include "var.FLYTE_AWS_ACCESS_KEY_ID" . | indent 6 }}
       {{ include "var.FLYTE_AWS_SECRET_ACCESS_KEY" . | indent 6 }}
       {{- end }}
+      {{- /*
+           When the file-mount path is on, the SDK config + creds live at
+           /etc/flyte/config.yaml on the task pod (mounted by the webhook from
+           the eager-oauth-config ConfigMap). Point the SDK at it via the
+           standard FLYTECTL_CONFIG env var so init_in_cluster()'s
+           resolve_config_path() picks it up.
+      */}}
+      {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+      - FLYTECTL_CONFIG: "/etc/flyte/config.yaml"
+      {{- end }}
       {{- range $k, $v := .Values.additionalPodEnvVars }}
       - {{ $k }}: {{ $v | quote }}
       {{- end }}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1556,8 +1556,17 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
-{{/* file-mount block lives on the leaseworker and executor configs
-(see "dataplane.fileMountConfig" below). The webhook no longer carries
+{{- /* When chart-managed pull is enabled, controllers handle imagePullSecrets
+       via podInjectConfig; turn off the webhook's lazy mirror path. */}}
+{{- if eq (include "secrets.imageBuilder.pull.enabled" .) "true" }}
+{{- $emsc := deepCopy (index $webhook "embeddedSecretManagerConfig" | default dict) }}
+{{- $ips := deepCopy (index $emsc "imagePullSecrets" | default dict) }}
+{{- $_ := set $ips "enabled" false }}
+{{- $_ = set $emsc "imagePullSecrets" $ips }}
+{{- $_ = set $webhook "embeddedSecretManagerConfig" $emsc }}
+{{- end }}
+{{/* podInject block lives on the leaseworker and executor configs
+(see "dataplane.podInjectConfig" below). The webhook no longer carries
 fileMount; controllers inject at pod-creation time. */}}
 {{- if include "singleNamespace" . }}
 propeller:
@@ -1568,15 +1577,24 @@ webhook:
 {{- end -}}
 
 {{/*
-  Controller-side fileMount block, included by both leaseworker and
-  executor configs. Replaces the legacy webhook fileMount path.
+  Controller-side podInject block, included by both leaseworker and
+  executor configs. Replaces the legacy webhook fileMount path AND the
+  webhook's lazy image-pull-secret injection.
 
-  Unconditional entries: config.yaml ConfigMap + client_secret Secret.
-  Conditional ca.crt Secret when secrets.internalCaCert is enabled.
+  Mounts: eager config.yaml + client_secret unconditionally;
+  internal-ca.crt when secrets.internalCaCert is enabled.
+
+  ImagePullSecrets: image-builder-pull when secrets.imageBuilder.pull
+  is enabled — chart-mirrored into every task NS by the operator's
+  ManifestMirrorSyncer.
 */}}
-{{- define "dataplane.fileMountConfig" -}}
-{{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-{{- $mounts := list
+{{- define "dataplane.podInjectConfig" -}}
+{{- $hasFileMounts := eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $hasImagePull := eq (include "secrets.imageBuilder.pull.enabled" .) "true" }}
+{{- if or $hasFileMounts $hasImagePull }}
+{{- $mounts := list }}
+{{- if $hasFileMounts }}
+{{- $mounts = list
     (dict
       "volume" (dict
         "name" "union-eager-auth-config"
@@ -1618,10 +1636,17 @@ webhook:
     )
 }}
 {{- end }}
-fileMount:
+{{- end }}
+{{- $imagePullSecrets := list }}
+{{- if $hasImagePull }}
+{{- $imagePullSecrets = append $imagePullSecrets (dict "name" (include "secrets.imageBuilder.pull.secretName" .)) }}
+{{- end }}
+podInject:
   enabled: true
   managedByLabelValue: {{ .Values.mirroring.managedByLabelValue | default "union-operator" | quote }}
   mounts:
 {{ toYaml $mounts | indent 4 }}
+  imagePullSecrets:
+{{ toYaml $imagePullSecrets | indent 4 }}
 {{- end }}
 {{- end -}}

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -1556,18 +1556,13 @@ union-pod-webhook
 {{- if or .Values.low_privilege (and .Values.flytepropellerwebhook.enabled .Values.flytepropellerwebhook.managedConfig) }}
 {{- $_ := set $webhook "disableCreateMutatingWebhookConfig" true }}
 {{- end }}
-{{- /* When chart-managed pull is enabled, controllers handle imagePullSecrets
-       via podInjectConfig; turn off the webhook's lazy mirror path. */}}
-{{- if eq (include "secrets.imageBuilder.pull.enabled" .) "true" }}
-{{- $emsc := deepCopy (index $webhook "embeddedSecretManagerConfig" | default dict) }}
-{{- $ips := deepCopy (index $emsc "imagePullSecrets" | default dict) }}
-{{- $_ := set $ips "enabled" false }}
-{{- $_ = set $emsc "imagePullSecrets" $ips }}
-{{- $_ = set $webhook "embeddedSecretManagerConfig" $emsc }}
-{{- end }}
-{{/* podInject block lives on the leaseworker and executor configs
-(see "dataplane.podInjectConfig" below). The webhook no longer carries
-fileMount; controllers inject at pod-creation time. */}}
+{{/* podInject (controller-side) and the webhook's embeddedSecretManager
+are independent image-pull paths and the chart does not couple them:
+secrets.imageBuilder.pull provides the DEFAULT pull secret for every
+task pod via the controller, while webhook.embeddedSecretManagerConfig
+.imagePullSecrets is configured independently to support Flyte-secret-
+provided pull secrets per task. The chart never mutates the webhook
+config from the controller path. */}}
 {{- if include "singleNamespace" . }}
 propeller:
   limit-namespace: {{ .Release.Namespace }}
@@ -1578,15 +1573,10 @@ webhook:
 
 {{/*
   Controller-side podInject block, included by both leaseworker and
-  executor configs. Replaces the legacy webhook fileMount path AND the
-  webhook's lazy image-pull-secret injection.
-
-  Mounts: eager config.yaml + client_secret unconditionally;
-  internal-ca.crt when secrets.internalCaCert is enabled.
-
-  ImagePullSecrets: image-builder-pull when secrets.imageBuilder.pull
-  is enabled — chart-mirrored into every task NS by the operator's
-  ManifestMirrorSyncer.
+  executor configs. mounts: eager config.yaml + client_secret when
+  eagerClientCreds is enabled, plus internal-ca.crt when internalCaCert
+  is enabled. imagePullSecrets: the default pull secret when
+  imageBuilder.pull is enabled.
 */}}
 {{- define "dataplane.podInjectConfig" -}}
 {{- $hasFileMounts := eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
@@ -1602,7 +1592,7 @@ webhook:
       )
       "volumeMount" (dict
         "name" "union-eager-auth-config"
-        "mountPath" "/etc/flyte/config.yaml"
+        "mountPath" (include "secrets.eagerOAuth.configMapMountPath" .)
         "subPath" "config.yaml"
         "readOnly" true
       )
@@ -1614,8 +1604,8 @@ webhook:
       )
       "volumeMount" (dict
         "name" "union-eager-client-secret"
-        "mountPath" "/etc/flyte/credentials/client_secret"
-        "subPath" "client_secret"
+        "mountPath" (include "secrets.eagerOAuth.secretMountPath" .)
+        "subPath" (include "secrets.eagerClientCreds.clientSecretKey" .)
         "readOnly" true
       )
     )
@@ -1629,8 +1619,8 @@ webhook:
       )
       "volumeMount" (dict
         "name" "union-internal-ca"
-        "mountPath" "/etc/flyte/credentials/ca.crt"
-        "subPath" "ca.crt"
+        "mountPath" (include "secrets.eagerOAuth.caCertMountPath" .)
+        "subPath" (include "secrets.internalCaCert.caCertKey" .)
         "readOnly" true
       )
     )

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -954,7 +954,7 @@ Global pod environment variables
       resource: limits.cpu
 - name: CLUSTER_NAME
   valueFrom:
-    secretKeyRef:
+    configMapKeyRef:
       name: operator-cluster-name
       key: cluster_name
 - name: DEPLOYMENT_NAME

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -130,15 +130,14 @@ secrets.eagerClientCreds — multi-key (client_id + client_secret)
 {{- $s := .Values.secrets.eagerClientCreds -}}
 {{- if $s.enabled -}}
   {{- $hasExternal := $s.existingSecret.name -}}
-  {{- $hasInline := or $s.clientId $s.clientSecret -}}
-  {{- if and $hasExternal $hasInline -}}
-    {{- fail "secrets.eagerClientCreds: set either existingSecret.name OR clientId/clientSecret, not both" -}}
+  {{- if and $hasExternal $s.clientSecret -}}
+    {{- fail "secrets.eagerClientCreds: set either existingSecret.name OR an inline clientSecret, not both" -}}
   {{- end -}}
-  {{- if not (or $hasExternal $hasInline) -}}
-    {{- fail "secrets.eagerClientCreds.enabled=true requires existingSecret.name or clientId+clientSecret" -}}
+  {{- if not (or $hasExternal $s.clientSecret) -}}
+    {{- fail "secrets.eagerClientCreds.enabled=true requires existingSecret.name or an inline clientSecret" -}}
   {{- end -}}
-  {{- if and $hasInline (or (not $s.clientId) (not $s.clientSecret)) -}}
-    {{- fail "secrets.eagerClientCreds: both clientId and clientSecret must be set for inline credentials" -}}
+  {{- if and $s.clientSecret (not $s.clientId) -}}
+    {{- fail "secrets.eagerClientCreds: clientId must be set alongside an inline clientSecret" -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -1,0 +1,189 @@
+{{/*
+Unified secrets helpers.
+
+Each managed secret follows the same shape under `.Values.secrets.<name>`:
+
+  enabled: bool
+  existingSecret:
+    name: ""
+    key: ""            # single-key secrets only — defaults to the canonical key
+  value: ""            # inline value for single-key secrets
+  # (multi-key secrets carry their inline fields at the top level — see eagerClientCreds, admin)
+
+State machine (single- and multi-key alike):
+
+  enabled: false                                  → render nothing; consumers must not reference
+  enabled: true  + existingSecret.name set        → skip chart-managed Secret; consumers reference external by name
+  enabled: true  + inline value(s) set            → chart creates `{{ .Release.Name }}-<logical>`; consumers reference it
+  enabled: true  + existingSecret.name + inline   → fail (ambiguous)
+  enabled: true  + neither                        → fail (must provide one)
+
+Consumer pattern for single-key:
+
+  {{- $ref := include "secrets.eagerApiKey.secretRef" . | fromYaml }}
+  - name: EAGER_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ $ref.name }}
+        key:  {{ $ref.key }}
+
+Consumer pattern for multi-key (eagerClientCreds, admin):
+
+  {{- $name := include "secrets.eagerClientCreds.secretName" . }}
+  - name: UNION_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ $name }}
+        key:  {{ include "secrets.eagerClientCreds.clientIdKey" . }}
+*/}}
+
+{{/*
+secrets.eagerApiKey
+*/}}
+
+{{- define "secrets.eagerApiKey.canonicalKey" -}}EAGER_API_KEY{{- end -}}
+
+{{- define "secrets.eagerApiKey.computedName" -}}{{ .Release.Name }}-eager-api-key{{- end -}}
+
+{{- define "secrets.eagerApiKey.enabled" -}}
+{{- $s := .Values.secrets.eagerApiKey -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerApiKey.validate" -}}
+{{- $s := .Values.secrets.eagerApiKey -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := $s.value -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.eagerApiKey: set either existingSecret.name OR value, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.eagerApiKey.enabled=true requires existingSecret.name or value" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerApiKey.secretRef" -}}
+{{- include "secrets.eagerApiKey.validate" . -}}
+{{- $s := .Values.secrets.eagerApiKey -}}
+{{- $defaultKey := include "secrets.eagerApiKey.canonicalKey" . -}}
+{{- if $s.existingSecret.name -}}
+name: {{ $s.existingSecret.name }}
+key: {{ default $defaultKey $s.existingSecret.key }}
+{{- else -}}
+name: {{ include "secrets.eagerApiKey.computedName" . }}
+key: {{ $defaultKey }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+secrets.eagerClientCreds — multi-key (client_id + client_secret)
+*/}}
+
+{{- define "secrets.eagerClientCreds.clientIdCanonical" -}}client_id{{- end -}}
+{{- define "secrets.eagerClientCreds.clientSecretCanonical" -}}client_secret{{- end -}}
+
+{{- define "secrets.eagerClientCreds.computedName" -}}{{ .Release.Name }}-eager-client-creds{{- end -}}
+
+{{- define "secrets.eagerClientCreds.enabled" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.validate" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := or $s.clientId $s.clientSecret -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.eagerClientCreds: set either existingSecret.name OR clientId/clientSecret, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.eagerClientCreds.enabled=true requires existingSecret.name or clientId+clientSecret" -}}
+  {{- end -}}
+  {{- if and $hasInline (or (not $s.clientId) (not $s.clientSecret)) -}}
+    {{- fail "secrets.eagerClientCreds: both clientId and clientSecret must be set for inline credentials" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.secretName" -}}
+{{- include "secrets.eagerClientCreds.validate" . -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.eagerClientCreds.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.clientIdKey" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- default (include "secrets.eagerClientCreds.clientIdCanonical" .) $s.existingSecret.clientIdKey -}}
+{{- end -}}
+
+{{- define "secrets.eagerClientCreds.clientSecretKey" -}}
+{{- $s := .Values.secrets.eagerClientCreds -}}
+{{- default (include "secrets.eagerClientCreds.clientSecretCanonical" .) $s.existingSecret.clientSecretKey -}}
+{{- end -}}
+
+{{/*
+secrets.imageBuilder.push — buildkit push credentials (opaque KV)
+*/}}
+
+{{- define "secrets.imageBuilder.push.computedName" -}}{{ .Release.Name }}-image-builder-push{{- end -}}
+
+{{- define "secrets.imageBuilder.push.enabled" -}}
+{{- $s := .Values.secrets.imageBuilder.push -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.push.validate" -}}
+{{- $s := .Values.secrets.imageBuilder.push -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := gt (len $s.values) 0 -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.imageBuilder.push: set either existingSecret.name OR values, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.imageBuilder.push.enabled=true requires existingSecret.name or values" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.push.secretName" -}}
+{{- include "secrets.imageBuilder.push.validate" . -}}
+{{- $s := .Values.secrets.imageBuilder.push -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.imageBuilder.push.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{/*
+secrets.imageBuilder.pull — image pull (imagePullSecrets dockerconfigjson). Absorbs depot-token.
+*/}}
+
+{{- define "secrets.imageBuilder.pull.canonicalKey" -}}.dockerconfigjson{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.computedName" -}}{{ .Release.Name }}-image-builder-pull{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.enabled" -}}
+{{- $s := .Values.secrets.imageBuilder.pull -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.validate" -}}
+{{- $s := .Values.secrets.imageBuilder.pull -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := $s.dockerconfigjson -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.imageBuilder.pull: set either existingSecret.name OR dockerconfigjson, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.imageBuilder.pull.enabled=true requires existingSecret.name or dockerconfigjson" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.imageBuilder.pull.secretName" -}}
+{{- include "secrets.imageBuilder.pull.validate" . -}}
+{{- $s := .Values.secrets.imageBuilder.pull -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.imageBuilder.pull.computedName" . }}{{- end -}}
+{{- end -}}

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -264,3 +264,34 @@ secrets.imageBuilder.pull — image pull (imagePullSecrets dockerconfigjson). Ab
 {{- $s := .Values.secrets.imageBuilder.pull -}}
 {{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.imageBuilder.pull.computedName" . }}{{- end -}}
 {{- end -}}
+
+{{/*
+Common labels for chart-managed Secrets + ConfigMaps that the operator
+mirrors into task namespaces. app.kubernetes.io/managed-by is load-bearing
+— the ManifestMirrorSyncer (and the controller-side MirrorChecker cache)
+select mirror sources on it, so it always derives from
+mirroring.managedByLabelValue and is not user-overridable. secrets.commonLabels
+is appended for arbitrary user metadata.
+*/}}
+{{- define "secrets.managedObjectLabels" -}}
+app.kubernetes.io/managed-by: {{ .Values.mirroring.managedByLabelValue | default "union-operator" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.secrets.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Eager OAuth file-mount paths. The same values feed both the SDK config.yaml
+(clientSecretLocation / caCertFilePath) and the controller's podInject volume
+mounts, so they stay consistent. Overridable via mirroring.eagerOAuth.
+*/}}
+{{- define "secrets.eagerOAuth.configMapMountPath" -}}
+{{- dig "eagerOAuth" "configMapMountPath" "/etc/flyte/config.yaml" .Values.mirroring -}}
+{{- end -}}
+{{- define "secrets.eagerOAuth.secretMountPath" -}}
+{{- dig "eagerOAuth" "secretMountPath" "/etc/flyte/credentials/client_secret" .Values.mirroring -}}
+{{- end -}}
+{{- define "secrets.eagerOAuth.caCertMountPath" -}}
+{{- dig "eagerOAuth" "caCertMountPath" "/etc/flyte/credentials/ca.crt" .Values.mirroring -}}
+{{- end -}}

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -162,6 +162,47 @@ secrets.eagerClientCreds — multi-key (client_id + client_secret)
 {{- end -}}
 
 {{/*
+secrets.internalCaCert — single-key (ca.crt) trust bundle for the CP
+internal-tls cert. Cluster operators typically wire `existingSecret.name`
+to an ExternalSecret-managed Secret (`internal-ca-bundle`); chart users
+without ExternalSecrets supply the PEM inline via `value`.
+*/}}
+
+{{- define "secrets.internalCaCert.caCertCanonical" -}}ca.crt{{- end -}}
+
+{{- define "secrets.internalCaCert.computedName" -}}{{ .Release.Name }}-internal-ca{{- end -}}
+
+{{- define "secrets.internalCaCert.enabled" -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.internalCaCert.validate" -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- if $s.enabled -}}
+  {{- $hasExternal := $s.existingSecret.name -}}
+  {{- $hasInline := $s.value -}}
+  {{- if and $hasExternal $hasInline -}}
+    {{- fail "secrets.internalCaCert: set either existingSecret.name OR value, not both" -}}
+  {{- end -}}
+  {{- if not (or $hasExternal $hasInline) -}}
+    {{- fail "secrets.internalCaCert.enabled=true requires existingSecret.name or value" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "secrets.internalCaCert.secretName" -}}
+{{- include "secrets.internalCaCert.validate" . -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.internalCaCert.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{- define "secrets.internalCaCert.caCertKey" -}}
+{{- $s := .Values.secrets.internalCaCert -}}
+{{- default (include "secrets.internalCaCert.caCertCanonical" .) $s.existingSecret.caCertKey -}}
+{{- end -}}
+
+{{/*
 secrets.imageBuilder.push — buildkit push credentials (opaque KV)
 */}}
 

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -143,6 +143,8 @@ secrets.eagerClientCreds — multi-key (client_id + client_secret)
 {{- end -}}
 {{- end -}}
 
+{{- define "secrets.eagerOAuthConfig.configMapName" -}}{{ .Release.Name }}-eager-oauth-config{{- end -}}
+
 {{- define "secrets.eagerClientCreds.secretName" -}}
 {{- include "secrets.eagerClientCreds.validate" . -}}
 {{- $s := .Values.secrets.eagerClientCreds -}}

--- a/charts/dataplane/templates/_secrets.tpl
+++ b/charts/dataplane/templates/_secrets.tpl
@@ -38,6 +38,41 @@ Consumer pattern for multi-key (eagerClientCreds, admin):
 */}}
 
 {{/*
+secrets.admin — admin client credentials.
+
+Carries the unified shape but also accepts the legacy `enable` and `create` flags so
+existing values files keep working. Default computed name is `union-secret-auth` to
+preserve the name historically baked into consumer configs.
+
+Legacy:
+  enable: bool            (alias for enabled)
+  create: bool            (legacy: false → external secret with hardcoded name `union-secret-auth`)
+*/}}
+
+{{- define "secrets.admin.computedName" -}}union-secret-auth{{- end -}}
+
+{{- define "secrets.admin.enabled" -}}
+{{- $s := .Values.secrets.admin -}}
+{{- if hasKey $s "enabled" -}}{{- if $s.enabled -}}true{{- else -}}false{{- end -}}
+{{- else if hasKey $s "enable" -}}{{- if $s.enable -}}true{{- else -}}false{{- end -}}
+{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.admin.shouldCreate" -}}
+{{- $s := .Values.secrets.admin -}}
+{{- if eq (include "secrets.admin.enabled" .) "true" -}}
+  {{- if $s.existingSecret.name -}}false
+  {{- else if and (hasKey $s "create") (not $s.create) -}}false
+  {{- else -}}true{{- end -}}
+{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "secrets.admin.secretName" -}}
+{{- $s := .Values.secrets.admin -}}
+{{- if $s.existingSecret.name -}}{{ $s.existingSecret.name }}{{- else -}}{{ include "secrets.admin.computedName" . }}{{- end -}}
+{{- end -}}
+
+{{/*
 secrets.eagerApiKey
 */}}
 

--- a/charts/dataplane/templates/common/auth-secret.yaml
+++ b/charts/dataplane/templates/common/auth-secret.yaml
@@ -1,14 +1,13 @@
-{{- if and .Values.secrets.admin.enable  .Values.secrets.admin.create }}
+{{- if eq (include "secrets.admin.shouldCreate" .) "true" }}
 {{- $secret := .Values.secrets.admin.clientSecret | required ".Values.secrets.admin.clientSecret is required when admin client credentials has been enabled." -}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: union-secret-auth
+  name: {{ include "secrets.admin.secretName" . }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: {{ $secret | b64enc | toString }}
   client_secret: {{ $secret | b64enc | toString }}
 {{- end }}

--- a/charts/dataplane/templates/common/cluster-name-configmap.yaml
+++ b/charts/dataplane/templates/common/cluster-name-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: {{ tpl .Values.clusterName $ | quote }}

--- a/charts/dataplane/templates/common/cluster-secret.yaml
+++ b/charts/dataplane/templates/common/cluster-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: {{ tpl .Values.clusterName $ | b64enc }}

--- a/charts/dataplane/templates/common/eager-api-key-secret.yaml
+++ b/charts/dataplane/templates/common/eager-api-key-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq (include "secrets.eagerApiKey.enabled" .) "true") (not .Values.secrets.eagerApiKey.existingSecret.name) }}
+{{- $ref := include "secrets.eagerApiKey.secretRef" . | fromYaml -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ref.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: eager-api-key
+type: Opaque
+data:
+  {{ $ref.key }}: {{ .Values.secrets.eagerApiKey.value | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/eager-api-key-secret.yaml
+++ b/charts/dataplane/templates/common/eager-api-key-secret.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ $ref.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    union.ai/secret-type: eager-api-key
+    {{- include "secrets.managedObjectLabels" . | nindent 4 }}
+  {{- with .Values.secrets.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{ $ref.key }}: {{ .Values.secrets.eagerApiKey.value | b64enc }}

--- a/charts/dataplane/templates/common/eager-client-creds-secret.yaml
+++ b/charts/dataplane/templates/common/eager-client-creds-secret.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ include "secrets.eagerClientCreds.secretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    union.ai/secret-type: eager-client-creds
+    {{- include "secrets.managedObjectLabels" . | nindent 4 }}
+  {{- with .Values.secrets.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{ include "secrets.eagerClientCreds.clientIdKey" . }}: {{ .Values.secrets.eagerClientCreds.clientId | b64enc }}

--- a/charts/dataplane/templates/common/eager-client-creds-secret.yaml
+++ b/charts/dataplane/templates/common/eager-client-creds-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq (include "secrets.eagerClientCreds.enabled" .) "true") (not .Values.secrets.eagerClientCreds.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.eagerClientCreds.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: eager-client-creds
+type: Opaque
+data:
+  {{ include "secrets.eagerClientCreds.clientIdKey" . }}: {{ .Values.secrets.eagerClientCreds.clientId | b64enc }}
+  {{ include "secrets.eagerClientCreds.clientSecretKey" . }}: {{ .Values.secrets.eagerClientCreds.clientSecret | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -33,7 +33,11 @@ metadata:
 data:
   config.yaml: |
     admin:
-      endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
+      {{/* Use the PUBLIC CP hostname (Values.host = global.UNION_CONTROL_PLANE_HOST)
+           so the SDK's OAuth + gRPC traffic hits a name covered by the CP TLS
+           cert SAN. The chart helper dataplane.cp.endpoint would resolve to
+           the INTERNAL CONTROLPLANE_HOST which is not in the cert. */}}
+      endpoint: {{ printf "dns:///%s:443" (tpl .Values.host .) | quote }}
       insecure: {{ default false $cpConn.insecure }}
       insecureSkipVerify: {{ default false $cpConn.insecureSkipVerify }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -13,7 +13,15 @@ Carries app.kubernetes.io/managed-by=union-operator AND the
 union.ai/mirrored-from-namespace=<operator NS> annotation so the
 mirror's cleanup query scopes copies to this install.
 */}}
+{{/*
+The endpoint, insecure, and insecureSkipVerify values mirror the
+dataplane's own CP-connection wiring (config.union.connection on the
+chart). For selfmanaged envs with self-signed CP certs, terraform sets
+insecureSkipVerify: true; the chart default is false (managed CP with
+valid cert).
+*/}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+{{- $cpConn := default dict (default dict .Values.config.union).connection -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,8 +33,10 @@ metadata:
 data:
   config.yaml: |
     admin:
-      endpoint: {{ tpl .Values.host . | quote }}
+      endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
+      insecure: {{ default false $cpConn.insecure }}
+      insecureSkipVerify: {{ default false $cpConn.insecureSkipVerify }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
       clientSecretLocation: {{ .Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret" | quote }}
-      authType: ClientSecret
+      authType: ClientCredentials
 {{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -12,16 +12,16 @@ _UNION_EAGER_API_KEY env-var path.
 Carries app.kubernetes.io/managed-by=union-operator AND the
 union.ai/mirrored-from-namespace=<operator NS> annotation so the
 mirror's cleanup query scopes copies to this install.
-*/}}
-{{/*
-The endpoint, insecure, and insecureSkipVerify values mirror the
-dataplane's own CP-connection wiring (config.union.connection on the
-chart). For selfmanaged envs with self-signed CP certs, terraform sets
-insecureSkipVerify: true; the chart default is false (managed CP with
-valid cert).
+
+Endpoint uses the chart's `dataplane.cp.endpoint` helper, which resolves
+to the CP's internal hostname (control-plane.internal.<full_domain>) —
+covered by the cert-manager-issued `controlplane-internal-tls` SAN. The
+SDK trusts the issuing CA via caCertFilePath, mounted from
+secrets.internalCaCert. Both `insecure` and `insecureSkipVerify` are
+deliberately omitted; the SDK defaults to verify, which is the only
+correct behavior under this trust chain.
 */}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-{{- $cpConn := default dict (default dict .Values.config.union).connection -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,14 +33,11 @@ metadata:
 data:
   config.yaml: |
     admin:
-      {{/* Use the PUBLIC CP hostname (Values.host = global.UNION_CONTROL_PLANE_HOST)
-           so the SDK's OAuth + gRPC traffic hits a name covered by the CP TLS
-           cert SAN. The chart helper dataplane.cp.endpoint would resolve to
-           the INTERNAL CONTROLPLANE_HOST which is not in the cert. */}}
-      endpoint: {{ printf "dns:///%s:443" (tpl .Values.host .) | quote }}
-      insecure: {{ default false $cpConn.insecure }}
-      insecureSkipVerify: {{ default false $cpConn.insecureSkipVerify }}
+      endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
-      clientSecretLocation: {{ .Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret" | quote }}
+      clientSecretLocation: "/etc/flyte/credentials/client_secret"
       authType: ClientCredentials
+      {{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
+      caCertFilePath: "/etc/flyte/credentials/ca.crt"
+      {{- end }}
 {{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -1,20 +1,9 @@
 {{/*
-SDK config.yaml mounted on task pods by the controller-side file-mount
-path. When secrets.eagerClientCreds.enabled is true, the operator
-mirrors this ConfigMap (and the client_secret Secret) into every
-flyte-typed target NS. Task pods mount config.yaml at
-/etc/flyte/config.yaml and the SDK's init_from_config() reads it at
-startup, replacing the legacy _UNION_EAGER_API_KEY env-var path.
-
-Carries app.kubernetes.io/managed-by=union-operator and the
-union.ai/mirrored-from-namespace=<operator NS> annotation so the
-mirror's cleanup query scopes copies to this install.
-
-Endpoint resolves to the CP's internal hostname via the
-dataplane.cp.endpoint helper, covered by the cert-manager-issued
-controlplane-internal-tls SAN. The SDK trusts the issuing CA via
-caCertFilePath (secrets.internalCaCert); insecure / insecureSkipVerify
-are deliberately omitted.
+SDK config.yaml the controller file-mounts on task pods when
+secrets.eagerClientCreds.enabled is true. The operator mirrors this
+ConfigMap into flyte-typed task namespaces; the SDK reads it via
+init_from_config() at startup. TLS posture (insecure / insecureSkipVerify)
+is operator-configurable; the default verifies against the mounted CA.
 */}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
 apiVersion: v1
@@ -23,16 +12,25 @@ metadata:
   name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Values.mirroring.managedByLabelValue | default "union-operator" }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "secrets.managedObjectLabels" . | nindent 4 }}
+  {{- with .Values.secrets.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   config.yaml: |
     admin:
       endpoint: {{ include "dataplane.cp.endpoint" . | quote }}
       clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
-      clientSecretLocation: "/etc/flyte/credentials/client_secret"
+      clientSecretLocation: {{ include "secrets.eagerOAuth.secretMountPath" . | quote }}
       authType: ClientCredentials
+      {{- if .Values.secrets.eagerClientCreds.insecure }}
+      insecure: true
+      {{- end }}
+      {{- if .Values.secrets.eagerClientCreds.insecureSkipVerify }}
+      insecureSkipVerify: true
+      {{- end }}
       {{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
-      caCertFilePath: "/etc/flyte/credentials/ca.crt"
+      caCertFilePath: {{ include "secrets.eagerOAuth.caCertMountPath" . | quote }}
       {{- end }}
 {{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -1,0 +1,32 @@
+{{/*
+eager-auth-config: SDK config.yaml mounted on task pods by the
+flyte-pod-webhook's file-mount path (FAB-241 file-mount workstream).
+
+When secrets.eagerClientCreds.enabled is true and the operator's
+SecretMirrorSyncer is enabled, the operator mirrors this ConfigMap and
+the client_secret Secret into every flyte-typed target NS. Task pods
+mount config.yaml at /etc/flyte/config.yaml and the SDK's
+init_from_config() reads it at startup, replacing the legacy
+_UNION_EAGER_API_KEY env-var path.
+
+Carries app.kubernetes.io/managed-by=union-operator AND the
+union.ai/mirrored-from-namespace=<operator NS> annotation so the
+mirror's cleanup query scopes copies to this install.
+*/}}
+{{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Values.mirroring.managedByLabelValue | default "union-operator" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  config.yaml: |
+    admin:
+      endpoint: {{ tpl .Values.host . | quote }}
+      clientId: {{ .Values.secrets.eagerClientCreds.clientId | default "" | quote }}
+      clientSecretLocation: {{ .Values.mirroring.eagerOAuth.secretMountPath | default "/etc/flyte/credentials/client_secret" | quote }}
+      authType: ClientSecret
+{{- end }}

--- a/charts/dataplane/templates/common/eager-oauth-config.yaml
+++ b/charts/dataplane/templates/common/eager-oauth-config.yaml
@@ -1,25 +1,20 @@
 {{/*
-eager-auth-config: SDK config.yaml mounted on task pods by the
-flyte-pod-webhook's file-mount path (FAB-241 file-mount workstream).
+SDK config.yaml mounted on task pods by the controller-side file-mount
+path. When secrets.eagerClientCreds.enabled is true, the operator
+mirrors this ConfigMap (and the client_secret Secret) into every
+flyte-typed target NS. Task pods mount config.yaml at
+/etc/flyte/config.yaml and the SDK's init_from_config() reads it at
+startup, replacing the legacy _UNION_EAGER_API_KEY env-var path.
 
-When secrets.eagerClientCreds.enabled is true and the operator's
-SecretMirrorSyncer is enabled, the operator mirrors this ConfigMap and
-the client_secret Secret into every flyte-typed target NS. Task pods
-mount config.yaml at /etc/flyte/config.yaml and the SDK's
-init_from_config() reads it at startup, replacing the legacy
-_UNION_EAGER_API_KEY env-var path.
-
-Carries app.kubernetes.io/managed-by=union-operator AND the
+Carries app.kubernetes.io/managed-by=union-operator and the
 union.ai/mirrored-from-namespace=<operator NS> annotation so the
 mirror's cleanup query scopes copies to this install.
 
-Endpoint uses the chart's `dataplane.cp.endpoint` helper, which resolves
-to the CP's internal hostname (control-plane.internal.<full_domain>) —
-covered by the cert-manager-issued `controlplane-internal-tls` SAN. The
-SDK trusts the issuing CA via caCertFilePath, mounted from
-secrets.internalCaCert. Both `insecure` and `insecureSkipVerify` are
-deliberately omitted; the SDK defaults to verify, which is the only
-correct behavior under this trust chain.
+Endpoint resolves to the CP's internal hostname via the
+dataplane.cp.endpoint helper, covered by the cert-manager-issued
+controlplane-internal-tls SAN. The SDK trusts the issuing CA via
+caCertFilePath (secrets.internalCaCert); insecure / insecureSkipVerify
+are deliberately omitted.
 */}}
 {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
 apiVersion: v1

--- a/charts/dataplane/templates/common/image-builder-push-secret.yaml
+++ b/charts/dataplane/templates/common/image-builder-push-secret.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ include "secrets.imageBuilder.push.secretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    union.ai/secret-type: image-builder-push
+    {{- include "secrets.managedObjectLabels" . | nindent 4 }}
+  {{- with .Values.secrets.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
 {{- range $k, $v := .Values.secrets.imageBuilder.push.values }}

--- a/charts/dataplane/templates/common/image-builder-push-secret.yaml
+++ b/charts/dataplane/templates/common/image-builder-push-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and (eq (include "secrets.imageBuilder.push.enabled" .) "true") (not .Values.secrets.imageBuilder.push.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.imageBuilder.push.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: image-builder-push
+type: Opaque
+data:
+{{- range $k, $v := .Values.secrets.imageBuilder.push.values }}
+  {{ $k }}: {{ $v | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/dataplane/templates/common/image-pull-secret.yaml
+++ b/charts/dataplane/templates/common/image-pull-secret.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ include "secrets.imageBuilder.pull.secretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    union.ai/secret-type: image-builder-pull
+    {{- include "secrets.managedObjectLabels" . | nindent 4 }}
+  {{- with .Values.secrets.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.secrets.imageBuilder.pull.dockerconfigjson | b64enc }}

--- a/charts/dataplane/templates/common/image-pull-secret.yaml
+++ b/charts/dataplane/templates/common/image-pull-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (include "secrets.imageBuilder.pull.enabled" .) "true") (not .Values.secrets.imageBuilder.pull.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.imageBuilder.pull.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: image-builder-pull
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.secrets.imageBuilder.pull.dockerconfigjson | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/internal-ca-secret.yaml
+++ b/charts/dataplane/templates/common/internal-ca-secret.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ include "secrets.internalCaCert.secretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    union.ai/secret-type: internal-ca-cert
+    {{- include "secrets.managedObjectLabels" . | nindent 4 }}
+  {{- with .Values.secrets.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{ include "secrets.internalCaCert.caCertKey" . }}: {{ .Values.secrets.internalCaCert.value | b64enc }}

--- a/charts/dataplane/templates/common/internal-ca-secret.yaml
+++ b/charts/dataplane/templates/common/internal-ca-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (include "secrets.internalCaCert.enabled" .) "true") (not .Values.secrets.internalCaCert.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.internalCaCert.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    union.ai/secret-type: internal-ca-cert
+type: Opaque
+data:
+  {{ include "secrets.internalCaCert.caCertKey" . }}: {{ .Values.secrets.internalCaCert.value | b64enc }}
+{{- end }}

--- a/charts/dataplane/templates/common/task-podtemplate.yaml
+++ b/charts/dataplane/templates/common/task-podtemplate.yaml
@@ -1,4 +1,5 @@
-{{- if or (include "singleNamespace" .) (include "operator.enableDepot" .) }}
+{{- $imageBuilderPullEnabled := eq (include "secrets.imageBuilder.pull.enabled" .) "true" }}
+{{- if or (include "singleNamespace" .) (include "operator.enableDepot" .) $imageBuilderPullEnabled }}
 apiVersion: v1
 kind: PodTemplate
 metadata:
@@ -9,7 +10,10 @@ template:
 {{- if include "singleNamespace" . }}
     serviceAccountName: union
 {{- end }}
-{{- if include "operator.enableDepot" . }}
+{{- if $imageBuilderPullEnabled }}
+    imagePullSecrets:
+      - name: {{ include "secrets.imageBuilder.pull.secretName" . }}
+{{- else if include "operator.enableDepot" . }}
     imagePullSecrets:
       - name: depot-token
 {{- end }}

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -20,13 +20,8 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- /*
-         When eagerClientCreds is enabled, the controller injects OAuth
-         creds + config + CA bundle on every task pod at Create-time and
-         the SDK reads them via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret
-         false so EAGER_API_KEY is not appended to SecurityContext.Secrets.
-    */}}
+    {{- /* When eagerClientCreds is enabled the controller file-mounts the
+         OAuth creds, so disable the legacy EAGER_API_KEY env-var injection. */}}
     {{- $leaseworkerConfig := deepCopy (.Values.leaseworker.config | default dict) }}
     {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
     {{- $unionAuth := deepCopy (index $leaseworkerConfig "unionAuth" | default dict) }}

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -21,14 +21,11 @@ data:
 {{- end }}
   config.yaml: |
     {{- /*
-         When the chart-managed eager-credentials file-mount path is on
-         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
-         + CA from mounted files via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
-         so leaseworker stops appending EAGER_API_KEY to
-         SecurityContext.Secrets and the webhook never emits the env var
-         on task pods. Users can still set injectSecret explicitly via
-         values-overrides to preserve a hybrid setup if needed.
+         When eagerClientCreds is enabled, the controller injects OAuth
+         creds + config + CA bundle on every task pod at Create-time and
+         the SDK reads them via init_from_config(). The legacy
+         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret
+         false so EAGER_API_KEY is not appended to SecurityContext.Secrets.
     */}}
     {{- $leaseworkerConfig := deepCopy (.Values.leaseworker.config | default dict) }}
     {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
@@ -64,6 +61,7 @@ data:
     {{- end }}
     leaseworker:
       {{- tpl (toYaml $leaseworkerConfig) $ | nindent 6 }}
+      {{- include "dataplane.fileMountConfig" . | nindent 6 }}
     union:
       {{- with .Values.config.union.connection }}
       connection:

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -20,22 +20,7 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- /*
-         When the chart-managed eager-credentials file-mount path is on
-         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
-         + CA from mounted files via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
-         so leaseworker stops appending EAGER_API_KEY to
-         SecurityContext.Secrets and the webhook never emits the env var
-         on task pods. Users can still set injectSecret explicitly via
-         values-overrides to preserve a hybrid setup if needed.
-    */}}
     {{- $leaseworkerConfig := deepCopy (.Values.leaseworker.config | default dict) }}
-    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-    {{- $unionAuth := deepCopy (index $leaseworkerConfig "unionAuth" | default dict) }}
-    {{- $_ := set $unionAuth "injectSecret" false }}
-    {{- $_ = set $leaseworkerConfig "unionAuth" $unionAuth }}
-    {{- end }}
     {{- $_ := set $leaseworkerConfig "capacity" .Values.leaseworker.capacity }}
     {{- $_ = set $leaseworkerConfig "dispatcherCount" .Values.leaseworker.dispatcherCount }}
     {{- $_ = set $leaseworkerConfig "refreshInterval" .Values.leaseworker.refreshInterval }}

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -20,7 +20,22 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
+    {{- /*
+         When the chart-managed eager-credentials file-mount path is on
+         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
+         + CA from mounted files via init_from_config(). The legacy
+         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
+         so leaseworker stops appending EAGER_API_KEY to
+         SecurityContext.Secrets and the webhook never emits the env var
+         on task pods. Users can still set injectSecret explicitly via
+         values-overrides to preserve a hybrid setup if needed.
+    */}}
     {{- $leaseworkerConfig := deepCopy (.Values.leaseworker.config | default dict) }}
+    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+    {{- $unionAuth := deepCopy (index $leaseworkerConfig "unionAuth" | default dict) }}
+    {{- $_ := set $unionAuth "injectSecret" false }}
+    {{- $_ = set $leaseworkerConfig "unionAuth" $unionAuth }}
+    {{- end }}
     {{- $_ := set $leaseworkerConfig "capacity" .Values.leaseworker.capacity }}
     {{- $_ = set $leaseworkerConfig "dispatcherCount" .Values.leaseworker.dispatcherCount }}
     {{- $_ = set $leaseworkerConfig "refreshInterval" .Values.leaseworker.refreshInterval }}

--- a/charts/dataplane/templates/leaseworker/configmap.yaml
+++ b/charts/dataplane/templates/leaseworker/configmap.yaml
@@ -61,7 +61,7 @@ data:
     {{- end }}
     leaseworker:
       {{- tpl (toYaml $leaseworkerConfig) $ | nindent 6 }}
-      {{- include "dataplane.fileMountConfig" . | nindent 6 }}
+      {{- include "dataplane.podInjectConfig" . | nindent 6 }}
     union:
       {{- with .Values.config.union.connection }}
       connection:

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -18,23 +18,7 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- /*
-         When the chart-managed eager-credentials file-mount path is on
-         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
-         + CA from mounted files via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
-         so leaseworker/executor/operator-apps stop appending EAGER_API_KEY
-         to SecurityContext.Secrets and the webhook never emits the env var
-         on task pods. Users can still set injectSecret explicitly via
-         values-overrides to preserve a hybrid setup if needed.
-    */}}
-    {{- $executorConfig := deepCopy (.Values.executor.config | default dict) }}
-    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
-    {{- $unionAuth := deepCopy (index $executorConfig "unionAuth" | default dict) }}
-    {{- $_ := set $unionAuth "injectSecret" false }}
-    {{- $_ = set $executorConfig "unionAuth" $unionAuth }}
-    {{- end }}
-    {{- with $executorConfig }}
+    {{- with .Values.executor.config }}
     executor:
       {{- tpl (toYaml .) $ | nindent 6 }}
     {{- end }}

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -37,7 +37,7 @@ data:
     {{- with $executorConfig }}
     executor:
       {{- tpl (toYaml .) $ | nindent 6 }}
-      {{- include "dataplane.fileMountConfig" $ | nindent 6 }}
+      {{- include "dataplane.podInjectConfig" $ | nindent 6 }}
     {{- end }}
     {{- with .Values.config.task_resource_defaults -}}
     {{ toYaml . | nindent 6 }}

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -18,7 +18,23 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- with .Values.executor.config }}
+    {{- /*
+         When the chart-managed eager-credentials file-mount path is on
+         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
+         + CA from mounted files via init_from_config(). The legacy
+         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
+         so leaseworker/executor/operator-apps stop appending EAGER_API_KEY
+         to SecurityContext.Secrets and the webhook never emits the env var
+         on task pods. Users can still set injectSecret explicitly via
+         values-overrides to preserve a hybrid setup if needed.
+    */}}
+    {{- $executorConfig := deepCopy (.Values.executor.config | default dict) }}
+    {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+    {{- $unionAuth := deepCopy (index $executorConfig "unionAuth" | default dict) }}
+    {{- $_ := set $unionAuth "injectSecret" false }}
+    {{- $_ = set $executorConfig "unionAuth" $unionAuth }}
+    {{- end }}
+    {{- with $executorConfig }}
     executor:
       {{- tpl (toYaml .) $ | nindent 6 }}
     {{- end }}

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -18,16 +18,9 @@ data:
 {{ tpl (toYaml .Values.config.enabled_plugins.tasks) $ | indent 6 }}
 {{- end }}
   config.yaml: |
-    {{- /*
-         When the chart-managed eager-credentials file-mount path is on
-         (secrets.eagerClientCreds.enabled), the SDK reads OAuth creds + config
-         + CA from mounted files via init_from_config(). The legacy
-         _UNION_EAGER_API_KEY env var is redundant; flip injectSecret false
-         so leaseworker/executor/operator-apps stop appending EAGER_API_KEY
-         to SecurityContext.Secrets and the webhook never emits the env var
-         on task pods. Users can still set injectSecret explicitly via
-         values-overrides to preserve a hybrid setup if needed.
-    */}}
+    {{- /* When eagerClientCreds is enabled the controller file-mounts the
+         OAuth creds, so disable the legacy EAGER_API_KEY env-var injection.
+         Override injectSecret via values-overrides for a hybrid setup. */}}
     {{- $executorConfig := deepCopy (.Values.executor.config | default dict) }}
     {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
     {{- $unionAuth := deepCopy (index $executorConfig "unionAuth" | default dict) }}

--- a/charts/dataplane/templates/nodeexecutor/configmap.yaml
+++ b/charts/dataplane/templates/nodeexecutor/configmap.yaml
@@ -37,6 +37,7 @@ data:
     {{- with $executorConfig }}
     executor:
       {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- include "dataplane.fileMountConfig" $ | nindent 6 }}
     {{- end }}
     {{- with .Values.config.task_resource_defaults -}}
     {{ toYaml . | nindent 6 }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -144,6 +144,14 @@ data:
         - kind: ConfigMap
           name: {{ .Values.imageBuilder.targetConfigMapName | default "build-image-config" }}
         {{- end }}
+        {{- if eq (include "secrets.imageBuilder.pull.enabled" .) "true" }}
+        - kind: Secret
+          name: {{ include "secrets.imageBuilder.pull.secretName" . }}
+        {{- end }}
+        {{- if eq (include "secrets.imageBuilder.push.enabled" .) "true" }}
+        - kind: Secret
+          name: {{ include "secrets.imageBuilder.push.secretName" . }}
+        {{- end }}
     {{- end }}
   {{- with .Values.config.proxy }}
     proxy:

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -136,6 +136,10 @@ data:
         - kind: ConfigMap
           name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
         {{- end }}
+        {{- if eq (include "secrets.internalCaCert.enabled" .) "true" }}
+        - kind: Secret
+          name: {{ include "secrets.internalCaCert.secretName" . }}
+        {{- end }}
         {{- if .Values.imageBuilder.enabled }}
         - kind: ConfigMap
           name: {{ .Values.imageBuilder.targetConfigMapName | default "build-image-config" }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -119,6 +119,28 @@ data:
         referenceConfigmapName: {{ include "union-operator.fullname" . }}
         targetConfigMapName: {{ .Values.imageBuilder.targetConfigMapName | quote }}
     {{- end }}
+    {{- if .Values.mirroring.enabled }}
+      mirroring:
+        enabled: true
+        managedByLabelValue: {{ .Values.mirroring.managedByLabelValue | default "union-operator" | quote }}
+        defaultNamespaceSelector:
+{{ toYaml .Values.mirroring.defaultNamespaceSelector | indent 10 }}
+        provenanceAnnotations:
+          sourceNamespace: union.ai/mirrored-from-namespace
+          sourceName: union.ai/mirrored-from-name
+          sourceVersion: union.ai/mirrored-from-version
+        resources:
+        {{- if eq (include "secrets.eagerClientCreds.enabled" .) "true" }}
+        - kind: Secret
+          name: {{ include "secrets.eagerClientCreds.secretName" . }}
+        - kind: ConfigMap
+          name: {{ include "secrets.eagerOAuthConfig.configMapName" . }}
+        {{- end }}
+        {{- if .Values.imageBuilder.enabled }}
+        - kind: ConfigMap
+          name: {{ .Values.imageBuilder.targetConfigMapName | default "build-image-config" }}
+        {{- end }}
+    {{- end }}
   {{- with .Values.config.proxy }}
     proxy:
       {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -152,6 +152,9 @@ data:
         - kind: Secret
           name: {{ include "secrets.imageBuilder.push.secretName" . }}
         {{- end }}
+        {{- with .Values.mirroring.extraResources }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
     {{- end }}
   {{- with .Values.config.proxy }}
     proxy:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1875,37 +1875,44 @@ proxy:
 resourcequota:
   create: false
 
-# -- Operator-side SecretMirrorSyncer config (FAB-241). When enabled, the
-# operator propagates chart-managed Secrets and ConfigMaps from this
-# release's namespace into every namespace matching the selector. The
-# flyte-pod-webhook's file-mount path activates simultaneously when
-# secrets.eagerClientCreds.enabled is true — it pre-checks the
-# mirror is present before injecting volume mounts and denies
-# admission with HTTP 503 on miss so the upstream retry path
-# absorbs operator-mirror lag.
+# -- Operator-side resource mirroring. When enabled, the operator copies
+# chart-managed Secrets + ConfigMaps from this namespace into every
+# namespace matching the selector so task pods can reference them.
 mirroring:
-  # -- Master switch. When false, SecretMirrorSyncer does not run and
-  # the legacy BuildImageConfigSyncer continues handling build-image
-  # ConfigMap mirror. When true, the new syncer subsumes it.
+  # -- Master switch. When false, the legacy BuildImageConfigSyncer
+  # continues handling the build-image ConfigMap mirror; when true the
+  # unified syncer subsumes it.
   enabled: false
   # -- Value applied as app.kubernetes.io/managed-by on every mirrored
-  # copy. Stable literal — does NOT incorporate release name. Customer-
-  # overridable for brand/white-label. Stability-critical: changing
-  # post-install orphans previously-mirrored copies.
+  # copy. Stable literal — does NOT incorporate release name. Changing
+  # it post-install orphans previously-mirrored copies.
   managedByLabelValue: union-operator
   # -- Default namespace selector applied to every mirror entry that
   # doesn't override.
   defaultNamespaceSelector:
     matchLabels:
       union.ai/namespace-type: flyte
-  # -- File-mount paths used by the operator config rendering and the
-  # webhook's fileMount block. Defaults match the SDK's expectations.
+  # -- Eager-OAuth file-mount paths. Shared by the SDK config.yaml render
+  # and the controller's podInject volume mounts so they stay consistent.
   eagerOAuth:
     configMapMountPath: /etc/flyte/config.yaml
     secretMountPath: /etc/flyte/credentials/client_secret
+    caCertMountPath: /etc/flyte/credentials/ca.crt
+  # -- Additional resources to mirror, appended to the chart-managed
+  # preset entries. Each item is `{kind: Secret|ConfigMap, name: <name>}`
+  # with an optional per-entry `namespaceSelector`.
+  extraResources: []
 
 # -- Connection secrets for the Union control plane services.
 secrets:
+  # -- Extra labels added to every chart-managed Secret + ConfigMap (eager
+  # creds, internal CA, image-builder pull/push, eager OAuth config). The
+  # app.kubernetes.io/managed-by label is always set from
+  # mirroring.managedByLabelValue and is not overridable here.
+  commonLabels: {}
+  # -- Extra annotations added to every chart-managed Secret + ConfigMap.
+  commonAnnotations: {}
+
   admin:
     # -- Reference an externally-provisioned Secret. When set, the chart skips creating its own
     # -- regardless of the legacy `create` flag.
@@ -1922,7 +1929,10 @@ secrets:
     # -- The client id used to authenticate to the control plane.  This will be provided by Union.
     clientId: dataplane-operator
 
-  # -- Eager-execution API key (DP → CP callback). Replaces post-install `flyte create secret EAGER_API_KEY`.
+  # -- DEPRECATED (removal targeted one release after file-mount adoption is
+  # confirmed). Legacy composite EAGER_API_KEY for the DP → CP callback.
+  # Superseded by `eagerClientCreds` + the controller file-mount path; kept
+  # only for the migration-coexistence window. Prefer `eagerClientCreds`.
   eagerApiKey:
     # -- Reference an externally-provisioned Secret (Whisper, sealed-secrets, external-secrets, etc.).
     existingSecret:
@@ -1954,14 +1964,21 @@ secrets:
     # Prefer existingSecret.name — inline values end up in rendered values
     # files and CI artifacts.
     clientSecret: ""
+    # -- Render `insecure: true` into the eager SDK config.yaml (plaintext
+    # DP→CP, no TLS). Default verifies TLS.
+    insecure: false
+    # -- Render `insecureSkipVerify: true` into the eager SDK config.yaml
+    # (TLS without chain verification). Workaround for environments where the
+    # runtime SDK cannot consume caCertFilePath (see flyte-sdk #1182); prefer
+    # secrets.internalCaCert so the chain verifies properly.
+    insecureSkipVerify: false
 
-  # -- Internal-CA trust bundle (`ca.crt`) used by the SDK to verify the
-  # CP `internal-tls` cert on the DP→CP gRPC path. Distinct from
-  # `eagerClientCreds`: trust material, not OAuth creds, so independent
-  # lifecycle and IAM scope (cluster operators typically point at an
-  # ExternalSecret-managed `internal-ca-bundle`). Single key inside the
-  # Secret: `ca.crt`. Picked up by the FAB-241 mirror + propeller
-  # webhook file-mount path when `secrets.internalCaCert.enabled` is true.
+  # -- Internal-CA trust bundle (`ca.crt`) the SDK uses to verify the CP
+  # `internal-tls` cert on the DP→CP gRPC path. Distinct from
+  # `eagerClientCreds` (trust material, not OAuth creds) so it carries an
+  # independent lifecycle and IAM scope — operators typically point at an
+  # ExternalSecret-managed bundle. Single key: `ca.crt`. Mirrored + file-
+  # mounted on task pods when `secrets.internalCaCert.enabled` is true.
   internalCaCert:
     existingSecret:
       # -- Name of the existing Secret. When set, the chart skips creating its own.

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1887,6 +1887,51 @@ secrets:
     # -- The client id used to authenticate to the control plane.  This will be provided by Union.
     clientId: dataplane-operator
 
+  # -- Eager-execution API key (DP → CP callback). Replaces post-install `flyte create secret EAGER_API_KEY`.
+  eagerApiKey:
+    # -- Reference an externally-provisioned Secret (Whisper, sealed-secrets, external-secrets, etc.).
+    existingSecret:
+      # -- Name of the existing Secret. When set, the chart skips creating its own and consumers reference this name.
+      name: ""
+      # -- Optional override of the data key. Defaults to `EAGER_API_KEY`.
+      key: ""
+    # -- Activate the consumer secretKeyRef wiring. When false, downstream env vars and references are omitted entirely.
+    enabled: false
+    # -- Inline API key value. Used only when `existingSecret.name` is empty. Chart creates `<release>-eager-api-key`.
+    value: ""
+
+  # -- Eager-execution client credentials (UNION_CLIENT_ID / UNION_CLIENT_SECRET). Kept separate from `admin` client creds.
+  eagerClientCreds:
+    existingSecret:
+      # -- Name of the existing Secret. When set, the chart skips creating its own.
+      name: ""
+      # -- Optional override of the client-id data key. Defaults to `client_id`.
+      clientIdKey: ""
+      # -- Optional override of the client-secret data key. Defaults to `client_secret`.
+      clientSecretKey: ""
+    enabled: false
+    # -- Inline client id. Used only when `existingSecret.name` is empty.
+    clientId: ""
+    # -- Inline client secret. Used only when `existingSecret.name` is empty.
+    clientSecret: ""
+
+  # -- Image builder registry credentials. Split into push (buildkit) and pull (task pods, replaces depot-token).
+  imageBuilder:
+    push:
+      existingSecret:
+        # -- Name of the existing Secret. When set, the chart skips creating its own.
+        name: ""
+      enabled: false
+      # -- Inline opaque KV map. Each key becomes a Secret data key. Used only when `existingSecret.name` is empty.
+      values: {}
+    pull:
+      existingSecret:
+        # -- Name of the existing Secret. When set, the chart skips creating its own.
+        name: ""
+      enabled: false
+      # -- Inline dockerconfigjson value (full JSON string). Used only when `existingSecret.name` is empty.
+      dockerconfigjson: ""
+
 sparkoperator:
   enabled: false
   plugin_config: { }

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1945,9 +1945,14 @@ secrets:
       # -- Optional override of the client-secret data key. Defaults to `client_secret`.
       clientSecretKey: ""
     enabled: false
-    # -- Inline client id. Used only when `existingSecret.name` is empty.
+    # -- OAuth client id (public identifier; rendered into the eager SDK
+    # config.yaml). Required with an inline clientSecret, and still required
+    # alongside existingSecret.name because the config.yaml render reads it
+    # from values.
     clientId: ""
     # -- Inline client secret. Used only when `existingSecret.name` is empty.
+    # Prefer existingSecret.name — inline values end up in rendered values
+    # files and CI artifacts.
     clientSecret: ""
 
   # -- Internal-CA trust bundle (`ca.crt`) used by the SDK to verify the

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1875,6 +1875,35 @@ proxy:
 resourcequota:
   create: false
 
+# -- Operator-side SecretMirrorSyncer config (FAB-241). When enabled, the
+# operator propagates chart-managed Secrets and ConfigMaps from this
+# release's namespace into every namespace matching the selector. The
+# flyte-pod-webhook's file-mount path activates simultaneously when
+# secrets.eagerClientCreds.enabled is true — it pre-checks the
+# mirror is present before injecting volume mounts and denies
+# admission with HTTP 503 on miss so the upstream retry path
+# absorbs operator-mirror lag.
+mirroring:
+  # -- Master switch. When false, SecretMirrorSyncer does not run and
+  # the legacy BuildImageConfigSyncer continues handling build-image
+  # ConfigMap mirror. When true, the new syncer subsumes it.
+  enabled: false
+  # -- Value applied as app.kubernetes.io/managed-by on every mirrored
+  # copy. Stable literal — does NOT incorporate release name. Customer-
+  # overridable for brand/white-label. Stability-critical: changing
+  # post-install orphans previously-mirrored copies.
+  managedByLabelValue: union-operator
+  # -- Default namespace selector applied to every mirror entry that
+  # doesn't override.
+  defaultNamespaceSelector:
+    matchLabels:
+      union.ai/namespace-type: flyte
+  # -- File-mount paths used by the operator config rendering and the
+  # webhook's fileMount block. Defaults match the SDK's expectations.
+  eagerOAuth:
+    configMapMountPath: /etc/flyte/config.yaml
+    secretMountPath: /etc/flyte/credentials/client_secret
+
 # -- Connection secrets for the Union control plane services.
 secrets:
   admin:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1950,6 +1950,23 @@ secrets:
     # -- Inline client secret. Used only when `existingSecret.name` is empty.
     clientSecret: ""
 
+  # -- Internal-CA trust bundle (`ca.crt`) used by the SDK to verify the
+  # CP `internal-tls` cert on the DP→CP gRPC path. Distinct from
+  # `eagerClientCreds`: trust material, not OAuth creds, so independent
+  # lifecycle and IAM scope (cluster operators typically point at an
+  # ExternalSecret-managed `internal-ca-bundle`). Single key inside the
+  # Secret: `ca.crt`. Picked up by the FAB-241 mirror + propeller
+  # webhook file-mount path when `secrets.internalCaCert.enabled` is true.
+  internalCaCert:
+    existingSecret:
+      # -- Name of the existing Secret. When set, the chart skips creating its own.
+      name: ""
+      # -- Optional override of the ca.crt data key. Defaults to `ca.crt`.
+      caCertKey: ""
+    enabled: false
+    # -- Inline PEM-encoded CA bundle. Used only when `existingSecret.name` is empty.
+    value: ""
+
   # -- Image builder registry credentials. Split into push (buildkit) and pull (task pods, replaces depot-token).
   imageBuilder:
     push:

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1878,9 +1878,15 @@ resourcequota:
 # -- Connection secrets for the Union control plane services.
 secrets:
   admin:
-    # -- Enable or disable the admin secret.  This is used to authenticate to the control plane.
+    # -- Reference an externally-provisioned Secret. When set, the chart skips creating its own
+    # -- regardless of the legacy `create` flag.
+    existingSecret:
+      name: ""
+    # -- Enable or disable the admin secret. This is used to authenticate to the control plane.
+    # -- DEPRECATED alias for `enable`. Either field is accepted; `enabled` wins when both are set.
     enable: true
-    # -- Create the secret resource containing the client id and secret.  If set to false the user is responsible for creating the secret before the installation.
+    # -- DEPRECATED. Set `existingSecret.name` instead. When `create: false` is left in place the
+    # -- chart treats it as referencing the historical name `union-secret-auth`.
     create: true
     # -- The client secret used to authenticate to the control plane.  This will be provided by Union.
     clientSecret: ""

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -15849,17 +15849,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -15876,6 +15876,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -15886,9 +15887,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -15897,6 +15901,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -15912,18 +15981,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -15977,34 +16035,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -15933,17 +15933,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -15960,6 +15960,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -15970,9 +15971,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -15981,6 +15985,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -15996,18 +16065,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -16061,34 +16119,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -19602,17 +19602,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -19629,6 +19629,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -19639,9 +19640,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -19650,6 +19654,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -19665,18 +19734,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -19730,34 +19788,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -15937,17 +15937,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -15964,6 +15964,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -15974,9 +15975,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -15985,6 +15989,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -16000,18 +16069,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -16065,34 +16123,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -15924,17 +15924,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -15951,6 +15951,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -15961,9 +15962,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -15972,6 +15976,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -15987,18 +16056,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -16052,34 +16110,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -15828,17 +15828,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -15855,6 +15855,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -15865,9 +15866,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -15876,6 +15880,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -15891,18 +15960,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -15956,34 +16014,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -16228,17 +16228,17 @@ data:
     controlplane chart's post-install / post-upgrade Helm hook Job
     (see templates/image-builder-bootstrap/).
     
-    Two env vars are required at registration time:
-      APP_VERSION              — image tag for build-image + frontend-v2
-                                 (set by the Job from .Chart.AppVersion).
-      UNION_IMAGE_NAME_PREFIX  — registry prefix where the build-image +
-                                 frontend-v2 images live
-                                 (set by the Job from values.imageBuilder.bootstrap
-                                 .unionImageNamePrefix).
+    Required env vars at registration time:
+      APP_VERSION              — image tag for build-image + frontend-v2.
+      UNION_IMAGE_NAME_PREFIX  — registry prefix.
     
-    Per-namespace defaults consumed at task execution time come from the
-    `build-image-config` ConfigMap that the union-operator BuildImageConfigSyncer
-    auto-creates in every namespace labelled `union.ai/namespace-type: flyte`.
+    Optional env vars:
+      IMAGE_BUILDER_PUSH_SECRET_NAME — when set, mounts the named K8s Secret
+                                       (kubernetes.io/dockerconfigjson) at
+                                       /etc/flyte/secrets/dockerconfigjson so
+                                       the build image's getDockerCredentials
+                                       picks it up alongside legacy Flyte
+                                       secrets in the same directory.
     """
     import os
     
@@ -16255,6 +16255,7 @@ data:
         V1VolumeProjection,
         V1ServiceAccountTokenProjection,
         V1ConfigMapVolumeSource,
+        V1SecretVolumeSource,
         V1KeyToPath,
     )
     
@@ -16265,9 +16266,12 @@ data:
     _DEFAULT_CONFIGMAP_NAME = "build-image-config"
     _STORAGE_YAML_KEY = "storage.yaml"
     _CONFIG_DIR = "/etc/union/config"
+    _PUSH_CREDS_DIR = "/etc/flyte/secrets"
+    _PUSH_CREDS_FILE = "dockerconfigjson"
     
     config_map_name = os.getenv("CONFIG_MAP_NAME", _DEFAULT_CONFIGMAP_NAME)
     log_level = os.getenv("LOG_LEVEL", "5")
+    push_secret_name = os.getenv("IMAGE_BUILDER_PUSH_SECRET_NAME", "").strip()
     
     union_image_name_prefix = os.getenv("UNION_IMAGE_NAME_PREFIX")
     if not union_image_name_prefix:
@@ -16276,6 +16280,71 @@ data:
     app_version = os.getenv("APP_VERSION")
     if not app_version:
         raise ValueError("APP_VERSION environment variable must be set")
+    
+    
+    _volume_mounts = [
+        V1VolumeMount(
+            mount_path="/var/run/secrets/union/registry",
+            name="registry-token",
+            read_only=True,
+        ),
+        V1VolumeMount(
+            name="config-volume",
+            mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
+            sub_path=_STORAGE_YAML_KEY,
+        ),
+    ]
+    
+    _volumes = [
+        V1Volume(
+            name="registry-token",
+            projected=V1ProjectedVolumeSource(
+                sources=[
+                    V1VolumeProjection(
+                        service_account_token=V1ServiceAccountTokenProjection(
+                            audience="registry",
+                            expiration_seconds=7200,
+                            path="token",
+                        )
+                    )
+                ]
+            ),
+        ),
+        V1Volume(
+            name="config-volume",
+            config_map=V1ConfigMapVolumeSource(
+                name=config_map_name,
+                items=[
+                    V1KeyToPath(
+                        key=_STORAGE_YAML_KEY,
+                        path=_STORAGE_YAML_KEY,
+                    )
+                ],
+            ),
+        ),
+    ]
+    
+    if push_secret_name:
+        # Key default for kubernetes.io/dockerconfigjson Secrets is
+        # ".dockerconfigjson" (leading dot). The build-image consumer skips
+        # hidden files, so remap to dockerconfigjson without the dot.
+        _volume_mounts.append(
+            V1VolumeMount(
+                name="image-builder-push-creds",
+                mount_path=f"{_PUSH_CREDS_DIR}/{_PUSH_CREDS_FILE}",
+                sub_path=_PUSH_CREDS_FILE,
+                read_only=True,
+            )
+        )
+        _volumes.append(
+            V1Volume(
+                name="image-builder-push-creds",
+                secret=V1SecretVolumeSource(
+                    secret_name=push_secret_name,
+                    items=[V1KeyToPath(key=".dockerconfigjson", path=_PUSH_CREDS_FILE)],
+                ),
+            )
+        )
     
     build_image_task = ContainerTask(
         name="build-image",
@@ -16291,18 +16360,7 @@ data:
                         name="main",
                         image_pull_policy="Always",
                         termination_message_policy="FallbackToLogsOnError",
-                        volume_mounts=[
-                            V1VolumeMount(
-                                mount_path="/var/run/secrets/union/registry",
-                                name="registry-token",
-                                read_only=True,
-                            ),
-                            V1VolumeMount(
-                                name="config-volume",
-                                mount_path=f"{_CONFIG_DIR}/{_STORAGE_YAML_KEY}",
-                                sub_path=_STORAGE_YAML_KEY,
-                            ),
-                        ],
+                        volume_mounts=_volume_mounts,
                         env=[
                             V1EnvVar(
                                 name="ORGANIZATION",
@@ -16356,34 +16414,7 @@ data:
                         ],
                     ),
                 ],
-                volumes=[
-                    V1Volume(
-                        name="registry-token",
-                        projected=V1ProjectedVolumeSource(
-                            sources=[
-                                V1VolumeProjection(
-                                    service_account_token=V1ServiceAccountTokenProjection(
-                                        audience="registry",
-                                        expiration_seconds=7200,
-                                        path="token",
-                                    )
-                                )
-                            ]
-                        ),
-                    ),
-                    V1Volume(
-                        name="config-volume",
-                        config_map=V1ConfigMapVolumeSource(
-                            name=config_map_name,
-                            items=[
-                                V1KeyToPath(
-                                    key=_STORAGE_YAML_KEY,
-                                    path=_STORAGE_YAML_KEY,
-                                )
-                            ],
-                        ),
-                    ),
-                ],
+                volumes=_volumes,
             ),
         ),
         command=[

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1zZWNyZXQ=
   client_secret: dGVzdC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -891,6 +891,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6488,7 +6489,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8dd61d12833bb8969f034899deb15c1705e832760b9c4c6f924af2c6a0b361c"
+        configChecksum: "399ed73be6266aad9e87e002e273697856a4e9b4c81de5efaa3dec4a92ab0da"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6971,7 +6972,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8dd61d12833bb8969f034899deb15c1705e832760b9c4c6f924af2c6a0b361c"
+        configChecksum: "399ed73be6266aad9e87e002e273697856a4e9b4c81de5efaa3dec4a92ab0da"
         prometheus.io/scrape: "true"
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tdGVzdA==
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-test"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6410,7 +6409,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6548,7 +6547,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6654,7 +6653,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6783,7 +6782,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6907,7 +6906,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7012,7 +7011,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -952,6 +952,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'union-union-test-worker1'
+      
     union:
       connection:
         host: 'dns:///union.test.union.ai:443'
@@ -3489,6 +3490,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6489,7 +6491,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "399ed73be6266aad9e87e002e273697856a4e9b4c81de5efaa3dec4a92ab0da"
+        configChecksum: "4702bc1e19109015e79c90baeddbaf83700f009ceaad717dfd9e2766f3a8cf4"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6593,7 +6595,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1b39fb93998c0b23888f4517108e47e52cea269726cdbba0bc5717c9dcdc8c4"
+        configChecksum: "3b9637f3084f17996838d4625510feb974130aab56168338f8c4e218d5ddab3"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6972,7 +6974,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "399ed73be6266aad9e87e002e273697856a4e9b4c81de5efaa3dec4a92ab0da"
+        configChecksum: "4702bc1e19109015e79c90baeddbaf83700f009ceaad717dfd9e2766f3a8cf4"
         prometheus.io/scrape: "true"
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -958,6 +958,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///test.example.com:443'
@@ -3501,6 +3502,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6521,7 +6523,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "15c59c30c88bbc61180d11087d9025e671de1be1489cf0c8a5828351fc8f74d"
+        configChecksum: "77980a1e70e880339d1d4e87311cfb7cd47be48d49c8db0c66c2da4012e408e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6623,7 +6625,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9e8740b6d5d93fb4460794ada878ff477d6fdc8f193c9b1faf3fbd15ad728f6"
+        configChecksum: "368691680a134fb9fa627faaf51939a701f06749b351ef62e4a38336659555e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6994,7 +6996,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "15c59c30c88bbc61180d11087d9025e671de1be1489cf0c8a5828351fc8f74d"
+        configChecksum: "77980a1e70e880339d1d4e87311cfb7cd47be48d49c8db0c66c2da4012e408e"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -897,6 +897,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6520,7 +6521,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "385f72f71de64efc2cd659f39f6d5438ba13fd52f1b9755f07f519bcf993301"
+        configChecksum: "15c59c30c88bbc61180d11087d9025e671de1be1489cf0c8a5828351fc8f74d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6993,7 +6994,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "385f72f71de64efc2cd659f39f6d5438ba13fd52f1b9755f07f519bcf993301"
+        configChecksum: "15c59c30c88bbc61180d11087d9025e671de1be1489cf0c8a5828351fc8f74d"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6442,7 +6441,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6578,7 +6577,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6682,7 +6681,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6809,7 +6808,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6931,7 +6930,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7034,7 +7033,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -187,16 +187,6 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -842,6 +832,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6948,7 +6947,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7084,7 +7083,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7188,7 +7187,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7315,7 +7314,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7437,7 +7436,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7540,7 +7539,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -1077,6 +1077,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'test-org-name-test-cluster-name-worker1'
+      
     union:
       connection:
         host: 'dns:///test-controlplane-host:443'
@@ -3639,6 +3640,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -7027,7 +7029,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "36a1faa7dbec782dfc331b5a55f3a0abaa05cd329723a3d5171816dab5ab6bd"
+        configChecksum: "f7ece005f257964dbac64c9dd77f53368368dddbe720f5d2f8e0c044cf2751c"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7129,7 +7131,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7e6d9cf29217331900d6f98451f30c124cf499ec32a6b87574c1dde9b71b1c2"
+        configChecksum: "715f9d89f7a30a790ea66adb82b3a918762352fee189d92d4bde322a7b5e32d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7500,7 +7502,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "36a1faa7dbec782dfc331b5a55f3a0abaa05cd329723a3d5171816dab5ab6bd"
+        configChecksum: "f7ece005f257964dbac64c9dd77f53368368dddbe720f5d2f8e0c044cf2751c"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -183,7 +183,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -1016,6 +1016,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -7026,7 +7027,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e60d1991c51a392fc4200858d2748de7eaaa5118560c5ff356586d4e71622c7"
+        configChecksum: "36a1faa7dbec782dfc331b5a55f3a0abaa05cd329723a3d5171816dab5ab6bd"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7499,7 +7500,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "e60d1991c51a392fc4200858d2748de7eaaa5118560c5ff356586d4e71622c7"
+        configChecksum: "36a1faa7dbec782dfc331b5a55f3a0abaa05cd329723a3d5171816dab5ab6bd"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -891,6 +891,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6488,7 +6489,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2db733ad473adf73c6473424f4f8632e8e395369b49aaf3a59386713a673ab7"
+        configChecksum: "0df87715d3c2e3c7db062d3a14b7689c0b02a7cca882e32735867ec850457e9"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6961,7 +6962,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "2db733ad473adf73c6473424f4f8632e8e395369b49aaf3a59386713a673ab7"
+        configChecksum: "0df87715d3c2e3c7db062d3a14b7689c0b02a7cca882e32735867ec850457e9"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: Y2xpZW50U2VjcmV0
   client_secret: Y2xpZW50U2VjcmV0
 

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: Y2xpZW50U2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tYXdz
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-aws"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6410,7 +6409,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6546,7 +6545,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6650,7 +6649,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6777,7 +6776,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6899,7 +6898,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7002,7 +7001,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -952,6 +952,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'union-union-aws-worker1'
+      
     union:
       connection:
         host: 'dns:///union.us-west-2.union.ai:443'
@@ -3489,6 +3490,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6489,7 +6491,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0df87715d3c2e3c7db062d3a14b7689c0b02a7cca882e32735867ec850457e9"
+        configChecksum: "1b46ff3759f1cd0b46684fec13f62476f0c806af38b2355ddf66339948c9613"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6591,7 +6593,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b61813f362282352a4b57d43849e26df7203c4522cd1c152dc9efd56cb06b0f"
+        configChecksum: "9539dcc3642a424a81e3a5b6334ec20da94022791268414e8c435cfce757936"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6962,7 +6964,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "0df87715d3c2e3c7db062d3a14b7689c0b02a7cca882e32735867ec850457e9"
+        configChecksum: "1b46ff3759f1cd0b46684fec13f62476f0c806af38b2355ddf66339948c9613"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -1077,6 +1077,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'test-org-name-test-cluster-name-worker1'
+      
     union:
       connection:
         host: 'dns:///test-controlplane-host:443'
@@ -3614,6 +3615,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6954,7 +6956,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "66fcaec06051eb037dbdcfcd7da2664eecea3b85b563290078a57aff3daeeb5"
+        configChecksum: "b60cb88bb8f13345ca47413d294aa8608b15fe5d5a863e3a9e4865dc4219ce6"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7056,7 +7058,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4ea12e0a3053fe57c2acc3b022bca7eddd7f09758a25073131cd507345ad434"
+        configChecksum: "12dabd792df102e858949b73b27508e6b4ae01315b7c6fff1ff17ca3cd17ad4"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7427,7 +7429,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "66fcaec06051eb037dbdcfcd7da2664eecea3b85b563290078a57aff3daeeb5"
+        configChecksum: "b60cb88bb8f13345ca47413d294aa8608b15fe5d5a863e3a9e4865dc4219ce6"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -1016,6 +1016,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6953,7 +6954,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "48929dcd17c30dc691d1cae7aea0a707a0dd53e9ac25034d3f05c4160942c6f"
+        configChecksum: "66fcaec06051eb037dbdcfcd7da2664eecea3b85b563290078a57aff3daeeb5"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7426,7 +7427,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "48929dcd17c30dc691d1cae7aea0a707a0dd53e9ac25034d3f05c4160942c6f"
+        configChecksum: "66fcaec06051eb037dbdcfcd7da2664eecea3b85b563290078a57aff3daeeb5"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -183,7 +183,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -187,6 +187,92 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
+# Source: dataplane/templates/common/eager-api-key-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-eager-api-key
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  EAGER_API_KEY: dGVzdC1ub3QtcmVhbC1lYWdlci1hcGkta2V5
+
+---
+# Source: dataplane/templates/common/eager-client-creds-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-eager-client-creds
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  client_id: dGVzdC1lYWdlci1jbGllbnQtaWQ=
+  client_secret: dGVzdC1ub3QtcmVhbC1lYWdlci1zZWNyZXQ=
+
+---
+# Source: dataplane/templates/common/image-builder-push-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-image-builder-push
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  token: dGVzdC1ub3QtcmVhbC1wdXNoLXRva2Vu
+
+---
+# Source: dataplane/templates/common/image-pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-image-builder-pull
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6e319
+
+---
+# Source: dataplane/templates/common/internal-ca-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-internal-ca
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  ca.crt: dGVzdC1ub3QtcmVhbC1jYS1wZW0=
+
+---
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -842,6 +928,29 @@ data:
   cluster_name: "test-cluster-name"
 
 ---
+# Source: dataplane/templates/common/eager-oauth-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-eager-oauth-config
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+data:
+  config.yaml: |
+    admin:
+      endpoint: "dns:///test-controlplane-host:443"
+      clientId: "test-eager-client-id"
+      clientSecretLocation: "/etc/flyte/credentials/client_secret"
+      authType: ClientCredentials
+      insecureSkipVerify: true
+      caCertFilePath: "/etc/flyte/credentials/ca.crt"
+
+---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -1074,10 +1183,43 @@ data:
           gpu: 256
           memory: 2Ti
       unionAuth:
-        injectSecret: true
+        injectSecret: false
         secretName: EAGER_API_KEY
       workerName: 'test-org-name-test-cluster-name-worker1'
       
+      podInject:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        mounts:
+          - volume:
+              configMap:
+                name: release-name-eager-oauth-config
+              name: union-eager-auth-config
+            volumeMount:
+              mountPath: /etc/flyte/config.yaml
+              name: union-eager-auth-config
+              readOnly: true
+              subPath: config.yaml
+          - volume:
+              name: union-eager-client-secret
+              secret:
+                secretName: release-name-eager-client-creds
+            volumeMount:
+              mountPath: /etc/flyte/credentials/client_secret
+              name: union-eager-client-secret
+              readOnly: true
+              subPath: client_secret
+          - volume:
+              name: union-internal-ca
+              secret:
+                secretName: release-name-internal-ca
+            volumeMount:
+              mountPath: /etc/flyte/credentials/ca.crt
+              name: union-internal-ca
+              readOnly: true
+              subPath: ca.crt
+        imagePullSecrets:
+          - name: release-name-image-builder-pull
     union:
       connection:
         host: 'dns:///test-controlplane-host:443'
@@ -1136,7 +1278,8 @@ data:
           name: flyte-copilot-
           start-timeout: 30s
         default-cpus: 100m
-        default-env-vars: []
+        default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         default-memory: 100Mi
         default-pod-template-name: task-template
         disable-inject-owner-references: true
@@ -3612,10 +3755,43 @@ data:
       maxActions: 2000
       organization: 'test-org-name'
       unionAuth:
-        injectSecret: true
+        injectSecret: false
         secretName: EAGER_API_KEY
       workerName: worker1
       
+      podInject:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        mounts:
+          - volume:
+              configMap:
+                name: release-name-eager-oauth-config
+              name: union-eager-auth-config
+            volumeMount:
+              mountPath: /etc/flyte/config.yaml
+              name: union-eager-auth-config
+              readOnly: true
+              subPath: config.yaml
+          - volume:
+              name: union-eager-client-secret
+              secret:
+                secretName: release-name-eager-client-creds
+            volumeMount:
+              mountPath: /etc/flyte/credentials/client_secret
+              name: union-eager-client-secret
+              readOnly: true
+              subPath: client_secret
+          - volume:
+              name: union-internal-ca
+              secret:
+                secretName: release-name-internal-ca
+            volumeMount:
+              mountPath: /etc/flyte/credentials/ca.crt
+              name: union-internal-ca
+              readOnly: true
+              subPath: ca.crt
+        imagePullSecrets:
+          - name: release-name-image-builder-pull
       task_resources:
         defaults:
           cpu: 100m
@@ -3687,7 +3863,8 @@ data:
       k8s:
         disable-inject-owner-references: true
         default-cpus: 100m
-        default-env-vars: []
+        default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         default-memory: 100Mi
         default-pod-template-name: task-template
         co-pilot:
@@ -3723,7 +3900,8 @@ data:
     plugins:
       k8s:
         default-cpus: 100m
-        default-env-vars: []
+        default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         default-memory: 100Mi
         default-pod-template-name: task-template
   config.yaml: |
@@ -3791,6 +3969,31 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      mirroring:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        defaultNamespaceSelector:
+          matchLabels:
+            union.ai/namespace-type: flyte
+        provenanceAnnotations:
+          sourceNamespace: union.ai/mirrored-from-namespace
+          sourceName: union.ai/mirrored-from-name
+          sourceVersion: union.ai/mirrored-from-version
+        resources:
+        - kind: Secret
+          name: release-name-eager-client-creds
+        - kind: ConfigMap
+          name: release-name-eager-oauth-config
+        - kind: Secret
+          name: release-name-internal-ca
+        - kind: ConfigMap
+          name: build-image-config
+        - kind: Secret
+          name: release-name-image-builder-pull
+        - kind: Secret
+          name: release-name-image-builder-push
+        - kind: Secret
+          name: my-custom-mirrored-secret
     proxy:
       persistedLogs:
         objectStore:
@@ -6956,7 +7159,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b60cb88bb8f13345ca47413d294aa8608b15fe5d5a863e3a9e4865dc4219ce6"
+        configChecksum: "a5f56797d6707765c160f45612b4abd30b5ba4afd4dd5ce17afed5ae16e9fda"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7058,7 +7261,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "12dabd792df102e858949b73b27508e6b4ae01315b7c6fff1ff17ca3cd17ad4"
+        configChecksum: "49bfce3ec4b415a9a00051b2c30265ddd5f055488525b146d3d0946d778c12d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7165,7 +7368,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af7aa0c43db278ce52f48fa1f424f8cb3fcf13b98f31436c37e425758b85230"
+        configChecksum: "f469c3586d5623220a80bd22642f7b5112ff509f86f6b7c7c6ddc44e63bed9a"
         
       labels:
         
@@ -7303,7 +7506,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af7aa0c43db278ce52f48fa1f424f8cb3fcf13b98f31436c37e425758b85230"
+        configChecksum: "f469c3586d5623220a80bd22642f7b5112ff509f86f6b7c7c6ddc44e63bed9a"
         
       labels:
         
@@ -7429,7 +7632,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "b60cb88bb8f13345ca47413d294aa8608b15fe5d5a863e3a9e4865dc4219ce6"
+        configChecksum: "a5f56797d6707765c160f45612b4abd30b5ba4afd4dd5ce17afed5ae16e9fda"
         
     spec:
       securityContext:
@@ -7645,6 +7848,8 @@ metadata:
 template:
   spec:
     serviceAccountName: union
+    imagePullSecrets:
+      - name: release-name-image-builder-pull
     containers:
       - name: default
         image: docker.io/rwgrim/docker-noop

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -187,16 +187,6 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -842,6 +832,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6875,7 +6874,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7011,7 +7010,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7115,7 +7114,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7242,7 +7241,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7364,7 +7363,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7467,7 +7466,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -181,16 +181,6 @@ metadata:
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/component: activator
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/gateway/webhook.yaml
 # Copyright 2020 The Knative Authors
 #
@@ -840,6 +830,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -8411,7 +8410,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9380,7 +9379,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9516,7 +9515,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9620,7 +9619,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9747,7 +9746,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -9843,7 +9842,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9946,7 +9945,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -2890,6 +2890,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -9458,7 +9459,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "92b621c136a0ecdf3cc5c2fbd1f67cd8e1b2d388db186bf6195571a68d3bd32"
+        configChecksum: "ac397608350f9b95bc4098fe41a1f63044c9fcff398808bffcbf9ef254d696a"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9905,7 +9906,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "92b621c136a0ecdf3cc5c2fbd1f67cd8e1b2d388db186bf6195571a68d3bd32"
+        configChecksum: "ac397608350f9b95bc4098fe41a1f63044c9fcff398808bffcbf9ef254d696a"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -2951,6 +2951,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'test-org-name-test-cluster-name-worker1'
+      
     union:
       connection:
         host: 'dns:///override.example.com:443'
@@ -5492,6 +5493,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -9459,7 +9461,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ac397608350f9b95bc4098fe41a1f63044c9fcff398808bffcbf9ef254d696a"
+        configChecksum: "526f5a429f0630acadcd3717227ac6afc03f81dbbe5f4d9e8c49b26c371f627"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9561,7 +9563,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7a112992af05aa6b13d1e3c7fda27241e6c387446bc7fb3029a046388660805"
+        configChecksum: "2452c3d942e4e0bfce5011551639d42d8e2e4a9dca11ad20d1f99662f0b653e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9906,7 +9908,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ac397608350f9b95bc4098fe41a1f63044c9fcff398808bffcbf9ef254d696a"
+        configChecksum: "526f5a429f0630acadcd3717227ac6afc03f81dbbe5f4d9e8c49b26c371f627"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -181,16 +181,6 @@ metadata:
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/component: activator
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1jbHVzdGVyLW5hbWU=
-
----
 # Source: dataplane/templates/gateway/webhook.yaml
 # Copyright 2020 The Knative Authors
 #
@@ -840,6 +830,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-cluster-name"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -8411,7 +8410,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9380,7 +9379,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9516,7 +9515,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9620,7 +9619,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9747,7 +9746,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -9843,7 +9842,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9946,7 +9945,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -2890,6 +2890,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -9458,7 +9459,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "92c77518e5cd20906e9148bd3e3cdd36d18ede1a3d09ce9123070a77e3594cc"
+        configChecksum: "2f674984e08e4f74f2726ad53fdaeb593bc30a6766e78fbff1bb861a142f6d1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9905,7 +9906,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "92c77518e5cd20906e9148bd3e3cdd36d18ede1a3d09ce9123070a77e3594cc"
+        configChecksum: "2f674984e08e4f74f2726ad53fdaeb593bc30a6766e78fbff1bb861a142f6d1"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -2951,6 +2951,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'test-org-name-test-cluster-name-worker1'
+      
     union:
       connection:
         host: 'dns:///test-controlplane-host:443'
@@ -5492,6 +5493,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -9459,7 +9461,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2f674984e08e4f74f2726ad53fdaeb593bc30a6766e78fbff1bb861a142f6d1"
+        configChecksum: "d5c23d443d2a324009a4bc70dcff7eca2a1e7bb3492574f41c970e9eb38c07d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9561,7 +9563,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "348ba68c65e9f876384eab40742abe3522e1fc794bde7eecd8ad8bba59b944b"
+        configChecksum: "b54a9678d6b66705bce40b6eba5a630352fe04f070f657fab43c9e1f1cd4578"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9906,7 +9908,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "2f674984e08e4f74f2726ad53fdaeb593bc30a6766e78fbff1bb861a142f6d1"
+        configChecksum: "d5c23d443d2a324009a4bc70dcff7eca2a1e7bb3492574f41c970e9eb38c07d"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1henVyZS1jbHVzdGVy
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-azure-cluster"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6477,7 +6476,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6614,7 +6613,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6719,7 +6718,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6847,7 +6846,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6970,7 +6969,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7074,7 +7073,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -882,6 +882,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6555,7 +6556,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "132273bd9c0bc79f7074b245b32e5671f8c48d2283106157316a2e13ad4098b"
+        configChecksum: "c4433f20bdda6e1a5497d10799cb910c044297daa19080bda9f6ed78d7f65cf"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7033,7 +7034,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "132273bd9c0bc79f7074b245b32e5671f8c48d2283106157316a2e13ad4098b"
+        configChecksum: "c4433f20bdda6e1a5497d10799cb910c044297daa19080bda9f6ed78d7f65cf"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -946,6 +946,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'test-org-test-azure-cluster-worker1'
+      
     union:
       connection:
         host: 'dns:///test.dataplane.union.ai:443'
@@ -3501,6 +3502,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6556,7 +6558,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c4433f20bdda6e1a5497d10799cb910c044297daa19080bda9f6ed78d7f65cf"
+        configChecksum: "ffa2db1ea7cffc58dd984a0ce5c3f7436ee60240f109ce67f15cd5432aa3a12"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6659,7 +6661,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4df6ac90b645d25eb996888199717417b2bd50aa650ad60772d0932644e0bab"
+        configChecksum: "f2354a77c222d16145f8cba39341feb7a950d44d6247f890afb8eac50578ee7"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7034,7 +7036,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "c4433f20bdda6e1a5497d10799cb910c044297daa19080bda9f6ed78d7f65cf"
+        configChecksum: "ffa2db1ea7cffc58dd984a0ce5c3f7436ee60240f109ce67f15cd5432aa3a12"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1henVyZS1jbHVzdGVy
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-azure-cluster"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6477,7 +6476,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6614,7 +6613,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6719,7 +6718,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6847,7 +6846,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6970,7 +6969,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7074,7 +7073,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -946,6 +946,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'test-org-test-azure-cluster-worker1'
+      
     union:
       connection:
         host: 'dns:///test.dataplane.union.ai:443'
@@ -3501,6 +3502,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6556,7 +6558,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "99106c59adbf858f458faa23153ef5d8f007782a610a30b7087bd2e0f651911"
+        configChecksum: "ddfc8153e765c3d935fc6c7720dad4addda8063b093f4e1f495c3de44f31e14"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6659,7 +6661,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a0b08b345594910ed0e9f9eb146f2dc97f14628702c17504bbf495e9d5b3f97"
+        configChecksum: "1480d5960ead087487ee0c5f20c195e690d950ef7a0d101e6ec74adffbc00ad"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7034,7 +7036,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "99106c59adbf858f458faa23153ef5d8f007782a610a30b7087bd2e0f651911"
+        configChecksum: "ddfc8153e765c3d935fc6c7720dad4addda8063b093f4e1f495c3de44f31e14"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -158,6 +158,75 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0LXZhbHVl
 
 ---
+# Source: dataplane/templates/common/eager-client-creds-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-eager-client-creds
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  client_id: dGVzdC1lYWdlci1jbGllbnQtaWQ=
+  client_secret: dGVzdC1ub3QtcmVhbC1lYWdlci1zZWNyZXQ=
+
+---
+# Source: dataplane/templates/common/image-builder-push-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-image-builder-push
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  token: dGVzdC1ub3QtcmVhbC1wdXNoLXRva2Vu
+
+---
+# Source: dataplane/templates/common/image-pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-image-builder-pull
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6e319
+
+---
+# Source: dataplane/templates/common/internal-ca-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-internal-ca
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  ca.crt: dGVzdC1ub3QtcmVhbC1jYS1wZW0=
+
+---
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +786,29 @@ data:
   cluster_name: "test-azure-cluster"
 
 ---
+# Source: dataplane/templates/common/eager-oauth-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-eager-oauth-config
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+data:
+  config.yaml: |
+    admin:
+      endpoint: "dns:///test.dataplane.union.ai:443"
+      clientId: "test-eager-client-id"
+      clientSecretLocation: "/etc/flyte/credentials/client_secret"
+      authType: ClientCredentials
+      insecureSkipVerify: true
+      caCertFilePath: "/etc/flyte/credentials/ca.crt"
+
+---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -943,10 +1035,43 @@ data:
           gpu: 256
           memory: 2Ti
       unionAuth:
-        injectSecret: true
+        injectSecret: false
         secretName: EAGER_API_KEY
       workerName: 'test-org-test-azure-cluster-worker1'
       
+      podInject:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        mounts:
+          - volume:
+              configMap:
+                name: release-name-eager-oauth-config
+              name: union-eager-auth-config
+            volumeMount:
+              mountPath: /etc/flyte/config.yaml
+              name: union-eager-auth-config
+              readOnly: true
+              subPath: config.yaml
+          - volume:
+              name: union-eager-client-secret
+              secret:
+                secretName: release-name-eager-client-creds
+            volumeMount:
+              mountPath: /etc/flyte/credentials/client_secret
+              name: union-eager-client-secret
+              readOnly: true
+              subPath: client_secret
+          - volume:
+              name: union-internal-ca
+              secret:
+                secretName: release-name-internal-ca
+            volumeMount:
+              mountPath: /etc/flyte/credentials/ca.crt
+              name: union-internal-ca
+              readOnly: true
+              subPath: ca.crt
+        imagePullSecrets:
+          - name: release-name-image-builder-pull
     union:
       connection:
         host: 'dns:///test.dataplane.union.ai:443'
@@ -1006,6 +1131,7 @@ data:
           start-timeout: 30s
         default-cpus: 100m
         default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         - AZURE_STORAGE_ACCOUNT_NAME: test-storage-account
         default-labels:
         - azure.workload.identity/use: "true"
@@ -3499,10 +3625,43 @@ data:
       maxActions: 2000
       organization: 'test-org'
       unionAuth:
-        injectSecret: true
+        injectSecret: false
         secretName: EAGER_API_KEY
       workerName: worker1
       
+      podInject:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        mounts:
+          - volume:
+              configMap:
+                name: release-name-eager-oauth-config
+              name: union-eager-auth-config
+            volumeMount:
+              mountPath: /etc/flyte/config.yaml
+              name: union-eager-auth-config
+              readOnly: true
+              subPath: config.yaml
+          - volume:
+              name: union-eager-client-secret
+              secret:
+                secretName: release-name-eager-client-creds
+            volumeMount:
+              mountPath: /etc/flyte/credentials/client_secret
+              name: union-eager-client-secret
+              readOnly: true
+              subPath: client_secret
+          - volume:
+              name: union-internal-ca
+              secret:
+                secretName: release-name-internal-ca
+            volumeMount:
+              mountPath: /etc/flyte/credentials/ca.crt
+              name: union-internal-ca
+              readOnly: true
+              subPath: ca.crt
+        imagePullSecrets:
+          - name: release-name-image-builder-pull
       task_resources:
         defaults:
           cpu: 100m
@@ -3575,6 +3734,7 @@ data:
         disable-inject-owner-references: true
         default-cpus: 100m
         default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         - AZURE_STORAGE_ACCOUNT_NAME: test-storage-account
         default-labels:
         - azure.workload.identity/use: "true"
@@ -3629,6 +3789,7 @@ data:
       k8s:
         default-cpus: 100m
         default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         - AZURE_STORAGE_ACCOUNT_NAME: test-storage-account
         default-labels:
         - azure.workload.identity/use: "true"
@@ -3723,6 +3884,31 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      mirroring:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        defaultNamespaceSelector:
+          matchLabels:
+            union.ai/namespace-type: flyte
+        provenanceAnnotations:
+          sourceNamespace: union.ai/mirrored-from-namespace
+          sourceName: union.ai/mirrored-from-name
+          sourceVersion: union.ai/mirrored-from-version
+        resources:
+        - kind: Secret
+          name: release-name-eager-client-creds
+        - kind: ConfigMap
+          name: release-name-eager-oauth-config
+        - kind: Secret
+          name: release-name-internal-ca
+        - kind: ConfigMap
+          name: build-image-config
+        - kind: Secret
+          name: release-name-image-builder-pull
+        - kind: Secret
+          name: release-name-image-builder-push
+        - kind: Secret
+          name: my-custom-mirrored-secret
     proxy:
       persistedLogs:
         azureLogAnalytics:
@@ -6558,7 +6744,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ddfc8153e765c3d935fc6c7720dad4addda8063b093f4e1f495c3de44f31e14"
+        configChecksum: "017ce95cc8ebf5410cde27b4253702f246f9e6c06cc78b34e0988fc24d24938"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6661,7 +6847,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1480d5960ead087487ee0c5f20c195e690d950ef7a0d101e6ec74adffbc00ad"
+        configChecksum: "2fca55c013227df341afeca2e822f75d7771d3782137b76d1e17a2b0e2f9708"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6769,7 +6955,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a9eeb80b68b74257be64e154225f2f7f1d57739c484c6a1bc5c3fc36043b35"
+        configChecksum: "cc5fe7430531a18f289d6f41fc4d4b6311c563c0c254f1241ffe013efc034ff"
         
       labels:
         
@@ -6908,7 +7094,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a9eeb80b68b74257be64e154225f2f7f1d57739c484c6a1bc5c3fc36043b35"
+        configChecksum: "cc5fe7430531a18f289d6f41fc4d4b6311c563c0c254f1241ffe013efc034ff"
         
       labels:
         
@@ -7036,7 +7222,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ddfc8153e765c3d935fc6c7720dad4addda8063b093f4e1f495c3de44f31e14"
+        configChecksum: "017ce95cc8ebf5410cde27b4253702f246f9e6c06cc78b34e0988fc24d24938"
         
     spec:
       securityContext:
@@ -7220,6 +7406,8 @@ metadata:
 template:
   spec:
     serviceAccountName: union
+    imagePullSecrets:
+      - name: release-name-image-builder-pull
     containers:
       - name: default
         image: docker.io/rwgrim/docker-noop

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -882,6 +882,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6555,7 +6556,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "66dd99d3c078d373ff7f5fbf9a36b3c514ac074122e7fda9d3b2198a6b89369"
+        configChecksum: "99106c59adbf858f458faa23153ef5d8f007782a610a30b7087bd2e0f651911"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7033,7 +7034,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "66dd99d3c078d373ff7f5fbf9a36b3c514ac074122e7fda9d3b2198a6b89369"
+        configChecksum: "99106c59adbf858f458faa23153ef5d8f007782a610a30b7087bd2e0f651911"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -187,7 +187,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1jbGllbnQtc2VjcmV0
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -1037,6 +1037,7 @@ data:
   webhook.yaml: |
 
     
+    
     webhook:
       certDir: /etc/webhook/certs
       disableCreateMutatingWebhookConfig: true
@@ -6689,7 +6690,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c77b8e234e874393773b557311a1731670d4e51c8b009711940e5afd27a5fa0"
+        configChecksum: "ef6473ba966e3e3b4d7de7652c7106d04706ccce996e1ef75ec2bca5c7bc651"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7164,7 +7165,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "c77b8e234e874393773b557311a1731670d4e51c8b009711940e5afd27a5fa0"
+        configChecksum: "ef6473ba966e3e3b4d7de7652c7106d04706ccce996e1ef75ec2bca5c7bc651"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -191,16 +191,6 @@ data:
   client_secret: dGVzdC1jbGllbnQtc2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -891,6 +881,15 @@ data:
         limits.memory: {{ projectQuotaMemory }}
         requests.nvidia.com/gpu: {{ projectQuotaNvidiaGpu }}
     
+
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
 
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
@@ -6449,7 +6448,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6611,7 +6610,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6747,7 +6746,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6851,7 +6850,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6980,7 +6979,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7102,7 +7101,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7205,7 +7204,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -1094,6 +1094,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///test.example.com:443'
@@ -3637,6 +3638,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6690,7 +6692,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ef6473ba966e3e3b4d7de7652c7106d04706ccce996e1ef75ec2bca5c7bc651"
+        configChecksum: "4c7b3f59a76f7742832091451ba161de42d4733d81c21e73e223f7c0247d5fd"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6792,7 +6794,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "83a28f5804d226d78f9c85d37bb15afc92eab8aa20cee93b8609ac1786ac6d1"
+        configChecksum: "eac105ccb6be8ad27abb37452affc2ba6d435786ae37e8bb4984a194b9df2f1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7165,7 +7167,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ef6473ba966e3e3b4d7de7652c7106d04706ccce996e1ef75ec2bca5c7bc651"
+        configChecksum: "4c7b3f59a76f7742832091451ba161de42d4733d81c21e73e223f7c0247d5fd"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -146,16 +146,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -705,6 +695,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6428,7 +6427,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6564,7 +6563,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6668,7 +6667,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6795,7 +6794,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6917,7 +6916,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7020,7 +7019,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -885,6 +885,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6506,7 +6507,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6979,7 +6980,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -946,6 +946,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///:443'
@@ -3489,6 +3490,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6507,7 +6509,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
+        configChecksum: "08a790e95b17cc0f2be33628613f2632fd841c5391b50dff8dc903ed77036a8"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6609,7 +6611,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8655b854deda3dd76ce6a90e79a506077dbf2c133972104f938471dcf72f1e4"
+        configChecksum: "caf351acc66abf38f6f07d62f590203f676a33a3d7a9663223e6cc51659439e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6980,7 +6982,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
+        configChecksum: "08a790e95b17cc0f2be33628613f2632fd841c5391b50dff8dc903ed77036a8"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -175,16 +175,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -830,6 +820,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6759,7 +6758,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6895,7 +6894,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6999,7 +6998,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7126,7 +7125,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7248,7 +7247,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7351,7 +7350,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -1010,6 +1010,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6837,7 +6838,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7310,7 +7311,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -1071,6 +1071,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///:443'
@@ -3614,6 +3615,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6838,7 +6840,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
+        configChecksum: "08a790e95b17cc0f2be33628613f2632fd841c5391b50dff8dc903ed77036a8"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6940,7 +6942,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8655b854deda3dd76ce6a90e79a506077dbf2c133972104f938471dcf72f1e4"
+        configChecksum: "caf351acc66abf38f6f07d62f590203f676a33a3d7a9663223e6cc51659439e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7311,7 +7313,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
+        configChecksum: "08a790e95b17cc0f2be33628613f2632fd841c5391b50dff8dc903ed77036a8"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -885,6 +885,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6511,7 +6512,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f24aa9aa16d7d6fec22c6e5c91babc367bb53875efbb19d969ce718a8a3ef66"
+        configChecksum: "9079da048d4503fa9bd876f1998747cf8206521d1c453c9a53ca049c0191815"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6928,7 +6929,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "f24aa9aa16d7d6fec22c6e5c91babc367bb53875efbb19d969ce718a8a3ef66"
+        configChecksum: "9079da048d4503fa9bd876f1998747cf8206521d1c453c9a53ca049c0191815"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -946,6 +946,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///:443'
@@ -3490,6 +3491,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6512,7 +6514,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9079da048d4503fa9bd876f1998747cf8206521d1c453c9a53ca049c0191815"
+        configChecksum: "8885a2db353057ae757b567758577f9bc16e9d1dcedf0304f4458c4ad6c0fc3"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6604,7 +6606,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ab719197934a1ba9e76ee5777d46bbc8cde882c11a1fa80367373eac44b5721"
+        configChecksum: "9031bfdc7cb0c79a1a8d9947ffee64d9cde4c697ff1925b2148878115ee89dc"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6929,7 +6931,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "9079da048d4503fa9bd876f1998747cf8206521d1c453c9a53ca049c0191815"
+        configChecksum: "8885a2db353057ae757b567758577f9bc16e9d1dcedf0304f4458c4ad6c0fc3"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -146,16 +146,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -705,6 +695,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6433,7 +6432,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6563,7 +6562,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6657,7 +6656,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6775,7 +6774,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6866,7 +6865,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6969,7 +6968,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -955,6 +955,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'byok-test-e2e-gcp-worker1'
+      
     union:
       connection:
         host: 'dns:///byok.us-west-2.union.ai:443'
@@ -3495,6 +3496,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6504,7 +6506,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b1aa562e3127e355cd7b84fea788998a2c8a52a031743e1dc5a564dbeb4715f"
+        configChecksum: "982315b150c409ed212b6afc2fddaca1ec6fef098b02fadb34d0f443aecbf10"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6606,7 +6608,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "853ec47dc33f5ea966ca07248c68e5fffa132a5ec4bc62425bea48ad38b0a03"
+        configChecksum: "1b0d2775915a10a7067683ec6d149b24d87bd5fd2f39cc3f477d19ed6d4d714"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6977,7 +6979,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "b1aa562e3127e355cd7b84fea788998a2c8a52a031743e1dc5a564dbeb4715f"
+        configChecksum: "982315b150c409ed212b6afc2fddaca1ec6fef098b02fadb34d0f443aecbf10"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -158,6 +158,75 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
+# Source: dataplane/templates/common/eager-client-creds-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-eager-client-creds
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  client_id: dGVzdC1lYWdlci1jbGllbnQtaWQ=
+  client_secret: dGVzdC1ub3QtcmVhbC1lYWdlci1zZWNyZXQ=
+
+---
+# Source: dataplane/templates/common/image-builder-push-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-image-builder-push
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  token: dGVzdC1ub3QtcmVhbC1wdXNoLXRva2Vu
+
+---
+# Source: dataplane/templates/common/image-pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-image-builder-pull
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6e319
+
+---
+# Source: dataplane/templates/common/internal-ca-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-internal-ca
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+type: Opaque
+data:
+  ca.crt: dGVzdC1ub3QtcmVhbC1jYS1wZW0=
+
+---
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +786,29 @@ data:
   cluster_name: "test-e2e-gcp"
 
 ---
+# Source: dataplane/templates/common/eager-oauth-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-eager-oauth-config
+  namespace: union
+  labels:
+    app.kubernetes.io/managed-by: union-operator
+    app.kubernetes.io/instance: release-name
+    team: ml-platform
+  annotations:
+    example.com/owner: ml-platform
+data:
+  config.yaml: |
+    admin:
+      endpoint: "dns:///byok.us-west-2.union.ai:443"
+      clientId: "test-eager-client-id"
+      clientSecretLocation: "/etc/flyte/credentials/client_secret"
+      authType: ClientCredentials
+      insecureSkipVerify: true
+      caCertFilePath: "/etc/flyte/credentials/ca.crt"
+
+---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -952,10 +1044,43 @@ data:
           gpu: 256
           memory: 2Ti
       unionAuth:
-        injectSecret: true
+        injectSecret: false
         secretName: EAGER_API_KEY
       workerName: 'byok-test-e2e-gcp-worker1'
       
+      podInject:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        mounts:
+          - volume:
+              configMap:
+                name: release-name-eager-oauth-config
+              name: union-eager-auth-config
+            volumeMount:
+              mountPath: /etc/flyte/config.yaml
+              name: union-eager-auth-config
+              readOnly: true
+              subPath: config.yaml
+          - volume:
+              name: union-eager-client-secret
+              secret:
+                secretName: release-name-eager-client-creds
+            volumeMount:
+              mountPath: /etc/flyte/credentials/client_secret
+              name: union-eager-client-secret
+              readOnly: true
+              subPath: client_secret
+          - volume:
+              name: union-internal-ca
+              secret:
+                secretName: release-name-internal-ca
+            volumeMount:
+              mountPath: /etc/flyte/credentials/ca.crt
+              name: union-internal-ca
+              readOnly: true
+              subPath: ca.crt
+        imagePullSecrets:
+          - name: release-name-image-builder-pull
     union:
       connection:
         host: 'dns:///byok.us-west-2.union.ai:443'
@@ -1014,7 +1139,8 @@ data:
           name: flyte-copilot-
           start-timeout: 30s
         default-cpus: 100m
-        default-env-vars: []
+        default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         default-memory: 100Mi
         default-pod-template-name: task-template
         disable-inject-owner-references: true
@@ -3493,10 +3619,43 @@ data:
       maxActions: 2000
       organization: 'byok'
       unionAuth:
-        injectSecret: true
+        injectSecret: false
         secretName: EAGER_API_KEY
       workerName: worker1
       
+      podInject:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        mounts:
+          - volume:
+              configMap:
+                name: release-name-eager-oauth-config
+              name: union-eager-auth-config
+            volumeMount:
+              mountPath: /etc/flyte/config.yaml
+              name: union-eager-auth-config
+              readOnly: true
+              subPath: config.yaml
+          - volume:
+              name: union-eager-client-secret
+              secret:
+                secretName: release-name-eager-client-creds
+            volumeMount:
+              mountPath: /etc/flyte/credentials/client_secret
+              name: union-eager-client-secret
+              readOnly: true
+              subPath: client_secret
+          - volume:
+              name: union-internal-ca
+              secret:
+                secretName: release-name-internal-ca
+            volumeMount:
+              mountPath: /etc/flyte/credentials/ca.crt
+              name: union-internal-ca
+              readOnly: true
+              subPath: ca.crt
+        imagePullSecrets:
+          - name: release-name-image-builder-pull
       task_resources:
         defaults:
           cpu: 100m
@@ -3566,7 +3725,8 @@ data:
       k8s:
         disable-inject-owner-references: true
         default-cpus: 100m
-        default-env-vars: []
+        default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         default-memory: 100Mi
         default-pod-template-name: task-template
         co-pilot:
@@ -3605,7 +3765,8 @@ data:
     plugins:
       k8s:
         default-cpus: 100m
-        default-env-vars: []
+        default-env-vars:
+        - FLYTECTL_CONFIG: /etc/flyte/config.yaml
         default-memory: 100Mi
         default-pod-template-name: task-template
   config.yaml: |
@@ -3673,6 +3834,31 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      mirroring:
+        enabled: true
+        managedByLabelValue: "union-operator"
+        defaultNamespaceSelector:
+          matchLabels:
+            union.ai/namespace-type: flyte
+        provenanceAnnotations:
+          sourceNamespace: union.ai/mirrored-from-namespace
+          sourceName: union.ai/mirrored-from-name
+          sourceVersion: union.ai/mirrored-from-version
+        resources:
+        - kind: Secret
+          name: release-name-eager-client-creds
+        - kind: ConfigMap
+          name: release-name-eager-oauth-config
+        - kind: Secret
+          name: release-name-internal-ca
+        - kind: ConfigMap
+          name: build-image-config
+        - kind: Secret
+          name: release-name-image-builder-pull
+        - kind: Secret
+          name: release-name-image-builder-push
+        - kind: Secret
+          name: my-custom-mirrored-secret
     proxy:
       persistedLogs:
         objectStore:
@@ -6506,7 +6692,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "982315b150c409ed212b6afc2fddaca1ec6fef098b02fadb34d0f443aecbf10"
+        configChecksum: "4f3c49d2181b80fc05200b55d5f48cca57847c519845d200eb14c6dce5caa23"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6608,7 +6794,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1b0d2775915a10a7067683ec6d149b24d87bd5fd2f39cc3f477d19ed6d4d714"
+        configChecksum: "4d59d0cd00813ed986480485529495ea1c2f5452d257d7d2ec902d15b565c19"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6715,7 +6901,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9183963bb2ce976b0859e384acc0ca0869e4f569d47e90480665a56be41442a"
+        configChecksum: "68b3864edead1561ec46631bec99c1dae4cd1b53b251b34175d91ee15d8ec53"
         
       labels:
         
@@ -6853,7 +7039,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9183963bb2ce976b0859e384acc0ca0869e4f569d47e90480665a56be41442a"
+        configChecksum: "68b3864edead1561ec46631bec99c1dae4cd1b53b251b34175d91ee15d8ec53"
         
       labels:
         
@@ -6979,7 +7165,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "982315b150c409ed212b6afc2fddaca1ec6fef098b02fadb34d0f443aecbf10"
+        configChecksum: "4f3c49d2181b80fc05200b55d5f48cca57847c519845d200eb14c6dce5caa23"
         
     spec:
       securityContext:
@@ -7163,6 +7349,8 @@ metadata:
 template:
   spec:
     serviceAccountName: union
+    imagePullSecrets:
+      - name: release-name-image-builder-pull
     containers:
       - name: default
         image: docker.io/rwgrim/docker-noop

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dGVzdC1lMmUtZ2Nw
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "test-e2e-gcp"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6425,7 +6424,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6561,7 +6560,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6665,7 +6664,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6792,7 +6791,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6914,7 +6913,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7017,7 +7016,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
   client_secret: dGVzdC1ub3QtcmVhbC1zZWNyZXQ=
 

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -894,6 +894,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6503,7 +6504,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b8c386452255d0b4c657421f5b16a7cd03e88cb09c5613c37ed984344786447"
+        configChecksum: "b1aa562e3127e355cd7b84fea788998a2c8a52a031743e1dc5a564dbeb4715f"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6976,7 +6977,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "b8c386452255d0b4c657421f5b16a7cd03e88cb09c5613c37ed984344786447"
+        configChecksum: "b1aa562e3127e355cd7b84fea788998a2c8a52a031743e1dc5a564dbeb4715f"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: bXktc2VjcmV0
   client_secret: bXktc2VjcmV0
 

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -959,6 +959,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'union-my-cluster-worker1'
+      
     union:
       connection:
         host: 'dns:///union.us-west-2.union.ai:443'
@@ -3505,6 +3506,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6529,7 +6531,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "18ef6b4f25b6852c2eb040e07b8735f6f4f13700973bd007eccb1cf601d45fd"
+        configChecksum: "20e15d336348bc58fa557fb04050ab3bd27df81a741c1750b19182d7cf044ae"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6631,7 +6633,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "44257b4bad74284d978ebcf836cf48a61968f6450d3c0caeb83bc0c4b136fbe"
+        configChecksum: "475ceb3f8b5330e66fdae75045d87365994ab444d28738d2a0d68033a22af18"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7002,7 +7004,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "18ef6b4f25b6852c2eb040e07b8735f6f4f13700973bd007eccb1cf601d45fd"
+        configChecksum: "20e15d336348bc58fa557fb04050ab3bd27df81a741c1750b19182d7cf044ae"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -898,6 +898,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6528,7 +6529,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a80079a52c829d53e66ae96b112c5240c3263972592298bd1a7e76cf2be1b9a"
+        configChecksum: "18ef6b4f25b6852c2eb040e07b8735f6f4f13700973bd007eccb1cf601d45fd"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7001,7 +7002,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "a80079a52c829d53e66ae96b112c5240c3263972592298bd1a7e76cf2be1b9a"
+        configChecksum: "18ef6b4f25b6852c2eb040e07b8735f6f4f13700973bd007eccb1cf601d45fd"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: bXktc2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: bXktY2x1c3Rlcg==
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "my-cluster"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6450,7 +6449,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6586,7 +6585,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6690,7 +6689,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6817,7 +6816,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6939,7 +6938,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7042,7 +7041,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -256,16 +256,6 @@ data:
   ldap-toml: ""
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -1533,6 +1523,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -8565,7 +8564,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -8701,7 +8700,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -8805,7 +8804,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -8932,7 +8931,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -9054,7 +9053,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -9157,7 +9156,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -1713,6 +1713,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -8643,7 +8644,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ee00187332ecf53c71f841e031b2473575b41f18d2bb3c3442d30bdd05e081a"
+        configChecksum: "3658700f6da4ffaa88c0ce11f155062384cdb5b7df6c3b57ce1762dfd360b2d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9116,7 +9117,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ee00187332ecf53c71f841e031b2473575b41f18d2bb3c3442d30bdd05e081a"
+        configChecksum: "3658700f6da4ffaa88c0ce11f155062384cdb5b7df6c3b57ce1762dfd360b2d"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -1774,6 +1774,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///:443'
@@ -4317,6 +4318,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -8644,7 +8646,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3658700f6da4ffaa88c0ce11f155062384cdb5b7df6c3b57ce1762dfd360b2d"
+        configChecksum: "019e76181e66993c69953c2c0572a8cb9dfb58314c50a8efdf4686d8137cd52"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -8746,7 +8748,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d4b346179fdb01e7c67d236d76c9c95cfbd8514e65f49825dd8532283e5b4e3"
+        configChecksum: "3c22a6f5eeee534cc66bb3b67c221f6ea86a67977022a33b51eac3ac5cdd8a6"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9117,7 +9119,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "3658700f6da4ffaa88c0ce11f155062384cdb5b7df6c3b57ce1762dfd360b2d"
+        configChecksum: "019e76181e66993c69953c2c0572a8cb9dfb58314c50a8efdf4686d8137cd52"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -953,6 +953,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: '--worker1'
+      
     union:
       connection:
         host: 'dns:///:443'
@@ -3496,6 +3497,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6657,7 +6659,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
+        configChecksum: "08a790e95b17cc0f2be33628613f2632fd841c5391b50dff8dc903ed77036a8"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6759,7 +6761,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8655b854deda3dd76ce6a90e79a506077dbf2c133972104f938471dcf72f1e4"
+        configChecksum: "caf351acc66abf38f6f07d62f590203f676a33a3d7a9663223e6cc51659439e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7130,7 +7132,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
+        configChecksum: "08a790e95b17cc0f2be33628613f2632fd841c5391b50dff8dc903ed77036a8"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -153,16 +153,6 @@ metadata:
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: 
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -712,6 +702,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: ""
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6014,7 +6013,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6578,7 +6577,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6714,7 +6713,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6818,7 +6817,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6945,7 +6944,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -7067,7 +7066,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7170,7 +7169,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -892,6 +892,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6656,7 +6657,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7129,7 +7130,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8161dcaa52607eca82492e1fcb80dbd59e4d87eb38dce6b3d570fc7655168b6"
+        configChecksum: "1103164f99a80ac472bfe68d29f10027fd7b87396d672876341754bb0bdbf05"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -898,6 +898,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6549,7 +6550,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d801712faeb5cad40384bce7b75230459fb57b4f63898d3fb94fb918eb9a4b3"
+        configChecksum: "8a3b0d5d8fa1edc507a39d0355fadfb63142c8af62cc19568dc1d987cec03ca"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7074,7 +7075,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "d801712faeb5cad40384bce7b75230459fb57b4f63898d3fb94fb918eb9a4b3"
+        configChecksum: "8a3b0d5d8fa1edc507a39d0355fadfb63142c8af62cc19568dc1d987cec03ca"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -154,7 +154,6 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: Y2xpZW50U2VjcmV0
   client_secret: Y2xpZW50U2VjcmV0
 

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -158,16 +158,6 @@ data:
   client_secret: Y2xpZW50U2VjcmV0
 
 ---
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tb2Np
-
----
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: v1
 kind: Secret
@@ -717,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-oci"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6465,7 +6464,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6607,7 +6606,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6724,7 +6723,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6864,7 +6863,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6999,7 +6998,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7115,7 +7114,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -959,6 +959,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'union-union-oci-worker1'
+      
     union:
       connection:
         host: 'dns:///union.us-west-2.union.ai:443'
@@ -3510,6 +3511,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6550,7 +6552,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8a3b0d5d8fa1edc507a39d0355fadfb63142c8af62cc19568dc1d987cec03ca"
+        configChecksum: "4adef2dc1e9636ebd27673b97d4a33ee087b1fac711c34e42ab6ec59c32e86a"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6665,7 +6667,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8856874b107ad8c8b6fa15d5c72fcdcd58f44b87329f0a72bde52d7e3a53352"
+        configChecksum: "b5a3a685b6c4fe8f75f9afea73e092d749b7bd86d2da474af1020686894023b"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7075,7 +7077,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "8a3b0d5d8fa1edc507a39d0355fadfb63142c8af62cc19568dc1d987cec03ca"
+        configChecksum: "4adef2dc1e9636ebd27673b97d4a33ee087b1fac711c34e42ab6ec59c32e86a"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -154,19 +154,8 @@ metadata:
   namespace: union
 type: Opaque
 data:
-  # TODO(rob): update or configure operator to use client_secret like all the other components.
   app_secret: Y2xpZW50U2VjcmV0
   client_secret: Y2xpZW50U2VjcmV0
-
----
-# Source: dataplane/templates/common/cluster-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: operator-cluster-name
-type: Opaque
-data:
-  cluster_name: dW5pb24tb2Np
 
 ---
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -718,6 +707,15 @@ data:
     {}
   rules: |
     {}
+---
+# Source: dataplane/templates/common/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-cluster-name
+data:
+  cluster_name: "union-oci"
+
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -6435,7 +6433,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6571,7 +6569,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6675,7 +6673,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -6802,7 +6800,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME
@@ -6924,7 +6922,7 @@ spec:
                   resource: limits.cpu
             - name: CLUSTER_NAME
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: operator-cluster-name
                   key: cluster_name
             - name: DEPLOYMENT_NAME
@@ -7027,7 +7025,7 @@ spec:
                 resource: limits.cpu
           - name: CLUSTER_NAME
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: operator-cluster-name
                 key: cluster_name
           - name: DEPLOYMENT_NAME

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -896,6 +896,7 @@ data:
   webhook.yaml: |
 
     
+    
     propeller:
       limit-namespace: union
     webhook:
@@ -6512,7 +6513,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "391b029baf52660e261385ff4dd41738443ff7bf076252aeb82b6931dafb0b0"
+        configChecksum: "a23b580bc8c58781371583dbd9bb13a3b9360acc13f826ef9050b1ff626b84b"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6985,7 +6986,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "391b029baf52660e261385ff4dd41738443ff7bf076252aeb82b6931dafb0b0"
+        configChecksum: "a23b580bc8c58781371583dbd9bb13a3b9360acc13f826ef9050b1ff626b84b"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -957,6 +957,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: 'union-union-oci-worker1'
+      
     union:
       connection:
         host: 'dns:///union.us-west-2.union.ai:443'
@@ -3499,6 +3500,7 @@ data:
         injectSecret: true
         secretName: EAGER_API_KEY
       workerName: worker1
+      
       task_resources:
         defaults:
           cpu: 100m
@@ -6513,7 +6515,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a23b580bc8c58781371583dbd9bb13a3b9360acc13f826ef9050b1ff626b84b"
+        configChecksum: "5a665fcfcff7ead1f450792c1a2cf577f9a63fb2caaaffa31253f52fca8c1e5"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6615,7 +6617,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "dae00ee77d0ead50f5c113ed94f4fa115f110b82a0280c6ed4ccffa8548ee20"
+        configChecksum: "bf9e1b6190541e66f7a7c79782b12b96e365fc1b1299d2a5e37076aafd79ecb"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6986,7 +6988,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "a23b580bc8c58781371583dbd9bb13a3b9360acc13f826ef9050b1ff626b84b"
+        configChecksum: "5a665fcfcff7ead1f450792c1a2cf577f9a63fb2caaaffa31253f52fca8c1e5"
         
     spec:
       securityContext:

--- a/tests/values/dataplane.aws.yaml
+++ b/tests/values/dataplane.aws.yaml
@@ -70,6 +70,39 @@ secrets:
     # Set to false if you manage secrets externally (e.g., via External Secrets Operator)
     create: true
 
+  # Chart-managed secret propagation: extra metadata + eager OAuth creds +
+  # internal-CA bundle + image-builder pull/push + the deprecated eager API key.
+  commonLabels:
+    team: ml-platform
+  commonAnnotations:
+    example.com/owner: ml-platform
+  eagerClientCreds:
+    enabled: true
+    clientId: test-eager-client-id
+    clientSecret: test-not-real-eager-secret
+    insecureSkipVerify: true
+  internalCaCert:
+    enabled: true
+    value: test-not-real-ca-pem
+  eagerApiKey:
+    enabled: true
+    value: test-not-real-eager-api-key
+  imageBuilder:
+    pull:
+      enabled: true
+      dockerconfigjson: '{"auths":{}}'
+    push:
+      enabled: true
+      values:
+        token: test-not-real-push-token
+
+# Operator-side mirror: chart-managed presets plus an extra resource.
+mirroring:
+  enabled: true
+  extraResources:
+    - kind: Secret
+      name: my-custom-mirrored-secret
+
 # ----------------------------------------------------------------------------
 # SECTION 6: Logging Configuration (REQUIRED)
 # ----------------------------------------------------------------------------

--- a/tests/values/dataplane.azure.yaml
+++ b/tests/values/dataplane.azure.yaml
@@ -80,6 +80,36 @@ secrets:
     # Set to false if you manage secrets externally (e.g., via External Secrets Operator)
     create: true
 
+  # Chart-managed secret propagation: extra metadata + eager OAuth creds +
+  # internal-CA bundle + image-builder pull/push.
+  commonLabels:
+    team: ml-platform
+  commonAnnotations:
+    example.com/owner: ml-platform
+  eagerClientCreds:
+    enabled: true
+    clientId: test-eager-client-id
+    clientSecret: test-not-real-eager-secret
+    insecureSkipVerify: true
+  internalCaCert:
+    enabled: true
+    value: test-not-real-ca-pem
+  imageBuilder:
+    pull:
+      enabled: true
+      dockerconfigjson: '{"auths":{}}'
+    push:
+      enabled: true
+      values:
+        token: test-not-real-push-token
+
+# Operator-side mirror: chart-managed presets plus an extra resource.
+mirroring:
+  enabled: true
+  extraResources:
+    - kind: Secret
+      name: my-custom-mirrored-secret
+
 # ----------------------------------------------------------------------------
 # SECTION 6: Logging Configuration (REQUIRED)
 # ----------------------------------------------------------------------------

--- a/tests/values/dataplane.gcp.yaml
+++ b/tests/values/dataplane.gcp.yaml
@@ -16,6 +16,34 @@ secrets:
     create: true
     clientId: byok-test-e2e-gcp-operator
     clientSecret: test-not-real-secret
+  # Chart-managed secret propagation: extra metadata + eager OAuth creds +
+  # internal-CA bundle + image-builder pull/push.
+  commonLabels:
+    team: ml-platform
+  commonAnnotations:
+    example.com/owner: ml-platform
+  eagerClientCreds:
+    enabled: true
+    clientId: test-eager-client-id
+    clientSecret: test-not-real-eager-secret
+    insecureSkipVerify: true
+  internalCaCert:
+    enabled: true
+    value: test-not-real-ca-pem
+  imageBuilder:
+    pull:
+      enabled: true
+      dockerconfigjson: '{"auths":{}}'
+    push:
+      enabled: true
+      values:
+        token: test-not-real-push-token
+# Operator-side mirror: chart-managed presets plus an extra resource.
+mirroring:
+  enabled: true
+  extraResources:
+    - kind: Secret
+      name: my-custom-mirrored-secret
 additionalServiceAccountAnnotations:
   iam.gke.io/gcp-service-account: 'union-backend@test-gcp-project-123.iam.gserviceaccount.com'
 userRoleAnnotationKey: iam.gke.io/gcp-service-account


### PR DESCRIPTION
## Summary

- Renames the controller-side mutator helper `dataplane.fileMountConfig` → `dataplane.podInjectConfig` and the YAML key `fileMount:` → `podInject:` on both leaseworker and executor configs to reflect the broader scope (file mounts AND `imagePullSecrets`).
- Extends `podInjectConfig` to emit an `imagePullSecrets:` list when `secrets.imageBuilder.pull` is enabled. Same name (`image-builder-pull`) the operator's `ManifestMirrorSyncer` already mirrors.
- Extends the operator's `mirroring.resources` to also cover `image-builder-pull` + `image-builder-push` so kubelet finds them in every flyte-typed task NS.
- Auto-flips webhook `embeddedSecretManagerConfig.imagePullSecrets.enabled=false` when chart-side pull is on, so the controller-side and webhook-side image-pull paths don't fight.
- Adds `imageBuilder.bootstrap.pushSecretName` on the controlplane chart. When set, the bootstrap Job exports `IMAGE_BUILDER_PUSH_SECRET_NAME` and `build_image_task.py` conditionally mounts the named Secret at `/etc/flyte/secrets/dockerconfigjson` — same dir the legacy Flyte `Secret(group=, key=)` system writes to. Companion change in the build-image consumer (`cloud-task`) hardens `getDockerCredentials` to merge across every parseable file there.

Companion PR on `unionai/cloud` carries the Go side: `shared_service/filemount/` → `shared_service/podinject/` rename, `ImagePullSecrets` field on `Config`, terraform wiring.

## Test plan

- `make test` green; snapshots regenerated via `make generate-expected` for the controlplane fixtures that pick up the build_image_task.py changes
- Deployed end-to-end on a staging selfmanaged environment via the standard ArgoCD path
- Pull validated end-to-end: direct pod test pulled a private GHCR image (`ghcr.io/mhotan/private-repo-sandbox:alpine-3.20`) using the mirrored chart-managed Secret as `imagePullSecrets` — kubelet auth + pull succeeded in ~2s
- Push substrate verified: chart-rendered build_image_task.py carries the conditional Volume + VolumeMount; bootstrap Job env passthrough renders; operator mirror replicates the push Secret into task NSes with type `kubernetes.io/dockerconfigjson` + `.dockerconfigjson` key