### PR TITLE
Fix protected-ingress auth cache key colliding for Authorization-header clients

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -377,19 +377,19 @@ ingress:
     nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login?redirect_url=$escaped_request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
-    nginx.ingress.kubernetes.io/auth-cache-key: "$http_flyte_authorization$http_cookie"
+    nginx.ingress.kubernetes.io/auth-cache-key: "$http_authorization$http_flyte_authorization$http_cookie"
     nginx.org/websocket-services: dataproxy-service
   enableProtectedConsoleIngress: false
   protectedIngressAnnotationsWithoutSignin:
     nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
-    nginx.ingress.kubernetes.io/auth-cache-key: "$http_flyte_authorization$http_cookie"
+    nginx.ingress.kubernetes.io/auth-cache-key: "$http_authorization$http_flyte_authorization$http_cookie"
     nginx.org/websocket-services: dataproxy-service
   protectedConsoleIngressAnnotations:
     nginx.ingress.kubernetes.io/auth-url: "https://$host/me"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login?redirect_url=$escaped_request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token"
-    nginx.ingress.kubernetes.io/auth-cache-key: "$http_flyte_authorization$http_cookie"
+    nginx.ingress.kubernetes.io/auth-cache-key: "$http_authorization$http_flyte_authorization$http_cookie"
     nginx.org/websocket-services: dataproxy-service
   protectedIngressAnnotationsGrpc:
     nginx.ingress.kubernetes.io/auth-url: "http://flyteadmin.{{ template \"flyte.namespace\" . }}.svc.cluster.local/me"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -13501,7 +13501,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13643,7 +13643,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13705,7 +13705,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -15665,7 +15665,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -13542,7 +13542,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13739,7 +13739,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13818,7 +13818,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -19140,7 +19140,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -13519,7 +13519,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13654,7 +13654,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13709,7 +13709,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -15669,7 +15669,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -13506,7 +13506,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13641,7 +13641,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13696,7 +13696,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -15656,7 +15656,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -13810,7 +13810,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -13945,7 +13945,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -14000,7 +14000,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me
@@ -15960,7 +15960,7 @@ metadata:
       client_header_buffer_size 16k;
       large_client_header_buffers 64 32k;
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-cache-key: $http_flyte_authorization$http_cookie
+    nginx.ingress.kubernetes.io/auth-cache-key: $http_authorization$http_flyte_authorization$http_cookie
     nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-User-Subject,X-User-Claim-Identitytype,X-User-Claim-Preferred-Username,X-User-Token
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?redirect_url=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/me


### PR DESCRIPTION
## Overview

The REST and console protected-ingress annotations key their nginx auth-request
cache on `$http_flyte_authorization$http_cookie`. A client that authenticates
with the standard `Authorization` header and no cookie produces an **empty,
shared** cache key, so every such request collapses into one auth-cache entry.

A `/me` auth subrequest that returns 401 (an unauthenticated probe, an expired
session) then gets cached and served back to valid requests as a `302 → /login`
for the cache TTL — intermittent auth failures uncorrelated with the caller's
token. The inverse is a cached `200` under the empty key letting a token-less
request through with another caller's identity headers.

This prefixes the three REST/console cache keys with `$http_authorization` so
each bearer credential gets its own cache entry, matching
`protectedIngressAnnotationsGrpc`, which already includes it.

## Test

`make generate-expected && make test` — green. Only `auth-cache-key` lines
change in the controlplane snapshots.

## Rollout

Values-only default change; picked up on the next chart render / ArgoCD sync.
No template or resource-shape changes.

## Rollback

Revert the commit; the cache key returns to its prior value.
