### PR TITLE
fix(controlplane): set dataproxy union.connection.host for CP authorizer clientset

### DIFF
--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -443,6 +443,24 @@ IfNotPresent
   {{- $_ := set $merged "identity" $identity }}
 {{- end }}
 
+{{- /* The dataproxy builds an api/v1 clientset for the control-plane authorizer
+       (service-credential-authenticated DP->CP authorizer requests); that
+       clientset's auth-metadata/admin connection dials union.connection.host.
+       The shared union.connection block carries only TLS flags, so derive the
+       host from the internal CP endpoint (connection.rootTenantURLPattern) — the
+       single source of truth — rather than duplicating it in values. Without it
+       the dataproxy gets an empty gRPC target and crashloops. */}}
+{{- if eq .key "dataproxy" }}
+  {{- $rootPattern := index (index $merged "connection" | default dict) "rootTenantURLPattern" }}
+  {{- if $rootPattern }}
+    {{- $union := index $merged "union" | default dict }}
+    {{- $unionConn := index $union "connection" | default dict }}
+    {{- $_ := set $unionConn "host" $rootPattern }}
+    {{- $_ := set $union "connection" $unionConn }}
+    {{- $_ := set $merged "union" $union }}
+  {{- end }}
+{{- end }}
+
 {{- if hasKey .Values "logging" }}
   {{- $_ := set $merged "logger" (omit .Values.logging "pythonLevel") }}
 {{- end }}

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -2205,6 +2205,7 @@ data:
         tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -2187,6 +2187,7 @@ data:
         tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -2207,6 +2207,7 @@ data:
         tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2202,6 +2202,7 @@ data:
         tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -2192,6 +2192,7 @@ data:
         tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -2185,6 +2185,7 @@ data:
         tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -2298,6 +2298,7 @@ data:
         tokenUrl: ''
         type: ClientSecret
       connection:
+        host: dns:///fake-host.domain
         insecure: false
         insecureSkipVerify: true
         trustedIdentityClaims:


### PR DESCRIPTION
## Overview

Stacked on the apiKeyOverrides change. Fixes a dataproxy crashloop: the dataproxy builds an api/v1 clientset for the control-plane authorizer (service-credential-authenticated DP->CP authorizer requests), and that clientset's auth-metadata/admin connection dials `union.connection.host`. The shared `union.connection` block sets only TLS flags, so with no explicit host the dataproxy gets an empty gRPC target (`passthrough: received empty target in Build()`) and crashloops at startup.

Derive the dataproxy's `union.connection.host` from `connection.rootTenantURLPattern` in the configMap template helper, rather than duplicating the endpoint literal in `values.yaml`. `rootTenantURLPattern` already points at the internal control-plane nginx endpoint and is the single source of truth for the in-cluster control-plane address. Scoped to the dataproxy service only.

## Test Plan

- `helm template`: rendered dataproxy ConfigMap now carries `union.connection.host` derived from `rootTenantURLPattern`; all other services unchanged.
- Regenerated controlplane snapshots (one `+1` line each); `make test` (helm + kubeconform) green.
- Validated on an internal selfmanaged AWS environment: dataproxy goes healthy.

## Rollback Plan

Revert the PR; restores the prior (empty-host) behavior.

## Checklist

- [x] Regenerated snapshot tests
- [x] helm lint passes

* \`main\` <!-- branch-stack -->
  - \#452
    - **fix(controlplane): set dataproxy union.connection.host for CP authorizer clientset** :point\_left: