### PR TITLE
feat(dataplane/serving): enable knative containerspec-addcapabilities

### DIFF
--- a/charts/dataplane/templates/serving/knative-serving.yaml
+++ b/charts/dataplane/templates/serving/knative-serving.yaml
@@ -30,6 +30,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
       {{- if .Values.serving.extraConfig.features }}
       {{- tpl (.Values.serving.extraConfig.features | toYaml) . | nindent 6 }}
       {{- end }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -2555,6 +2555,10 @@ gateway:
       kubernetes.podspec-runtimeclassname: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN from PodTemplate.allow_fuse(), used to mount a FUSE
+      # filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
       kubernetes.podspec-shareprocessnamespace: "enabled"
       kubernetes.podspec-tolerations: "enabled"
       kubernetes.podspec-topologyspreadconstraints: "enabled"

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -7265,6 +7265,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -7287,6 +7287,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -7882,6 +7882,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -7376,6 +7376,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -7752,6 +7752,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -1797,6 +1797,7 @@ metadata:
   annotations:
     knative.dev/example-checksum: "9ff569ad"
 data:
+  kubernetes.containerspec-addcapabilities: "enabled"
   kubernetes.podspec-affinity: "enabled"
   kubernetes.podspec-dnsconfig: "enabled"
   kubernetes.podspec-dnspolicy: "enabled"

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -1797,6 +1797,7 @@ metadata:
   annotations:
     knative.dev/example-checksum: "9ff569ad"
 data:
+  kubernetes.containerspec-addcapabilities: "enabled"
   kubernetes.podspec-affinity: "enabled"
   kubernetes.podspec-dnsconfig: "enabled"
   kubernetes.podspec-dnspolicy: "enabled"

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -7327,6 +7327,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -7327,6 +7327,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -7444,6 +7444,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -7272,6 +7272,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -7635,6 +7635,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -7345,6 +7345,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -7270,6 +7270,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -7295,6 +7295,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -13888,6 +13888,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -7422,6 +7422,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -7381,6 +7381,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -7279,6 +7279,10 @@ spec:
       kubernetes.podspec-dnspolicy: "enabled"
       kubernetes.podspec-schedulername: "enabled"
       kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
     network:
       ingress-class: "kourier.ingress.networking.knative.dev"
   high-availability:


### PR DESCRIPTION
## What
Enables the Knative Serving `kubernetes.containerspec-addcapabilities` feature flag in the dataplane chart, in **both** serving configuration paths:
- the **KnativeServing operator CR** (non-zero-trust) — `charts/dataplane/templates/serving/knative-serving.yaml`
- the directly-created **`config-features` ConfigMap** (zero-trust) — via `gateway.config.features` in `charts/dataplane/values.yaml`

## Why
Knative Serving gates per-container `securityContext.capabilities.add` behind this feature flag. With it disabled (the default), the serving webhook **rejects** any Knative Service whose container adds a capability:

```
admission webhook denied the request: ... must not set the field(s): spec.template.spec.containers[0].securityContext.capabilities.add
```

That is exactly what `flyte.PodTemplate.allow_fuse()` does — it adds `CAP_SYS_ADMIN` (plus the `smarter-devices/fuse` device request) so an app or task can mount a FUSE filesystem such as a `flyteplugins-union` **Volume**. Without this flag, app serving of Volumes fails at admission. This was confirmed on canary, where the flag had to be flipped by hand to get a Volume-mounting app to deploy.

`podspec-securitycontext` is already enabled; this is the container-level companion.

## Test
Snapshot fixtures regenerated and verified with **helm v4.2.0** (the version pinned in CI via `azure/setup-helm`), so `make helm-test` is green. The diff is additive only — the new flag line (plus a short rationale comment in the operator CR), no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)