### PR TITLE
feat: secret-by-reference apiKeyOverrides for identity + operator eager-key bootstrap toggle

### DIFF
--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -422,6 +422,24 @@ IfNotPresent
   {{- $_ := set $merged "executions" $executions }}
 {{- end }}
 
+{{- /* apiKeyOverrides: render identity.app.apiKeyOverrides file locations from the
+       seeded-secret references on services.identity. The Secrets are mounted by
+       deployment.yaml; locations derive from controlplane.apiKeyOverride.mountDir
+       so they match the volumeMount paths exactly. Reference-only — only paths,
+       never secret material, reach the rendered config. */}}
+{{- if and (eq .key "identity") .config.apiKeyOverrides }}
+  {{- $identity := index $merged "identity" | default dict }}
+  {{- $app := index $identity "app" | default dict }}
+  {{- $overrides := dict }}
+  {{- range $keyName, $entry := .config.apiKeyOverrides }}
+    {{- $dir := include "controlplane.apiKeyOverride.mountDir" $keyName }}
+    {{- $_ := set $overrides $keyName (dict "clientIdLocation" (printf "%s/client_id" $dir) "clientSecretLocation" (printf "%s/client_secret" $dir)) }}
+  {{- end }}
+  {{- $_ := set $app "apiKeyOverrides" $overrides }}
+  {{- $_ := set $identity "app" $app }}
+  {{- $_ := set $merged "identity" $identity }}
+{{- end }}
+
 {{- if hasKey .Values "logging" }}
   {{- $_ := set $merged "logger" (omit .Values.logging "pythonLevel") }}
 {{- end }}
@@ -429,6 +447,41 @@ IfNotPresent
 {{- $rendered := tpl ($merged | toYaml) . }}
 {{- $rendered }}
 {{- end }}
+
+{{/*
+apiKeyOverrides helpers — secret-by-reference overrides for system API keys
+consumed by the identity service's ApiKeyService.CreateKey. Each entry references
+a pre-created K8s Secret holding the OAuth client_id + client_secret; the chart
+mounts it and renders identity.app.apiKeyOverrides with the resulting file paths.
+Mount dir and config locations both derive from controlplane.apiKeyOverride.mountDir
+so they cannot drift.
+*/}}
+{{- define "controlplane.apiKeyOverride.mountDir" -}}
+/etc/secrets/apikey/{{ . }}
+{{- end -}}
+
+{{- define "controlplane.apiKeyOverride.volumeName" -}}
+apikey-{{ . | lower | replace "_" "-" }}
+{{- end -}}
+
+{{- define "controlplane.apiKeyOverride.clientIdKey" -}}
+{{- default "client_id" .existingSecret.clientIdKey -}}
+{{- end -}}
+
+{{- define "controlplane.apiKeyOverride.clientSecretKey" -}}
+{{- default "client_secret" .existingSecret.clientSecretKey -}}
+{{- end -}}
+
+{{/* Fail fast if any apiKeyOverrides entry omits existingSecret.name (reference is mandatory). */}}
+{{- define "controlplane.apiKeyOverrides.validate" -}}
+{{- range $svcKey, $svc := .Values.services -}}
+{{- range $keyName, $entry := ($svc.apiKeyOverrides | default dict) -}}
+{{- if not (($entry.existingSecret).name) -}}
+{{- fail (printf "services.%s.apiKeyOverrides.%s: existingSecret.name is required (reference-only, no inline secret)" $svcKey $keyName) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Renders a complete tree, even values that contains template.

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -430,10 +430,13 @@ IfNotPresent
 {{- if and (eq .key "identity") .config.apiKeyOverrides }}
   {{- $identity := index $merged "identity" | default dict }}
   {{- $app := index $identity "app" | default dict }}
-  {{- $overrides := dict }}
+  {{- /* Render as a LIST with the key as a value field (`key`), not a map keyed
+         by name: config loading (viper) lowercases map keys, which would mangle
+         the case-sensitive system key name. As a value the case is preserved. */}}
+  {{- $overrides := list }}
   {{- range $keyName, $entry := .config.apiKeyOverrides }}
     {{- $dir := include "controlplane.apiKeyOverride.mountDir" $keyName }}
-    {{- $_ := set $overrides $keyName (dict "clientIdLocation" (printf "%s/client_id" $dir) "clientSecretLocation" (printf "%s/client_secret" $dir)) }}
+    {{- $overrides = append $overrides (dict "key" $keyName "clientIdLocation" (printf "%s/client_id" $dir) "clientSecretLocation" (printf "%s/client_secret" $dir)) }}
   {{- end }}
   {{- $_ := set $app "apiKeyOverrides" $overrides }}
   {{- $_ := set $identity "app" $app }}

--- a/charts/controlplane/templates/configmap.yaml
+++ b/charts/controlplane/templates/configmap.yaml
@@ -1,6 +1,9 @@
 {{/* Validate database name configuration */}}
 {{- include "controlplane.validateDatabaseNames" . }}
 
+{{/* Validate apiKeyOverrides references (reference-only; existingSecret.name required) */}}
+{{- include "controlplane.apiKeyOverrides.validate" . }}
+
 {{- if (index .Values "controlplane" | default dict).enabled }}
 {{- range $serviceKey, $serviceConfig := .Values.services }}
 ---

--- a/charts/controlplane/templates/deployment.yaml
+++ b/charts/controlplane/templates/deployment.yaml
@@ -64,6 +64,16 @@ spec:
       - name: config
         configMap:
           name: {{ include "unionai.fullname" $service }}
+      {{- range $keyName, $entry := ($service.config.apiKeyOverrides | default dict) }}
+      - name: {{ include "controlplane.apiKeyOverride.volumeName" $keyName }}
+        secret:
+          secretName: {{ $entry.existingSecret.name }}
+          items:
+          - key: {{ include "controlplane.apiKeyOverride.clientIdKey" $entry }}
+            path: client_id
+          - key: {{ include "controlplane.apiKeyOverride.clientSecretKey" $entry }}
+            path: client_secret
+      {{- end }}
       {{- with $service.config.initContainers }}
       initContainers:
         {{- range . }}
@@ -127,6 +137,11 @@ spec:
               mountPath: /etc/secrets/union
             - name: config
               mountPath: /etc/config/
+            {{- range $keyName, $entry := ($service.config.apiKeyOverrides | default dict) }}
+            - name: {{ include "controlplane.apiKeyOverride.volumeName" $keyName }}
+              mountPath: {{ include "controlplane.apiKeyOverride.mountDir" $keyName }}
+              readOnly: true
+            {{- end }}
           {{- $env := include "unionai.env" $service }}
           {{- if $env }}
           env:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1034,6 +1034,20 @@ services:
             ttl: 10m
   identity:
     fullnameOverride: "identity"
+    # apiKeyOverrides: secret-by-reference overrides for system API keys that the
+    # identity ApiKeyService.CreateKey would otherwise mint by registering an OAuth
+    # client on the IdP. Use when the control plane cannot register clients on an
+    # operator-controlled IdP (selfhosted Okta/Entra): an out-of-band process seeds
+    # the pre-created OAuth client credentials as a K8s Secret, and CreateKey reads
+    # them instead of contacting the IdP. The map key MUST be a recognized system
+    # key name (e.g. EAGER_API_KEY). Reference-only: never put a client secret
+    # inline here — this values file is rendered into a git-committed overlay.
+    apiKeyOverrides: {}
+    #   EAGER_API_KEY:
+    #     existingSecret:
+    #       name: eager-client-creds       # pre-created Secret (required)
+    #       clientIdKey: client_id         # optional; data key, defaults to client_id
+    #       clientSecretKey: client_secret # optional; data key, defaults to client_secret
     service:
       type: ClusterIP
       grpcport: 80

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -119,6 +119,10 @@ data:
         referenceConfigmapName: {{ include "union-operator.fullname" . }}
         targetConfigMapName: {{ .Values.imageBuilder.targetConfigMapName | quote }}
     {{- end }}
+      {{- if .Values.config.operator.apiKey.enabled }}
+      apiKey:
+        {{- tpl (toYaml .Values.config.operator.apiKey) $ | nindent 8 }}
+      {{- end }}
   {{- with .Values.config.proxy }}
     proxy:
       {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -467,6 +467,13 @@ config:
     limitNamespace: ""
     # -- Disable cluster-wide permissions. Auto-set when low_privilege is true.
     disableClusterPermissions: false
+    # -- Eager API key bootstrap loop. When enabled, the operator mints the eager
+    # API key on the control plane and writes it through the operator-proxy
+    # SecretProxyService. Requires the secret manager (proxy.secretManager.enabled);
+    # leave disabled otherwise. dataproxyServiceUrl/stateSecretName fall back to
+    # operator code defaults when unset.
+    apiKey:
+      enabled: false
     # -- Compute resource manager configuration.
     computeResourceManager: {}
     # -- Organization namespace template override.

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2376,6 +2376,10 @@ data:
             scopes:
             - 'all'
             tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        apiKeyOverrides:
+          EAGER_API_KEY:
+            clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY/client_id
+            clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY/client_secret
         identityProviderConfig:
           provider: noop
     logger:
@@ -12474,6 +12478,14 @@ spec:
       - name: config
         configMap:
           name: identity
+      - name: apikey-eager-api-key
+        secret:
+          secretName: eager-client-creds
+          items:
+          - key: client_id
+            path: client_id
+          - key: oauth_client_secret
+            path: client_secret
       containers:
         - name: identity
           image: registry.unionai.cloud/controlplane/services:2026.6.7
@@ -12503,6 +12515,9 @@ spec:
               mountPath: /etc/secrets/union
             - name: config
               mountPath: /etc/config/
+            - name: apikey-eager-api-key
+              mountPath: /etc/secrets/apikey/EAGER_API_KEY
+              readOnly: true
           env:
             - name: GOMEMLIMIT
               valueFrom:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2377,9 +2377,9 @@ data:
             - 'all'
             tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
         apiKeyOverrides:
-          EAGER_API_KEY:
-            clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY/client_id
-            clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY/client_secret
+        - clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY/client_id
+          clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY/client_secret
+          key: EAGER_API_KEY
         identityProviderConfig:
           provider: noop
     logger:

--- a/tests/values/controlplane.custom-oidc.yaml
+++ b/tests/values/controlplane.custom-oidc.yaml
@@ -56,3 +56,14 @@ flyte:
           identityTypeClaimsForApps:
             idtyp:
             - app
+
+# Eager-key secret-by-reference override on the identity service: CreateKey reads
+# seeded OAuth client creds from a mounted Secret instead of registering an IdP app.
+# Exercises a custom client-secret data key to cover the key-name default-override path.
+services:
+  identity:
+    apiKeyOverrides:
+      EAGER_API_KEY:
+        existingSecret:
+          name: eager-client-creds
+          clientSecretKey: oauth_client_secret


### PR DESCRIPTION
## Overview

Adds a secret-by-reference override for system API keys on the identity service, plus an operator-side toggle so the operator can self-bootstrap the eager API key. This unblocks selfhosted deployments where the control plane cannot register an OAuth client on an operator-controlled IdP.

- **controlplane**: `services.identity.apiKeyOverrides` — keyed by system API key name (e.g. `EAGER_API_KEY`), referencing a pre-created Secret holding the OAuth `client_id` + `client_secret`. The chart mounts it into the identity pod and renders `identity.app.apiKeyOverrides` so the service serves the key from the seeded credentials instead of registering an OAuth client on the IdP. Reference-only (no inline secret — control-plane values render into committed overlays). Rendered as a **list** with the key as a value field, so config loading preserves the case-sensitive key name. Default empty = no-op; missing `existingSecret.name` fails validation.
- **dataplane**: `config.operator.apiKey` toggle (default off, gated) so the operator's eager API key bootstrap loop can be enabled per environment. Requires the operator-proxy secret manager.

## Test Plan

- `helm lint` + `helm template` both charts: the rendered identity Deployment carries the mounted volume + `app.apiKeyOverrides` list; negative validation (missing `existingSecret.name`) fails; default (empty) renders nothing.
- Snapshot tests regenerated (`make generate-expected`); `kubeconform` clean.
- Validated end-to-end on an internal selfmanaged AWS environment.

## Rollout Plan

Chart defaults are off / empty (no-op). Environments opt in via values.

## Rollback Plan

Revert the PR; the new values default to disabled, so removal is safe.

## Checklist

- [x] Added/updated snapshot tests
- [x] helm lint / kubeconform pass

* `main` <!-- branch-stack -->
  - **feat: secret-by-reference apiKeyOverrides for identity + operator eager-key bootstrap toggle** :point\_left:
    - \#453
