### PR TITLE
fix(dataplane): avoid emitting bare `{}` for empty custom storage config

### DIFF
--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -74,7 +74,9 @@ the stow based options to provide additional configuration flexibility.
     {{- end -}}
   {{- end -}}
 
+  {{- if $custom }}
   {{- tpl (toYaml $custom) $ | nindent 2 }}
+  {{- end }}
 {{- else }}
 {{- fail "invalid provider" }}
 {{- end }}


### PR DESCRIPTION
## Problem

`#449` enabled the `custom` storage provider to pull credentials from a Secret. In doing so it replaced the original guard:

```gotemplate
{{- with .Values.storage.custom -}}
  {{ tpl (toYaml .) $ | nindent 2 }}
{{- end }}
```

with an **unconditional** render:

```gotemplate
{{- tpl (toYaml $custom) $ | nindent 2 }}
```

The old `with` block emitted nothing when `storage.custom` was empty. The new code always serializes `$custom` — so when `storage.provider=custom` is set with the default/empty `storage.custom: {}`, it renders a literal `{}` line into the embedded config:

```yaml
storage:
  container: "union"
  {}                       # <-- invalid YAML
  enable-multicontainer: false
```

This appears in both `storage.yaml` and `fast_registration_storage.yaml` inside the operator/propeller ConfigMaps. A bare `{}` interleaved with block-mapping keys is **not valid YAML** (`could not find expected ':'`), so the component fails to parse its storage config at runtime. On `main` prior to #449 this case rendered nothing (valid).

## Fix

Restore the non-empty guard around the final render, keeping the new secret-injection logic untouched:

```gotemplate
{{- if $custom }}
{{- tpl (toYaml $custom) $ | nindent 2 }}
{{- end }}
```

## Verification

Rendered `templates/operator/configmap.yaml` (helm v4.2.0, matching CI):

- **Empty custom** (`provider: custom`, no `custom` block) → no `{}` line; valid YAML. ✅
- **Non-empty custom** (`stow`/`s3` + `credentialsSecretRef`) → still renders fully, secret-injection path intact. ✅
- **Existing `dataplane.azure-custom-storage-prefix` case** → byte-identical to pre-fix output; no snapshot churn. ✅

No existing snapshot exercises the empty-custom path, so no generated test files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)