### PR TITLE
Enable custom storage provider to include credentials from secret

### DIFF
--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -55,9 +55,26 @@ the stow based options to provide additional configuration flexibility.
         project_id: {{ required "GCP project required for GCS storage provider" .Values.storage.gcp.projectId }}
         scopes: https://www.googleapis.com/auth/cloud-platform
 {{- else if eq .Values.storage.provider "custom" }}
-{{- with .Values.storage.custom -}}
-  {{ tpl (toYaml .) $ | nindent 2 }}
-{{- end }}
+  {{- $custom := deepCopy (default dict .Values.storage.custom) -}}
+  {{- $customType := default "" $custom.type -}}
+  {{- $stow := default dict $custom.stow -}}
+  {{- $stowKind := default "" $stow.kind -}}
+  {{- $stowConfig := default dict $stow.config -}}
+
+  {{- if and .Values.storage.credentialsSecretRef.name (eq $customType "stow") (eq $stowKind "s3") -}}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.storage.credentialsSecretRef.name -}}
+    {{- if $secret -}}
+      {{- $secretCreds := dict
+        "access_key_id" (index $secret.data (.Values.storage.credentialsSecretRef.accessKeyIdKey | default "access_key_id") | b64dec)
+        "secret_key" (index $secret.data (.Values.storage.credentialsSecretRef.secretKeyKey | default "secret_key") | b64dec)
+      -}}
+      {{- $mergedStowConfig := mergeOverwrite (deepCopy $stowConfig) $secretCreds -}}
+      {{- $_ := set $stow "config" $mergedStowConfig -}}
+      {{- $_ := set $custom "stow" $stow -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- tpl (toYaml $custom) $ | nindent 2 }}
 {{- else }}
 {{- fail "invalid provider" }}
 {{- end }}


### PR DESCRIPTION
Tested with values:

```
storage:
  provider: custom
  bucketName: union
  fastRegistrationBucketName: union
  custom:
    type: stow
    container: union
    stow:
      kind: s3
      config:
        region: xyz
        auth_type: accesskey
        endpoint: xyz
        disable_ssl: false
        disable_force_path_style: "true"
  credentialsSecretRef:
    name: "storage-credentials"
```

Also tested without secrets and just regular `access_key_id` and `secret_key` and it also works fine