### PR TITLE
dataplane: operator self-reported connection config + controlplane endpoint-global cleanup

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -4,7 +4,7 @@ description: Deploys the Union controlplane components to onboard a kubernetes c
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
 version: 2026.6.9
-appVersion: 2026.6.9
+appVersion: 2026.6.10-alpha.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: flyte-core

--- a/charts/controlplane/examples/values.aws.intracluster.yaml
+++ b/charts/controlplane/examples/values.aws.intracluster.yaml
@@ -16,7 +16,6 @@
 # ============================================================================
 
 global:
-  # CP -> DP HTTP traffic dials the DP nginx Service directly. Bypasses the
-  # public LB and works without any additional DNS resolution outside the
-  # cluster.
-  DATAPLANE_HOST: "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
+  # CP→DP routing is handled by Phase 2 DP self-registration — the dataplane
+  # operator self-reports its CP-dial endpoint on every UpdateStatus, and the
+  # CP reads it from cluster.Spec.ConnectionConfig. No DATAPLANE_HOST needed.

--- a/charts/controlplane/examples/values.gcp.intracluster.yaml
+++ b/charts/controlplane/examples/values.gcp.intracluster.yaml
@@ -16,7 +16,6 @@
 # ============================================================================
 
 global:
-  # CP -> DP HTTP traffic dials the DP nginx Service directly. Bypasses the
-  # public LB and works without any additional DNS resolution outside the
-  # cluster.
-  DATAPLANE_HOST: "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
+  # CP→DP routing is handled by Phase 2 DP self-registration — the dataplane
+  # operator self-reports its CP-dial endpoint on every UpdateStatus, and the
+  # CP reads it from cluster.Spec.ConnectionConfig. No DATAPLANE_HOST needed.

--- a/charts/controlplane/templates/leasor/configmap.yaml
+++ b/charts/controlplane/templates/leasor/configmap.yaml
@@ -3,12 +3,23 @@
 Bespoke ConfigMap for leasor. Mirrors what the generic services renderer
 (templates/configmap.yaml) would produce — same name, same labels, same
 unionai.configMap-style merge of global .Values.configMap with
-.Values.services.leasor.configMap — and then auto-generates
-queueSync.queues from .Values.global.DATAPLANE_CLUSTER_NAME: one `default`
-queue + one per-cluster queue, both containing that single cluster name. The
-auto-generation is skipped if services.leasor.configMap.leasor.queueSync.queues
-is already set explicitly (full override — use that to enumerate clusters in
-the rare multi-DP case).
+.Values.services.leasor.configMap — then defaults each entry of
+queueSync.queues so callers can write terser overlays.
+
+Per-queue defaults injected when the field is absent from an entry:
+  org:               .Values.global.UNION_ORG  (single-tenant CP convention)
+  name:              "default"
+  priority:          50  (PriorityMedium — see cloud/leasor/config:Priority)
+  fairnessAlgorithm: 1   (FairnessRoundRobin)
+
+The caller still owns `clusters: [...]` (required — there is no sensible
+default) and any other QueueSpec field (project / domain / status /
+maxDepth / maxActionConcurrency / maxRunConcurrency).
+
+Backward compat: if `queueSync.queues` is empty AND
+.Values.global.DATAPLANE_CLUSTER_NAME is non-empty, we auto-generate a
+2-entry list ({name: default, clusters: [X]}, {name: X, clusters: [X]}).
+This path is DEPRECATED — new installs should configure queues directly.
 */ -}}
 {{- $service := dict "config" .Values.services.leasor "key" "leasor" "Release" .Release "Values" .Values "Chart" .Chart -}}
 
@@ -20,20 +31,32 @@ the rare multi-DP case).
   {{- $_ := set $merged "logger" (omit .Values.logging "pythonLevel") -}}
 {{- end -}}
 
-{{- /* Auto-generate queueSync.queues unless explicitly set. */ -}}
+{{- /* Normalize queueSync.queues. */ -}}
 {{- $leasor    := index $merged "leasor"    | default dict -}}
 {{- $queueSync := index $leasor "queueSync" | default dict -}}
 {{- $existing  := index $queueSync "queues" | default list -}}
-{{- $cluster   := .Values.global.DATAPLANE_CLUSTER_NAME | default "" -}}
-{{- $org       := .Values.global.UNION_ORG | default "" -}}
-{{- if and (eq (len $existing) 0) (ne $cluster "") (ne $org "") -}}
-  {{- $queues := list -}}
-  {{- /* default queue pointing at the attached cluster */ -}}
-  {{- $queues = append $queues (dict "org" $org "name" "default"  "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $cluster)) -}}
-  {{- /* per-cluster queue with the same name as the cluster */ -}}
-  {{- $queues = append $queues (dict "org" $org "name" $cluster   "priority" 50 "fairnessAlgorithm" 1 "clusters" (list $cluster)) -}}
-  {{- $_ := set $queueSync "queues" $queues -}}
+{{- $defaultOrg := .Values.global.UNION_ORG | default "" -}}
+
+{{- /* DEPRECATED auto-generation from DATAPLANE_CLUSTER_NAME. */ -}}
+{{- $deprecatedCluster := .Values.global.DATAPLANE_CLUSTER_NAME | default "" -}}
+{{- if and (eq (len $existing) 0) (ne $deprecatedCluster "") (ne $defaultOrg "") -}}
+  {{- $existing = list -}}
+  {{- $existing = append $existing (dict "name" "default"          "clusters" (list $deprecatedCluster)) -}}
+  {{- $existing = append $existing (dict "name" $deprecatedCluster "clusters" (list $deprecatedCluster)) -}}
   {{- if not (hasKey $queueSync "source") -}}{{- $_ := set $queueSync "source" "static" -}}{{- end -}}
+{{- end -}}
+
+{{- if gt (len $existing) 0 -}}
+  {{- $defaulted := list -}}
+  {{- range $q := $existing -}}
+    {{- $entry := deepCopy $q -}}
+    {{- if not (hasKey $entry "org")               -}}{{- $_ := set $entry "org"               $defaultOrg -}}{{- end -}}
+    {{- if not (hasKey $entry "name")              -}}{{- $_ := set $entry "name"              "default"   -}}{{- end -}}
+    {{- if not (hasKey $entry "priority")          -}}{{- $_ := set $entry "priority"          50          -}}{{- end -}}
+    {{- if not (hasKey $entry "fairnessAlgorithm") -}}{{- $_ := set $entry "fairnessAlgorithm" 1           -}}{{- end -}}
+    {{- $defaulted = append $defaulted $entry -}}
+  {{- end -}}
+  {{- $_ := set $queueSync "queues" $defaulted -}}
   {{- $_ := set $leasor "queueSync" $queueSync -}}
   {{- $_ := set $merged "leasor" $leasor -}}
 {{- end -}}

--- a/charts/controlplane/values.aws.yaml
+++ b/charts/controlplane/values.aws.yaml
@@ -17,9 +17,6 @@ global:
   ARTIFACTS_BUCKET_NAME: ""   # S3 bucket for artifacts
   KUBERNETES_SECRET_NAME: ""  # K8s secret with DB password under key "pass.txt"
 
-  # --- DP entrypoint (CP -> DP) ---
-  DATAPLANE_HOST: ""          # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
-
   # --- Images ---
   IMAGE_REPOSITORY_PREFIX: "registry.unionai.cloud/controlplane"
 
@@ -102,11 +99,6 @@ services:
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: "{{ .Values.global.ARTIFACT_IAM_ROLE_ARN }}"
-  dataproxy:
-    configMap:
-      dataproxy:
-        # Falls back to DATAPLANE_HOST when DATAPLANE_ENDPOINT is unset.
-        secureTunnelTenantURLPattern: '{{ default .Values.global.DATAPLANE_HOST .Values.global.DATAPLANE_ENDPOINT }}'
 
 scylla:
   storageClass:

--- a/charts/controlplane/values.gcp.yaml
+++ b/charts/controlplane/values.gcp.yaml
@@ -18,9 +18,6 @@ global:
   ARTIFACTS_BUCKET_NAME: ""   # GCS bucket for artifacts
   KUBERNETES_SECRET_NAME: ""  # K8s secret with DB password under key "pass.txt"
 
-  # --- DP entrypoint (CP -> DP) ---
-  DATAPLANE_HOST: ""          # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
-
   # --- Images ---
   IMAGE_REPOSITORY_PREFIX: "registry.unionai.cloud/controlplane"
 
@@ -107,12 +104,6 @@ services:
               config:
                 projectId: '{{ .Values.global.GOOGLE_PROJECT_ID }}'
             type: stow
-
-  dataproxy:
-    configMap:
-      dataproxy:
-        # Falls back to DATAPLANE_HOST when DATAPLANE_ENDPOINT is unset.
-        secureTunnelTenantURLPattern: '{{ default .Values.global.DATAPLANE_HOST .Values.global.DATAPLANE_ENDPOINT }}'
 
 scylla:
   storageClass:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -15,37 +15,22 @@ global:
   ARTIFACTS_BUCKET_NAME: ""
   KUBERNETES_SECRET_NAME: "" # K8s secret with DB password under key "pass.txt"
 
-  # --- DP entrypoint (CP -> DP) ---
-  DATAPLANE_HOST: ""        # e.g. "http://dataplane-nginx-controller.dataplane.svc.cluster.local:80"
-  DATAPLANE_ENDPOINT: ""    # Deprecated alias — falls back to DATAPLANE_HOST when unset.
-
-  # --- Leasor: attached dataplane cluster identifier ---
-  # TEMPORARY. The ship-today way to tell leasor which dataplane cluster its
-  # queues should target. A future control-plane queue/cluster CRUD service
-  # will own this state and deprecate this knob — plan to migrate when that
-  # lands.
+  # --- Leasor: attached dataplane cluster identifier (DEPRECATED) ---
+  # Kept for single-DP backward compatibility. New installs should configure
+  # services.leasor.configMap.leasor.queueSync.queues directly — see that
+  # section below for the multi-cluster shape.
   #
-  # The cluster identifier — same value the corresponding dataplane chart
-  # install sets in its own global.CLUSTER_NAME, which is what leaseworker
-  # reports on StreamLeases and what leasor matches queues against. The
-  # common self-hosted shape is one CP fronting one DP (often intracluster on
-  # the same K8s), so a single string fits. For the rare multi-DP case,
-  # override services.leasor.configMap.leasor.queueSync.queues directly to
-  # enumerate every dataplane.
-  #
-  # Used to auto-generate services.leasor.configMap.leasor.queueSync.queues
-  # (one `default` queue + one per-cluster queue, both containing this name).
-  # No reasonable default — set explicitly.
-  #
-  # NOT the same as flyte.configmap.clusters.clusterConfigs. That is
-  # flyteadmin's routing registry (name + endpoint + auth per cluster) used
-  # by RandomClusterSelector for v1 execution dispatch; populate that only
-  # when you actually need flyteadmin v1 multi-cluster routing. This knob is
-  # leasor-only and just carries a name. Empty by default; per-env overlay
-  # populates from the dataplane's cluster_name. The leasor configmap
-  # auto-queue-gen is a no-op when this is empty (see
-  # templates/leasor/configmap.yaml).
+  # When set AND services.leasor.configMap.leasor.queueSync.queues is empty,
+  # templates/leasor/configmap.yaml auto-generates a 2-entry queue list:
+  #   - { name: default,                clusters: [<this value>] }
+  #   - { name: <DATAPLANE_CLUSTER_NAME>, clusters: [<this value>] }
+  # No reasonable default; empty disables auto-gen.
   DATAPLANE_CLUSTER_NAME: ""
+
+  # NOTE: global.DATAPLANE_HOST + global.DATAPLANE_ENDPOINT were removed in
+  # the Phase 2 DP self-registration cleanup. CP→DP routing now reads the
+  # DP's self-reported endpoint from cluster.Spec.ConnectionConfig (the
+  # operator self-reports on every UpdateStatus). See cloud #16362.
 
   # --- Images ---
   # Customer-facing registry default; internal deployments override to private ECR/GCR.
@@ -1324,11 +1309,57 @@ services:
   # router is needed — leasor rides the generic services renderer like queue.
   #
   # ConfigMap special-cased: leasor's ConfigMap is NOT produced by the generic
-  # services renderer. templates/leasor/configmap.yaml builds it instead so
-  # that queueSync.queues can be auto-generated from
-  # global.DATAPLANE_CLUSTER_NAME (one `default` queue + one per-cluster
-  # queue, both containing that name). To bypass auto-generation entirely,
-  # set configMap.leasor.queueSync.queues below explicitly.
+  # services renderer. templates/leasor/configmap.yaml builds it instead so it
+  # can inject per-queue defaults onto each entry of queueSync.queues — see
+  # below for the supported shape and the QueueSpec field reference.
+  #
+  # queueSync.queues — list of leasor.config.QueueSpec entries
+  # (cloud/leasor/config/config.go:121). Each entry routes Actions queued
+  # under (org, project, domain) to one or more dataplane clusters.
+  #
+  # Per-entry defaults (template-injected when the field is absent):
+  #
+  #   org:               global.UNION_ORG     (single-tenant CP convention)
+  #   name:              "default"
+  #   priority:          50  (PriorityMedium — 0=Low, 50=Medium, 100=High)
+  #   fairnessAlgorithm: 1   (FairnessRoundRobin; 0=None=FIFO, 2=Shuffle)
+  #
+  # Caller-owned fields:
+  #
+  #   clusters:         REQUIRED — list of DP cluster_name strings this queue
+  #                     dispatches to. ["*"] matches every connected DP.
+  #
+  # Optional fields (omit unless you need to scope or shape the queue):
+  #
+  #   project:          scope to a single Flyte project (default: "" = all)
+  #   domain:           scope to a single Flyte domain (default: "" = all)
+  #   status:           0=Active (default), 1=Draining, 2=Drained
+  #   maxDepth:         max queued leases (0 = unlimited)
+  #   maxActionConcurrency: max concurrent in-flight actions (0 = unlimited)
+  #   maxRunConcurrency:    max concurrent runs (0 = unlimited)
+  #
+  # Single-DP example (matches what DATAPLANE_CLUSTER_NAME auto-generated):
+  #
+  #   services:
+  #     leasor:
+  #       configMap:
+  #         leasor:
+  #           queueSync:
+  #             source: static
+  #             queues:
+  #               - { clusters: [dp-1] }            # → name=default
+  #               - { name: dp-1, clusters: [dp-1] }
+  #
+  # Multi-DP example (one default that fans out + one per-cluster):
+  #
+  #   queues:
+  #     - { clusters: [dp-east, dp-west] }
+  #     - { name: dp-east, clusters: [dp-east] }
+  #     - { name: dp-west, clusters: [dp-west] }
+  #
+  # Backward compat: if queues is empty AND global.DATAPLANE_CLUSTER_NAME
+  # is set, the template auto-generates the 2-entry single-DP shape. This
+  # path is DEPRECATED — migrate to explicit `queues` above.
   leasor:
     fullnameOverride: "leasor"
     replicaCount: 1

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -4,7 +4,7 @@ description: Deploys the Union dataplane components to onboard a kubernetes clus
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
 version: 2026.6.9
-appVersion: 2026.6.9
+appVersion: 2026.6.10-alpha.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:
 - name: kube-prometheus-stack

--- a/charts/dataplane/templates/_connection.tpl
+++ b/charts/dataplane/templates/_connection.tpl
@@ -38,3 +38,33 @@ spelling varies across config schemas (insecure vs insecure-skip-verify
 vs insecureSkipVerify) and YAML/Go-config bool coercion through helm
 template strings is fragile, so callers write the booleans inline.
 */}}
+
+{{/*
+Self-reporting helpers for the data-plane → control-plane Heartbeat /
+UpdateStatus.connection_config field. The operator reads the rendered
+JSON file at startup and ships it on every UpdateStatus so the CP can
+dial back without anyone having to admin-set DataplaneIngressURL.
+
+Override surface (.Values.updateStatus.connectionConfig):
+  host                bare DP-reachable hostname (no scheme, no port).
+                      Empty falls back to .Values.ingress.host — the
+                      dataplane's own ingress hostname — so most installs
+                      don't need to set this explicitly.
+  insecure            CP dials with plain HTTP/2 (no TLS) when true
+  insecureSkipVerify  CP skips cert validation (self-signed cert envs)
+
+dataplane.dp.endpoint formats host as `dns:///<host>:443` — the same
+scheme used for CP→DP DP→CP and CP-to-DP gRPC dials elsewhere in the
+chart. Empty host returns empty string; callers gate emission on this.
+*/}}
+
+{{- define "dataplane.dp.host" -}}
+{{- $explicit := tpl (default "" .Values.updateStatus.connectionConfig.host) . -}}
+{{- $derived := tpl (default "" .Values.ingress.host) . -}}
+{{- default $derived $explicit -}}
+{{- end -}}
+
+{{- define "dataplane.dp.endpoint" -}}
+{{- $host := include "dataplane.dp.host" . -}}
+{{- if $host -}}{{- printf "dns:///%s:443" $host -}}{{- end -}}
+{{- end -}}

--- a/charts/dataplane/templates/operator/configmap-connection.yaml
+++ b/charts/dataplane/templates/operator/configmap-connection.yaml
@@ -1,0 +1,26 @@
+{{- if include "dataplane.dp.host" . }}
+{{/*
+ConfigMap rendering the DP's self-reported connection_config as a JSON
+file the operator reads at startup and ships in every UpdateStatus to
+the controlplane (UpdateStatusRequest.connection_config). The CP prefers
+this over the legacy admin-set DataplaneIngressURL when present.
+
+Gated on .Values.updateStatus.connectionConfig.host being non-empty so
+charts consumed by envs that don't set it (BYOC, self-managed, legacy
+selfhosted with admin-set URL) emit no resource.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "union-operator.fullname" . }}-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+data:
+  connection_config.json: |
+    {
+      "endpoint": "{{ include "dataplane.dp.endpoint" . }}",
+      "insecure": {{ .Values.updateStatus.connectionConfig.insecure }},
+      "insecureSkipVerify": {{ .Values.updateStatus.connectionConfig.insecureSkipVerify }}
+    }
+{{- end }}

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -27,6 +27,11 @@ data:
     operator:
       enabled: {{ .Values.config.operator.enabled }}
       enableTunnelService: {{ .Values.config.operator.enableTunnelService }}
+      {{- if include "dataplane.dp.host" . }}
+      # Path to the chart-rendered connection_config JSON the operator
+      # self-reports on every UpdateStatus call. Empty path = disabled.
+      connectionConfigPath: /etc/union/connection-config/connection_config.json
+      {{- end }}
       #  enableDepot: {{ include "operator.enableDepot" . | default "false" }}
       tunnel:
         enableDirectToAppIngress: {{ and .Values.serving.enabled .Values.tunnelService.apps.enableGlobalIngress }}

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           secret:
             secretName: {{ .Values.operator.secretName }}
         {{- end }}
+        {{- if include "dataplane.dp.host" . }}
+        - name: connection-config-volume
+          configMap:
+            name: {{ include "union-operator.fullname" . }}-connection
+        {{- end }}
       {{- with .Values.operator.additionalVolumes -}}
       {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
@@ -59,6 +64,11 @@ spec:
             {{- if .Values.secrets.admin.enable }}
             - mountPath: /etc/union/secret
               name: secret-volume
+            {{- end }}
+            {{- if include "dataplane.dp.host" . }}
+            - mountPath: /etc/union/connection-config
+              name: connection-config-volume
+              readOnly: true
             {{- end }}
           {{- with .Values.operator.additionalVolumeMounts -}}
           {{ tpl (toYaml .) $ | nindent 12 }}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -38,6 +38,24 @@ clusterName: "{{ .Values.global.CLUSTER_NAME }}"
 # -- Organization name (provided by Union).
 orgName: "{{ .Values.global.ORG_NAME }}"
 
+# -- Self-reported CP-client-construction data the operator ships in every
+# UpdateStatus call (UpdateStatusRequest.connection_config). The controlplane
+# prefers this over the legacy admin-set DataplaneIngressURL when present.
+# Empty host disables self-reporting; CP falls back to the legacy URL.
+updateStatus:
+  connectionConfig:
+    # -- DP-reachable hostname the CP should dial back. e.g.
+    # "dp-1.internal.<full_domain>". Bare hostname only — no scheme, no port.
+    # Chart helper derives the gRPC endpoint as `dns:///<host>:443`.
+    # Empty falls back to `Values.ingress.host` (the dataplane's own ingress
+    # hostname), so most installs don't need to set this explicitly —
+    # the chart already knows where the DP is reachable.
+    host: ""
+    # -- CP dials this DP with plain HTTP/2 (no TLS) when true. Default false.
+    insecure: false
+    # -- CP skips cert validation on the TLS handshake (self-signed CP cert envs).
+    insecureSkipVerify: false
+
 # -- Define additional pod environment variables for all of the Union pods.
 additionalPodEnvVars: { }
 #  key1: "value1"

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -124,7 +124,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -138,7 +138,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -150,7 +150,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -162,7 +162,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -174,7 +174,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -186,7 +186,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -198,7 +198,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -210,7 +210,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -222,7 +222,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -234,7 +234,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -246,7 +246,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -260,7 +260,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -522,7 +522,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -625,7 +625,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -699,7 +699,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1388,7 +1388,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1422,7 +1422,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1845,7 +1845,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1944,7 +1944,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2035,7 +2035,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2227,7 +2227,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2343,7 +2343,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2427,7 +2427,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2518,7 +2518,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2602,7 +2602,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2687,7 +2687,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2898,7 +2898,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8195,7 +8195,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8271,7 +8271,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8458,7 +8458,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8492,7 +8492,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8529,7 +8529,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8566,7 +8566,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8603,7 +8603,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8640,7 +8640,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8677,7 +8677,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8714,7 +8714,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8751,7 +8751,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8788,7 +8788,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8825,7 +8825,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8893,7 +8893,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8922,7 +8922,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8961,7 +8961,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9000,7 +9000,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9035,7 +9035,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9070,7 +9070,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9105,7 +9105,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9140,7 +9140,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9179,7 +9179,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9214,7 +9214,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9249,7 +9249,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9800,7 +9800,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9857,7 +9857,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9908,7 +9908,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9984,7 +9984,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10041,7 +10041,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10092,7 +10092,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10168,7 +10168,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10225,7 +10225,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10276,7 +10276,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10352,7 +10352,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10409,7 +10409,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10460,7 +10460,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10536,7 +10536,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10593,7 +10593,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10644,7 +10644,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10720,7 +10720,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10777,7 +10777,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10828,7 +10828,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10904,7 +10904,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10961,7 +10961,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11012,7 +11012,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11088,7 +11088,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11145,7 +11145,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11196,7 +11196,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11272,7 +11272,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11329,7 +11329,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11380,7 +11380,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11456,7 +11456,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11513,7 +11513,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11564,7 +11564,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11641,7 +11641,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11656,9 +11656,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: 4c1ed840cd1c24add2eb9a43cac436e27a716bfc476a153e7caf0b376c4bf22c
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: c9dcf3d9548137c5e9ca31ed689c6d79716dc9c23bc01f07cc92083df8c0ee8c
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11691,7 +11691,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11883,7 +11883,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11923,7 +11923,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11954,7 +11954,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11992,7 +11992,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12069,7 +12069,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12107,7 +12107,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12123,7 +12123,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12200,7 +12200,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12238,7 +12238,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12312,7 +12312,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12350,7 +12350,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12366,7 +12366,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12440,7 +12440,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12478,7 +12478,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12555,7 +12555,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12591,7 +12591,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12607,7 +12607,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12681,7 +12681,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12719,7 +12719,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12734,7 +12734,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12751,7 +12751,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12828,7 +12828,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12867,7 +12867,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12883,7 +12883,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12957,7 +12957,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12995,7 +12995,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13011,7 +13011,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13086,7 +13086,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13124,7 +13124,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13236,7 +13236,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16063,10 +16063,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -98,7 +98,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -126,7 +126,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -140,7 +140,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -152,7 +152,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -164,7 +164,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -188,7 +188,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -200,7 +200,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -212,7 +212,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -224,7 +224,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -236,7 +236,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -248,7 +248,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -262,7 +262,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -524,7 +524,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -627,7 +627,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -701,7 +701,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1390,7 +1390,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1424,7 +1424,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1827,7 +1827,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1926,7 +1926,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2017,7 +2017,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2209,7 +2209,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2324,7 +2324,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2408,7 +2408,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2499,7 +2499,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2583,7 +2583,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2668,7 +2668,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2879,7 +2879,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8176,7 +8176,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8252,7 +8252,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8439,7 +8439,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8473,7 +8473,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8510,7 +8510,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8547,7 +8547,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8584,7 +8584,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8621,7 +8621,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8658,7 +8658,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8695,7 +8695,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8732,7 +8732,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8769,7 +8769,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8806,7 +8806,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8874,7 +8874,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8903,7 +8903,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8942,7 +8942,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8981,7 +8981,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9016,7 +9016,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9051,7 +9051,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9086,7 +9086,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9121,7 +9121,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9160,7 +9160,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9195,7 +9195,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9230,7 +9230,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9781,7 +9781,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9838,7 +9838,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9889,7 +9889,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9965,7 +9965,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10022,7 +10022,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10073,7 +10073,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10149,7 +10149,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10206,7 +10206,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10257,7 +10257,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10333,7 +10333,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10390,7 +10390,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10441,7 +10441,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10517,7 +10517,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10574,7 +10574,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10625,7 +10625,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10701,7 +10701,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10758,7 +10758,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10809,7 +10809,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10885,7 +10885,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10942,7 +10942,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10993,7 +10993,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11069,7 +11069,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11126,7 +11126,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11177,7 +11177,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11253,7 +11253,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11310,7 +11310,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11361,7 +11361,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11437,7 +11437,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11494,7 +11494,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11545,7 +11545,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11622,7 +11622,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11637,9 +11637,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: ddd3caad8706a67836182d812c7cd81d1feb6f56852543da7f169472f3b38806
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: 8ee550c67a72945d19ad66770565fa5832d8888473e4dcde809b04e0b42ec018
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11672,7 +11672,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11864,7 +11864,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11904,7 +11904,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11935,7 +11935,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11973,7 +11973,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12050,7 +12050,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12088,7 +12088,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12104,7 +12104,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12181,7 +12181,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12219,7 +12219,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12293,7 +12293,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12331,7 +12331,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12347,7 +12347,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12421,7 +12421,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12459,7 +12459,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12536,7 +12536,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12572,7 +12572,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12588,7 +12588,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12662,7 +12662,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12700,7 +12700,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12715,7 +12715,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12732,7 +12732,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12809,7 +12809,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12848,7 +12848,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12864,7 +12864,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12938,7 +12938,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12976,7 +12976,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12992,7 +12992,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13067,7 +13067,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13105,7 +13105,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13217,7 +13217,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16147,10 +16147,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -98,7 +98,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -126,7 +126,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -140,7 +140,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -152,7 +152,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -164,7 +164,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -188,7 +188,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -200,7 +200,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -212,7 +212,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -224,7 +224,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -236,7 +236,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -248,7 +248,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -262,7 +262,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -524,7 +524,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -627,7 +627,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -701,7 +701,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1390,7 +1390,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1424,7 +1424,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1847,7 +1847,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1946,7 +1946,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2037,7 +2037,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2229,7 +2229,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2344,7 +2344,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2428,7 +2428,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2519,7 +2519,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2603,7 +2603,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2688,7 +2688,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2899,7 +2899,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8211,7 +8211,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8287,7 +8287,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8474,7 +8474,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8508,7 +8508,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8545,7 +8545,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8582,7 +8582,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8619,7 +8619,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8656,7 +8656,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8693,7 +8693,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8730,7 +8730,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8767,7 +8767,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8804,7 +8804,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8841,7 +8841,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8909,7 +8909,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8938,7 +8938,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8977,7 +8977,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9016,7 +9016,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9051,7 +9051,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9086,7 +9086,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9121,7 +9121,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9156,7 +9156,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9195,7 +9195,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9230,7 +9230,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9265,7 +9265,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9816,7 +9816,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9873,7 +9873,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9924,7 +9924,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10000,7 +10000,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10057,7 +10057,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10108,7 +10108,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10184,7 +10184,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10241,7 +10241,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10292,7 +10292,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10368,7 +10368,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10425,7 +10425,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10476,7 +10476,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10552,7 +10552,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10609,7 +10609,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10660,7 +10660,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10736,7 +10736,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10793,7 +10793,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10844,7 +10844,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10920,7 +10920,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10977,7 +10977,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11028,7 +11028,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11104,7 +11104,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11161,7 +11161,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11212,7 +11212,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11288,7 +11288,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11345,7 +11345,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11396,7 +11396,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11472,7 +11472,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11529,7 +11529,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11580,7 +11580,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11657,7 +11657,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11672,9 +11672,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: 4c1ed840cd1c24add2eb9a43cac436e27a716bfc476a153e7caf0b376c4bf22c
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: c9dcf3d9548137c5e9ca31ed689c6d79716dc9c23bc01f07cc92083df8c0ee8c
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11707,7 +11707,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11900,7 +11900,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11941,7 +11941,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11972,7 +11972,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12011,7 +12011,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12088,7 +12088,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12127,7 +12127,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12143,7 +12143,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12220,7 +12220,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12259,7 +12259,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12333,7 +12333,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12372,7 +12372,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12388,7 +12388,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12462,7 +12462,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12501,7 +12501,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12578,7 +12578,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12615,7 +12615,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12631,7 +12631,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12705,7 +12705,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12744,7 +12744,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12759,7 +12759,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12776,7 +12776,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12853,7 +12853,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12893,7 +12893,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12909,7 +12909,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12983,7 +12983,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13022,7 +13022,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13038,7 +13038,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13113,7 +13113,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13152,7 +13152,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13258,7 +13258,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -19816,10 +19816,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2082,7 +2082,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: ''
+      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -98,7 +98,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -128,7 +128,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -142,7 +142,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -154,7 +154,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -178,7 +178,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -190,7 +190,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -202,7 +202,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -214,7 +214,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -226,7 +226,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -238,7 +238,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -250,7 +250,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -264,7 +264,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -534,7 +534,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -637,7 +637,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -711,7 +711,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1400,7 +1400,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1434,7 +1434,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1862,7 +1862,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1961,7 +1961,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2052,7 +2052,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2244,7 +2244,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2359,7 +2359,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2448,7 +2448,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2539,7 +2539,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2623,7 +2623,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2708,7 +2708,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2919,7 +2919,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8219,7 +8219,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8295,7 +8295,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8482,7 +8482,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8516,7 +8516,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8553,7 +8553,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8590,7 +8590,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8627,7 +8627,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8664,7 +8664,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8701,7 +8701,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8738,7 +8738,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8775,7 +8775,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8812,7 +8812,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8849,7 +8849,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8917,7 +8917,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8946,7 +8946,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8985,7 +8985,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9024,7 +9024,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9059,7 +9059,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9094,7 +9094,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9129,7 +9129,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9164,7 +9164,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9203,7 +9203,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9238,7 +9238,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9273,7 +9273,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9824,7 +9824,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9881,7 +9881,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9932,7 +9932,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10008,7 +10008,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10065,7 +10065,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10116,7 +10116,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10192,7 +10192,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10249,7 +10249,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10300,7 +10300,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10376,7 +10376,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10433,7 +10433,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10484,7 +10484,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10560,7 +10560,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10617,7 +10617,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10668,7 +10668,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10744,7 +10744,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10801,7 +10801,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10852,7 +10852,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10928,7 +10928,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10985,7 +10985,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11036,7 +11036,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11112,7 +11112,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11169,7 +11169,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11220,7 +11220,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11296,7 +11296,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11353,7 +11353,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11404,7 +11404,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11480,7 +11480,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11537,7 +11537,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11588,7 +11588,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11665,7 +11665,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11680,9 +11680,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: 4c1ed840cd1c24add2eb9a43cac436e27a716bfc476a153e7caf0b376c4bf22c
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: c9dcf3d9548137c5e9ca31ed689c6d79716dc9c23bc01f07cc92083df8c0ee8c
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11715,7 +11715,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11907,7 +11907,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11947,7 +11947,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11978,7 +11978,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12016,7 +12016,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12093,7 +12093,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12131,7 +12131,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12147,7 +12147,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12224,7 +12224,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12262,7 +12262,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12336,7 +12336,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12374,7 +12374,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12390,7 +12390,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12464,7 +12464,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12510,7 +12510,7 @@ spec:
             path: client_secret
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12590,7 +12590,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12626,7 +12626,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12642,7 +12642,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12716,7 +12716,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12754,7 +12754,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12769,7 +12769,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12786,7 +12786,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12863,7 +12863,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12902,7 +12902,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12918,7 +12918,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12992,7 +12992,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13030,7 +13030,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13046,7 +13046,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13121,7 +13121,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13159,7 +13159,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13271,7 +13271,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16187,10 +16187,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -124,7 +124,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -138,7 +138,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -150,7 +150,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -162,7 +162,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -174,7 +174,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -186,7 +186,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -198,7 +198,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -210,7 +210,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -222,7 +222,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -234,7 +234,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -246,7 +246,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -260,7 +260,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -525,7 +525,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -628,7 +628,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -702,7 +702,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1391,7 +1391,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1425,7 +1425,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1828,7 +1828,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1931,7 +1931,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2022,7 +2022,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2214,7 +2214,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2329,7 +2329,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2413,7 +2413,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2504,7 +2504,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2588,7 +2588,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2673,7 +2673,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2884,7 +2884,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8181,7 +8181,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8257,7 +8257,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8444,7 +8444,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8478,7 +8478,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8515,7 +8515,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8552,7 +8552,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8589,7 +8589,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8626,7 +8626,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8663,7 +8663,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8700,7 +8700,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8737,7 +8737,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8774,7 +8774,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8811,7 +8811,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8879,7 +8879,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8908,7 +8908,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8947,7 +8947,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8986,7 +8986,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9021,7 +9021,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9056,7 +9056,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9091,7 +9091,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9126,7 +9126,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9165,7 +9165,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9200,7 +9200,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9235,7 +9235,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9786,7 +9786,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9843,7 +9843,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9894,7 +9894,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9970,7 +9970,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10027,7 +10027,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10078,7 +10078,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10154,7 +10154,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10211,7 +10211,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10262,7 +10262,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10338,7 +10338,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10395,7 +10395,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10446,7 +10446,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10522,7 +10522,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10579,7 +10579,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10630,7 +10630,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10706,7 +10706,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10763,7 +10763,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10814,7 +10814,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10890,7 +10890,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10947,7 +10947,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10998,7 +10998,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11074,7 +11074,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11131,7 +11131,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11182,7 +11182,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11258,7 +11258,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11315,7 +11315,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11366,7 +11366,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11442,7 +11442,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11499,7 +11499,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11550,7 +11550,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11627,7 +11627,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11642,9 +11642,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: ddd3caad8706a67836182d812c7cd81d1feb6f56852543da7f169472f3b38806
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: 8ee550c67a72945d19ad66770565fa5832d8888473e4dcde809b04e0b42ec018
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11677,7 +11677,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11869,7 +11869,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11909,7 +11909,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11940,7 +11940,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11978,7 +11978,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12055,7 +12055,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12093,7 +12093,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12109,7 +12109,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12186,7 +12186,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12224,7 +12224,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12298,7 +12298,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12336,7 +12336,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12352,7 +12352,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12426,7 +12426,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12464,7 +12464,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12541,7 +12541,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12577,7 +12577,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12593,7 +12593,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12667,7 +12667,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12705,7 +12705,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12720,7 +12720,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12737,7 +12737,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12814,7 +12814,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12853,7 +12853,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12869,7 +12869,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12943,7 +12943,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12981,7 +12981,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12997,7 +12997,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13072,7 +13072,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13110,7 +13110,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13222,7 +13222,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16138,10 +16138,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -124,7 +124,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -138,7 +138,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -150,7 +150,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -162,7 +162,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -174,7 +174,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -186,7 +186,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -198,7 +198,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -210,7 +210,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -222,7 +222,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -234,7 +234,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -246,7 +246,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -260,7 +260,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -522,7 +522,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -625,7 +625,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -699,7 +699,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1388,7 +1388,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1422,7 +1422,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1825,7 +1825,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1924,7 +1924,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2015,7 +2015,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2207,7 +2207,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2322,7 +2322,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2406,7 +2406,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2497,7 +2497,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2581,7 +2581,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2666,7 +2666,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2877,7 +2877,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8174,7 +8174,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8250,7 +8250,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8437,7 +8437,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8471,7 +8471,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8508,7 +8508,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8545,7 +8545,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8582,7 +8582,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8619,7 +8619,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8656,7 +8656,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8693,7 +8693,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8730,7 +8730,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8767,7 +8767,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8804,7 +8804,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8872,7 +8872,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8901,7 +8901,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8940,7 +8940,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8979,7 +8979,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9014,7 +9014,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9049,7 +9049,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9084,7 +9084,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9119,7 +9119,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9158,7 +9158,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9193,7 +9193,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9228,7 +9228,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9779,7 +9779,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -9836,7 +9836,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9887,7 +9887,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -9963,7 +9963,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10020,7 +10020,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10071,7 +10071,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10147,7 +10147,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10204,7 +10204,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10255,7 +10255,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10331,7 +10331,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10388,7 +10388,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10439,7 +10439,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10515,7 +10515,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10572,7 +10572,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10623,7 +10623,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10699,7 +10699,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10756,7 +10756,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10807,7 +10807,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10883,7 +10883,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -10940,7 +10940,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10991,7 +10991,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11067,7 +11067,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11124,7 +11124,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11175,7 +11175,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11251,7 +11251,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11308,7 +11308,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11359,7 +11359,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11435,7 +11435,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11492,7 +11492,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11543,7 +11543,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11620,7 +11620,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11635,9 +11635,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: ddd3caad8706a67836182d812c7cd81d1feb6f56852543da7f169472f3b38806
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: 8ee550c67a72945d19ad66770565fa5832d8888473e4dcde809b04e0b42ec018
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11670,7 +11670,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11862,7 +11862,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11902,7 +11902,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -11933,7 +11933,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -11971,7 +11971,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12048,7 +12048,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12086,7 +12086,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12102,7 +12102,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12179,7 +12179,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12217,7 +12217,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12291,7 +12291,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12329,7 +12329,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12345,7 +12345,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12419,7 +12419,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12457,7 +12457,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12534,7 +12534,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12570,7 +12570,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12586,7 +12586,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12660,7 +12660,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12698,7 +12698,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12713,7 +12713,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -12730,7 +12730,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -12807,7 +12807,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12846,7 +12846,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -12862,7 +12862,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -12936,7 +12936,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12974,7 +12974,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12990,7 +12990,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13065,7 +13065,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13103,7 +13103,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13215,7 +13215,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16042,10 +16042,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -42,7 +42,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -117,7 +117,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -130,7 +130,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -158,7 +158,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -172,7 +172,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -184,7 +184,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -196,7 +196,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -208,7 +208,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -220,7 +220,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -232,7 +232,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -244,7 +244,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -256,7 +256,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -268,7 +268,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: controlplane/templates/serviceaccount.yaml
@@ -280,7 +280,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 
 ---
@@ -556,7 +556,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -659,7 +659,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   peer-hashes: |
@@ -733,7 +733,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1422,7 +1422,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1456,7 +1456,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 data:
@@ -1808,7 +1808,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1926,7 +1926,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2037,7 +2037,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2128,7 +2128,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2320,7 +2320,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2435,7 +2435,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2519,7 +2519,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2610,7 +2610,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2694,7 +2694,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2779,7 +2779,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -2990,7 +2990,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -8287,7 +8287,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -8307,7 +8307,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -8379,7 +8379,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8400,7 +8400,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8587,7 +8587,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8621,7 +8621,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -8658,7 +8658,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -8695,7 +8695,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -8732,7 +8732,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -8769,7 +8769,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -8806,7 +8806,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -8843,7 +8843,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -8880,7 +8880,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -8917,7 +8917,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -8954,7 +8954,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -8990,7 +8990,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9045,7 +9045,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9074,7 +9074,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9113,7 +9113,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9152,7 +9152,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9187,7 +9187,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9222,7 +9222,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9257,7 +9257,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9292,7 +9292,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9331,7 +9331,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9366,7 +9366,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9401,7 +9401,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9952,7 +9952,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
@@ -10009,7 +10009,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10060,7 +10060,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10136,7 +10136,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
@@ -10193,7 +10193,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10244,7 +10244,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10320,7 +10320,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
@@ -10377,7 +10377,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10428,7 +10428,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10504,7 +10504,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
@@ -10561,7 +10561,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10612,7 +10612,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10688,7 +10688,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
@@ -10745,7 +10745,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10796,7 +10796,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10872,7 +10872,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
@@ -10929,7 +10929,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -10980,7 +10980,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11056,7 +11056,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
@@ -11113,7 +11113,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11164,7 +11164,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11240,7 +11240,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
@@ -11297,7 +11297,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11348,7 +11348,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11424,7 +11424,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
@@ -11481,7 +11481,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11532,7 +11532,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11608,7 +11608,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
@@ -11665,7 +11665,7 @@ spec:
               path: wait-for-non-peers.sh
       initContainers:
         - name: actions-migrate
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11716,7 +11716,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: actions
-          image: "registry.unionai.cloud/controlplane/services:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - actions
@@ -11793,7 +11793,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: router
 spec:
@@ -11808,9 +11808,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 07ce1fa8a0eaf78f1fcbe710c52d1e14e6f8723a99dd4c89afc22a2f6e426b43
-        checksum/router-cds: f5c5f696a1e36acda9aaba749727cbb1759d2e93d8dadacf0e49a7f78ddc8648
-        checksum/router-lds: 4c1ed840cd1c24add2eb9a43cac436e27a716bfc476a153e7caf0b376c4bf22c
+        checksum/router-bootstrap: e89b814205e4eb2663f349d00daaf859609a46f4410149bd95fa0b48b8e5417f
+        checksum/router-cds: 34abb0ba656866379b8269690e59e1563d8421e89b8cb20aeb985b3f79910d46
+        checksum/router-lds: c9dcf3d9548137c5e9ca31ed689c6d79716dc9c23bc01f07cc92083df8c0ee8c
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11843,7 +11843,7 @@ spec:
               path: lds.yaml
       containers:
         - name: envoy
-          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.9
+          image: registry.unionai.cloud/controlplane/envoy-router:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - envoy
@@ -11919,7 +11919,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -11934,7 +11934,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1eeb00265f2697cfffec1e1597f1ed9a9803c321b501b3f899050e931730400a
+        checksum/config: e3b24b9308b2f1f0091cb91f5610f8eb26867c899c0069b9e84991d73cb47f1f
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11960,7 +11960,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           command:
             - userclouds-lite
@@ -12152,7 +12152,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -12192,7 +12192,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.9"
+        image: "registry.unionai.cloud/controlplane/unionconsole:2026.6.10-alpha.0"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -12223,7 +12223,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12261,7 +12261,7 @@ spec:
           name: authorizer
       containers:
         - name: authorizer
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - authorizer
@@ -12338,7 +12338,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12376,7 +12376,7 @@ spec:
           name: cluster
       initContainers:
         - name: cluster-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudcluster
@@ -12392,7 +12392,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: cluster
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudcluster
@@ -12469,7 +12469,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12507,7 +12507,7 @@ spec:
           name: dataproxy
       containers:
         - name: dataproxy
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - dataproxy
@@ -12581,7 +12581,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12619,7 +12619,7 @@ spec:
           name: executions
       initContainers:
         - name: executions-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -12635,7 +12635,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: executions
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -12709,7 +12709,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12747,7 +12747,7 @@ spec:
           name: identity
       containers:
         - name: identity
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudidentity
@@ -12824,7 +12824,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12860,7 +12860,7 @@ spec:
           name: leasor
       initContainers:
         - name: leasor-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - leasor
@@ -12876,7 +12876,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: leasor
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - leasor
@@ -12950,7 +12950,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -12988,7 +12988,7 @@ spec:
           name: organizations
       initContainers:
         - name: organizations-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -13003,7 +13003,7 @@ spec:
           - name: config
             mountPath: /etc/config/
         - name: organizations-bootstrap
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudorganizations
@@ -13020,7 +13020,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: organizations
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudorganizations
@@ -13097,7 +13097,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -13136,7 +13136,7 @@ spec:
           name: queue
       initContainers:
         - name: queue-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - queue
@@ -13152,7 +13152,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: queue
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - queue
@@ -13226,7 +13226,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13264,7 +13264,7 @@ spec:
           name: run-scheduler
       initContainers:
         - name: run-scheduler-migrate
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
           - cloudpropeller
@@ -13280,7 +13280,7 @@ spec:
             mountPath: /etc/config/
       containers:
         - name: run-scheduler
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - cloudpropeller
@@ -13355,7 +13355,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -13393,7 +13393,7 @@ spec:
           name: usage
       containers:
         - name: usage
-          image: registry.unionai.cloud/controlplane/services:2026.6.9
+          image: registry.unionai.cloud/controlplane/services:2026.6.10-alpha.0
           imagePullPolicy: IfNotPresent
           args:
             - usage
@@ -13499,7 +13499,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -13526,7 +13526,7 @@ metadata:
     helm.sh/chart: controlplane-2026.6.9
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -16442,10 +16442,10 @@ spec:
         - name: union-registry-secret
       containers:
         - name: bootstrap
-          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.9"
+          image: "registry.unionai.cloud/controlplane/build-image-bootstrap:2026.6.10-alpha.0"
           env:
             - name: APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: UNION_IMAGE_NAME_PREFIX
               value: "public.ecr.aws/g1m2l3c1/imagebuilder-staging"
             - name: FLYTECTL_CONFIG

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -3245,7 +3245,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6513,7 +6513,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6616,7 +6616,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6726,7 +6726,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6794,7 +6794,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6864,7 +6864,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6883,7 +6883,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6980,7 +6980,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7273,7 +7273,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7327,7 +7327,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -3277,7 +3277,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6543,7 +6543,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6644,7 +6644,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6752,7 +6752,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6820,7 +6820,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6888,7 +6888,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6907,7 +6907,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7002,7 +7002,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7295,7 +7295,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7349,7 +7349,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3445,7 +3445,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -7049,7 +7049,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -7150,7 +7150,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7258,7 +7258,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7326,7 +7326,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7394,7 +7394,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7413,7 +7413,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7508,7 +7508,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7890,7 +7890,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7944,7 +7944,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -3245,7 +3245,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6511,7 +6511,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6612,7 +6612,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6720,7 +6720,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6788,7 +6788,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6856,7 +6856,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6875,7 +6875,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6970,7 +6970,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7384,7 +7384,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7438,7 +7438,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -3372,7 +3372,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6976,7 +6976,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -7077,7 +7077,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7185,7 +7185,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7253,7 +7253,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7321,7 +7321,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7340,7 +7340,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7435,7 +7435,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7760,7 +7760,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7814,7 +7814,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -5321,7 +5321,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -8451,7 +8451,7 @@ spec:
         - name: dataproxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9082,7 +9082,7 @@ spec:
     spec:
       containers:
         - name: kourier-gateway
-          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.9
+          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.10-alpha.0
           args:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
@@ -9225,7 +9225,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9
+          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0
           command:
             - /bin/kourier
           env:
@@ -9575,7 +9575,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9676,7 +9676,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9784,7 +9784,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9894,7 +9894,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9913,7 +9913,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -10008,7 +10008,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -5321,7 +5321,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -8451,7 +8451,7 @@ spec:
         - name: dataproxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9082,7 +9082,7 @@ spec:
     spec:
       containers:
         - name: kourier-gateway
-          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.9
+          image: public.ecr.aws/p0i0a9q8/envoy:2026.6.10-alpha.0
           args:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
@@ -9225,7 +9225,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9
+          image: public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0
           command:
             - /bin/kourier
           env:
@@ -9575,7 +9575,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -9676,7 +9676,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -9784,7 +9784,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9894,7 +9894,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9913,7 +9913,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -10008,7 +10008,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -3312,7 +3312,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6579,7 +6579,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6681,7 +6681,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6790,7 +6790,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6858,7 +6858,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6927,7 +6927,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6946,7 +6946,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7042,7 +7042,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7335,7 +7335,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7389,7 +7389,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -3312,7 +3312,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6579,7 +6579,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6681,7 +6681,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6790,7 +6790,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6858,7 +6858,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6927,7 +6927,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6946,7 +6946,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7042,7 +7042,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7335,7 +7335,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7389,7 +7389,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3404,7 +3404,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6457,7 +6457,7 @@ spec:
             value: http://union-operator-prometheus:80
           - name: KNATIVE_PROXY_SERVICE_URL
             value: http://kourier-internal
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           name: sync-cluster-resources
           resources:
@@ -6712,7 +6712,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6813,7 +6813,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6923,7 +6923,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6991,7 +6991,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7059,7 +7059,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7078,7 +7078,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7173,7 +7173,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7452,7 +7452,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7506,7 +7506,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -3262,7 +3262,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6528,7 +6528,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6629,7 +6629,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6737,7 +6737,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6805,7 +6805,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6873,7 +6873,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6892,7 +6892,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6987,7 +6987,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7280,7 +7280,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7334,7 +7334,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3387,7 +3387,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6859,7 +6859,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6960,7 +6960,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -7068,7 +7068,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7136,7 +7136,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7204,7 +7204,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7223,7 +7223,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7318,7 +7318,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7643,7 +7643,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7697,7 +7697,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -3267,7 +3267,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6527,7 +6527,7 @@ spec:
             name: leaseworker
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6618,7 +6618,7 @@ spec:
             name: executor
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6719,7 +6719,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6824,7 +6824,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6841,7 +6841,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6936,7 +6936,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7353,7 +7353,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7407,7 +7407,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -3260,7 +3260,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6526,7 +6526,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6627,7 +6627,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6735,7 +6735,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6803,7 +6803,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6871,7 +6871,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6890,7 +6890,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6985,7 +6985,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7278,7 +7278,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7332,7 +7332,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -3285,7 +3285,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6551,7 +6551,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6652,7 +6652,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6760,7 +6760,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6828,7 +6828,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6896,7 +6896,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6915,7 +6915,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7010,7 +7010,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7303,7 +7303,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7357,7 +7357,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -4090,7 +4090,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -8665,7 +8665,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -8766,7 +8766,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -8874,7 +8874,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -8942,7 +8942,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -9010,7 +9010,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -9029,7 +9029,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -9124,7 +9124,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -13896,7 +13896,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -13950,7 +13950,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -3280,7 +3280,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -5962,7 +5962,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6678,7 +6678,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6779,7 +6779,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6887,7 +6887,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6955,7 +6955,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -7023,7 +7023,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -7042,7 +7042,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7137,7 +7137,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7430,7 +7430,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7484,7 +7484,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3300,7 +3300,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6572,7 +6572,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6686,7 +6686,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6807,7 +6807,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6881,7 +6881,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6956,7 +6956,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6975,7 +6975,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -7083,7 +7083,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7389,7 +7389,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7443,7 +7443,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -3269,7 +3269,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   allow-snippet-annotations: "false"
@@ -6535,7 +6535,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: leaseworker
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - leaseworker
@@ -6636,7 +6636,7 @@ spec:
             secretName: union-secret-auth
       containers:
         - name: executor
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           command:
             - executorv2
@@ -6744,7 +6744,7 @@ spec:
         - name: operator-proxy
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6812,7 +6812,7 @@ spec:
         - name: "tunnel"
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - cloudflared
@@ -6880,7 +6880,7 @@ spec:
         - name: operator
           securityContext:
             {}
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
@@ -6899,7 +6899,7 @@ spec:
             - name: HELM_CHART_VERSION
               value: "2026.6.9"
             - name: HELM_APP_VERSION
-              value: "2026.6.9"
+              value: "2026.6.10-alpha.0"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -6994,7 +6994,7 @@ spec:
       serviceAccountName: union-system
       containers:
         - name: webhook
-          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.9"
+          image: "public.ecr.aws/p0i0a9q8/unionoperator:2026.6.10-alpha.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - flytepropeller
@@ -7287,7 +7287,7 @@ metadata:
     helm.sh/chart: dataplane-2026.6.9
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2026.6.9"
+    app.kubernetes.io/version: "2026.6.10-alpha.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: serving
 spec:
@@ -7341,7 +7341,7 @@ spec:
       helm.sh/chart: dataplane-2026.6.9
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
-      app.kubernetes.io/version: "2026.6.9"
+      app.kubernetes.io/version: "2026.6.10-alpha.0"
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/component: 3scale-kourier-gateway
     affinity:


### PR DESCRIPTION
## Overview

Adds dataplane chart support for operator self-reported connection config: a `_connection.tpl` helper, an operator connection ConfigMap + mount, and `updateStatus.connectionConfig` values. Removes the controlplane `DATAPLANE_HOST` / `DATAPLANE_ENDPOINT` globals (and their consumer) now that dataplanes self-report their endpoint, and adds leasor `queueSync.queues` template support for multi-dataplane routing.

## Test Plan

`make test` (snapshot + kubeconform) passes.

## Rollout Plan

Merge alongside the corresponding cloud control-plane/dataplane change.

## Rollback Plan

Revert.

- `main` <!-- branch-stack -->
  - **dataplane: operator self-reported connection config + controlplane endpoint-global cleanup** :point\_left:
    - \#456
