### PR TITLE
Add tag-triggered alpha/beta pre-release channel for charts

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,83 @@
+name: prerelease
+
+# Cut an alpha/beta (pre-release) chart by pushing a tag named
+# <chart>-<version>, where <version> carries a SemVer-2 pre-release suffix, e.g.
+#
+#   charts/controlplane/Chart.yaml: version: 2026.6.10-beta.0
+#   git tag controlplane-2026.6.10-beta.0   # tag the commit holding that bump
+#   git push origin controlplane-2026.6.10-beta.0
+#
+# The pre-release is published to the SAME gh-pages Helm repo as stable charts
+# but flagged a GitHub pre-release and never marked "latest", so it does not
+# displace the stable channel. Consumers opt in explicitly:
+#
+#   helm repo add union https://unionai.github.io/helm-charts
+#   helm repo update
+#   helm pull union/controlplane --devel            # newest incl. pre-releases
+#   helm pull union/controlplane --version 2026.6.10-beta.0
+#
+# This is the pre-release counterpart of release.yaml (which fires on Chart.yaml
+# changes merged to main and produces the stable channel).
+on:
+  push:
+    tags:
+      - '*-alpha.*'
+      - '*-beta.*'
+
+jobs:
+  prerelease:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # checkout resolves to the tagged commit, so chart-releaser packages
+          # the Chart.yaml versions captured by the tag.
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # Record every tag EXCEPT the one that triggered this run, so the notes
+      # script (which skips tags present in EXISTING_TAGS) annotates only the new
+      # pre-release. Unlike release.yaml — where chart-releaser creates the tags,
+      # so they are genuinely "new" — our trigger tag already exists because we
+      # pushed it, so it must be excluded explicitly.
+      - name: Record existing tags
+        id: existing-tags
+        run: echo "tags=$(git tag -l | grep -vx "${GITHUB_REF_NAME}" | tr '\n' ',')" >> "$GITHUB_OUTPUT"
+
+      # chart-releaser packages every chart under charts/ at its Chart.yaml
+      # version and skips ones already released (skip_existing). On a pre-release
+      # tag the only un-released version is the one just bumped, so only it is
+      # published. mark_as_latest: false guarantees a pre-release never displaces
+      # the stable channel — consumers reach it only via --devel or an exact
+      # --version pin.
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: charts
+          skip_existing: true
+          mark_as_latest: false
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # chart-releaser names the GitHub release after the pushed tag
+      # (<chart>-<version>). Flag it as a pre-release so it is excluded from
+      # "latest" everywhere and surfaced as a pre-release in the UI/API.
+      - name: Flag GitHub release as pre-release
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: gh release edit "${GITHUB_REF_NAME}" --prerelease --latest=false
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          EXISTING_TAGS: "${{ steps.existing-tags.outputs.tags }}"
+        run: |
+          git fetch --tags
+          ./scripts/generate-release-notes.sh --publish

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Helm charts for deploying Union.ai onto Kubernetes:
 - [`charts/CONVENTIONS.md`](./charts/CONVENTIONS.md) — overlay file naming, what's actively tested vs. an example.
 - [`charts/MIGRATION.md`](./charts/MIGRATION.md) — recent breaking-ish chart changes and how to migrate.
 
+## Releasing
+
+- [`RELEASING.md`](./RELEASING.md) — stable releases (merge to `main`) and alpha/beta pre-releases (tag push), versioning, and how to consume each.
+
 ## Local development
 
 Sample Terraform configurations for spinning up substrate to test against live in [`providers/`](./providers).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing charts
+
+This repo publishes charts to a Helm repository hosted on the `gh-pages` branch
+(`https://unionai.github.io/helm-charts`). There are two channels:
+
+| Channel | Workflow | Trigger | Marked "latest"? |
+|---------|----------|---------|------------------|
+| **Stable** | `.github/workflows/release.yaml` | a `charts/*/Chart.yaml` version change merged to `main` | yes |
+| **Pre-release** (alpha/beta) | `.github/workflows/prerelease.yaml` | pushing a tag `<chart>-<version>` whose version has a SemVer pre-release suffix | no |
+
+Both run [`chart-releaser`](https://github.com/helm/chart-releaser-action): it
+packages each chart at its `Chart.yaml` `version:`, creates a GitHub Release +
+tag (`<chart>-<version>`), and updates the shared Helm repo index. `skip_existing`
+means only versions that aren't already released are published.
+
+## Versioning
+
+Stable charts use CalVer: `YYYY.M.PATCH`, e.g. `2026.6.9` — **no hyphen**.
+
+A pre-release adds a SemVer-2 pre-release suffix to the *next* version:
+`2026.6.10-alpha.0`, `2026.6.10-beta.1`. Helm sorts these below the
+corresponding stable version and hides them from `helm pull` / `dependency
+update` unless `--devel` is passed or the exact version is pinned.
+
+## Cut a stable release
+
+1. Bump the chart's `version:` in `charts/<chart>/Chart.yaml` (and regenerate
+   snapshots: `make generate-expected`).
+2. Open a PR and merge to `main`.
+3. `release.yaml` publishes the chart and marks it latest.
+
+## Cut a pre-release (alpha/beta)
+
+Pre-releases are cut from a **tag**, not from `main` — so you can publish an
+alpha/beta from a feature branch without touching the stable channel.
+
+```bash
+# 1. On your branch, set the pre-release version in the chart you're releasing:
+#      charts/controlplane/Chart.yaml:  version: 2026.6.10-beta.0
+git commit -am "controlplane 2026.6.10-beta.0"
+
+# 2. Tag that commit <chart>-<version> and push the tag:
+git tag controlplane-2026.6.10-beta.0
+git push origin controlplane-2026.6.10-beta.0
+```
+
+`prerelease.yaml` packages the chart at the tagged commit, publishes a GitHub
+**pre-release** (never "latest"), and adds it to the Helm repo index. Bump the
+suffix (`-beta.1`, `-beta.2`, …) for each iteration.
+
+### Consuming a pre-release
+
+```bash
+helm repo add union https://unionai.github.io/helm-charts
+helm repo update
+helm pull union/controlplane --devel                    # newest, including pre-releases
+helm pull union/controlplane --version 2026.6.10-beta.0  # an exact pre-release
+```
+
+> Note: selfhosted/managed deployments pin this repo by **git ref** (via
+> `revisions.yaml` in `unionai/cloud`), not by the Helm repo index — so for those
+> consumers a pre-release tag is mainly a stable, named point to pin against.
+
+## Promoting a pre-release to stable
+
+When the pre-release is good, **drop the suffix** before merging to `main`:
+set the version to the final `2026.6.10` (no `-beta`), then follow
+[Cut a stable release](#cut-a-stable-release).
+
+> ⚠️ **Never merge a `-alpha`/`-beta` version into `main`.** `release.yaml`
+> fires on any `Chart.yaml` change to `main` and would publish that pre-release
+> on the **stable, latest** channel. Always promote by removing the suffix first.


### PR DESCRIPTION
## Overview

Adds an alpha/beta pre-release channel. A pre-release is cut by pushing a tag `<chart>-<version>` whose version carries a SemVer pre-release suffix (e.g. `controlplane-2026.6.10-beta.0`). `prerelease.yaml` packages that chart at the tagged commit, publishes a GitHub **pre-release** (never marked "latest") to the same gh-pages Helm repo, and indexes it. Consumers opt in with `helm pull --devel` or an exact `--version` pin; the stable channel is untouched.

Mirrors the existing `release.yaml` machinery (`chart-releaser`) with `mark_as_latest: false` + an explicit prerelease flag. `RELEASING.md` (new) documents both channels — stable via `main`, pre-release via tag — plus versioning, consumption, and promotion.

## Test plan

- `prerelease.yaml` YAML validated locally. The first real tag push should be checked to confirm the GitHub pre-release and the gh-pages index entry both land (chart-releaser references the pushed tag rather than creating it).

## Rollout / Rollback

Additive — a new workflow + docs only; no change to the existing stable `release.yaml`. Rollback = revert.

## Follow-up (not in this PR)

Optionally harden `release.yaml` to fail fast if a pre-release version reaches `main`. Until then, `RELEASING.md` documents the "drop the `-beta` suffix before merging" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)