### PR TITLE
dataplane: gate self-reported connection_config behind opt-in flag

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,7 +3,7 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.10-alpha.0
+version: 2026.6.10-alpha.1
 appVersion: 2026.6.10-alpha.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -10,7 +10,7 @@ description: 'DEPRECATED. Use `crds/flyte-v1/` for FlyteWorkflow and `crds/kube-
 deprecated: true
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.9
+version: 2026.6.10-alpha.0
 appVersion: 2026.6.9
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.10-alpha.0
+version: 2026.6.10-alpha.1
 appVersion: 2026.6.10-alpha.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane/templates/_connection.tpl
+++ b/charts/dataplane/templates/_connection.tpl
@@ -46,6 +46,10 @@ JSON file at startup and ships it on every UpdateStatus so the CP can
 dial back without anyone having to admin-set DataplaneIngressURL.
 
 Override surface (.Values.updateStatus.connectionConfig):
+  enabled             opt in to self-reporting. Off by default so the chart
+                      stays compatible with operator images that predate the
+                      connection_config support — they receive no config key,
+                      ConfigMap, or mount they can't consume.
   host                bare DP-reachable hostname (no scheme, no port).
                       Empty falls back to .Values.ingress.host — the
                       dataplane's own ingress hostname — so most installs
@@ -56,6 +60,11 @@ Override surface (.Values.updateStatus.connectionConfig):
 dataplane.dp.endpoint formats host as `dns:///<host>:443` — the same
 scheme used for CP→DP DP→CP and CP-to-DP gRPC dials elsewhere in the
 chart. Empty host returns empty string; callers gate emission on this.
+
+dataplane.connectionConfig.emit is the single gate every consumer keys off:
+it returns the resolved host only when self-reporting is both enabled and
+resolvable, empty otherwise — so an opt-out or missing host renders no
+connection_config resource, config key, volume, or mount.
 */}}
 
 {{- define "dataplane.dp.host" -}}
@@ -67,4 +76,10 @@ chart. Empty host returns empty string; callers gate emission on this.
 {{- define "dataplane.dp.endpoint" -}}
 {{- $host := include "dataplane.dp.host" . -}}
 {{- if $host -}}{{- printf "dns:///%s:443" $host -}}{{- end -}}
+{{- end -}}
+
+{{- define "dataplane.connectionConfig.emit" -}}
+{{- if .Values.updateStatus.connectionConfig.enabled -}}
+{{- include "dataplane.dp.host" . -}}
+{{- end -}}
 {{- end -}}

--- a/charts/dataplane/templates/operator/configmap-connection.yaml
+++ b/charts/dataplane/templates/operator/configmap-connection.yaml
@@ -1,13 +1,14 @@
-{{- if include "dataplane.dp.host" . }}
+{{- if include "dataplane.connectionConfig.emit" . }}
 {{/*
 ConfigMap rendering the DP's self-reported connection_config as a JSON
 file the operator reads at startup and ships in every UpdateStatus to
 the controlplane (UpdateStatusRequest.connection_config). The CP prefers
 this over the legacy admin-set DataplaneIngressURL when present.
 
-Gated on .Values.updateStatus.connectionConfig.host being non-empty so
-charts consumed by envs that don't set it (BYOC, self-managed, legacy
-selfhosted with admin-set URL) emit no resource.
+Gated on .Values.updateStatus.connectionConfig.enabled (default false) so
+charts consumed by envs that don't opt in, or by operator images that
+predate connection_config support (BYOC, self-managed, legacy selfhosted
+with admin-set URL), emit no resource.
 */}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/dataplane/templates/operator/configmap.yaml
+++ b/charts/dataplane/templates/operator/configmap.yaml
@@ -27,7 +27,7 @@ data:
     operator:
       enabled: {{ .Values.config.operator.enabled }}
       enableTunnelService: {{ .Values.config.operator.enableTunnelService }}
-      {{- if include "dataplane.dp.host" . }}
+      {{- if include "dataplane.connectionConfig.emit" . }}
       # Path to the chart-rendered connection_config JSON the operator
       # self-reports on every UpdateStatus call. Empty path = disabled.
       connectionConfigPath: /etc/union/connection-config/connection_config.json

--- a/charts/dataplane/templates/operator/deployment.yaml
+++ b/charts/dataplane/templates/operator/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           secret:
             secretName: {{ .Values.operator.secretName }}
         {{- end }}
-        {{- if include "dataplane.dp.host" . }}
+        {{- if include "dataplane.connectionConfig.emit" . }}
         - name: connection-config-volume
           configMap:
             name: {{ include "union-operator.fullname" . }}-connection
@@ -65,7 +65,7 @@ spec:
             - mountPath: /etc/union/secret
               name: secret-volume
             {{- end }}
-            {{- if include "dataplane.dp.host" . }}
+            {{- if include "dataplane.connectionConfig.emit" . }}
             - mountPath: /etc/union/connection-config
               name: connection-config-volume
               readOnly: true

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -41,9 +41,14 @@ orgName: "{{ .Values.global.ORG_NAME }}"
 # -- Self-reported CP-client-construction data the operator ships in every
 # UpdateStatus call (UpdateStatusRequest.connection_config). The controlplane
 # prefers this over the legacy admin-set DataplaneIngressURL when present.
-# Empty host disables self-reporting; CP falls back to the legacy URL.
 updateStatus:
   connectionConfig:
+    # -- Opt in to self-reporting. Off by default: the connection_config
+    # ConfigMap, operator `connectionConfigPath`, volume, and mount only
+    # render when this is true, keeping the chart compatible with operator
+    # images that predate connection_config support. Enable only when the
+    # deployed operator image understands `connectionConfigPath`.
+    enabled: false
     # -- DP-reachable hostname the CP should dial back. e.g.
     # "dp-1.internal.<full_domain>". Bare hostname only — no scheme, no port.
     # Chart helper derives the gRPC endpoint as `dns:///<host>:443`.

--- a/charts/knative-migration/Chart.yaml
+++ b/charts/knative-migration/Chart.yaml
@@ -13,6 +13,6 @@ description: 'One-shot cleanup of knative-operator residue (stuck KnativeServing
   '
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.9
+version: 2026.6.10-alpha.0
 appVersion: 0.1.0
 kubeVersion: '>= 1.28.0-0'

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.6.9
+version: 2026.6.10-alpha.0
 appVersion: 2026.6.9
 kubeVersion: '>= 1.28.0'

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -257,7 +257,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -519,7 +519,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -622,7 +622,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -696,7 +696,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1385,7 +1385,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1419,7 +1419,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1774,7 +1774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1842,7 +1842,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1941,7 +1941,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2032,7 +2032,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2224,7 +2224,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2340,7 +2340,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2424,7 +2424,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2515,7 +2515,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2599,7 +2599,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2684,7 +2684,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2879,7 +2879,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2895,7 +2895,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8194,7 +8194,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8217,7 +8217,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8270,7 +8270,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8294,7 +8294,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8457,7 +8457,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8491,7 +8491,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8528,7 +8528,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8565,7 +8565,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8602,7 +8602,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8639,7 +8639,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8676,7 +8676,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8713,7 +8713,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8750,7 +8750,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8787,7 +8787,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8824,7 +8824,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8864,7 +8864,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8892,7 +8892,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8921,7 +8921,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8960,7 +8960,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8999,7 +8999,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9034,7 +9034,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9069,7 +9069,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9104,7 +9104,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9139,7 +9139,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9178,7 +9178,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9213,7 +9213,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9248,7 +9248,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9799,7 +9799,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9983,7 +9983,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10167,7 +10167,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10351,7 +10351,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10535,7 +10535,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10719,7 +10719,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10903,7 +10903,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11087,7 +11087,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11271,7 +11271,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11455,7 +11455,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11640,7 +11640,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11658,9 +11658,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: f655b7723fd783635d75faa558a8583f3502a9730d2a2f75536daae12925020b
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 37a829d48ac9d6c79cf210c7ae3dbe347038820bf08becc31522f6152b2896aa
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11769,7 +11769,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11780,7 +11780,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f90833ad968e05cf1eed9ca9f151c9ca97764cc3823bed45e1c809764e1adb"
+        configChecksum: "c61d64da6ce1f679fdd9bea5a856dadedc4aca08abd7411c1974365336f0844"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11789,7 +11789,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11882,7 +11882,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11953,7 +11953,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12068,7 +12068,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12199,7 +12199,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12311,7 +12311,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12439,7 +12439,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12554,7 +12554,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12680,7 +12680,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12827,7 +12827,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12956,7 +12956,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13085,7 +13085,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13235,7 +13235,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -137,7 +137,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -161,7 +161,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -197,7 +197,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -209,7 +209,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -259,7 +259,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -521,7 +521,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -624,7 +624,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -698,7 +698,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1387,7 +1387,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1421,7 +1421,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1756,7 +1756,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1824,7 +1824,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1923,7 +1923,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2014,7 +2014,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2206,7 +2206,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2321,7 +2321,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2405,7 +2405,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2496,7 +2496,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2580,7 +2580,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2665,7 +2665,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2860,7 +2860,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2876,7 +2876,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8175,7 +8175,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8198,7 +8198,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8251,7 +8251,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8275,7 +8275,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8438,7 +8438,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8472,7 +8472,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8509,7 +8509,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8546,7 +8546,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8583,7 +8583,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8620,7 +8620,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8657,7 +8657,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8694,7 +8694,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8731,7 +8731,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8768,7 +8768,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8805,7 +8805,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8845,7 +8845,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8873,7 +8873,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8902,7 +8902,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8941,7 +8941,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8980,7 +8980,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9015,7 +9015,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9050,7 +9050,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9085,7 +9085,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9120,7 +9120,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9159,7 +9159,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9194,7 +9194,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9229,7 +9229,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9780,7 +9780,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9964,7 +9964,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10148,7 +10148,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10332,7 +10332,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10516,7 +10516,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10700,7 +10700,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10884,7 +10884,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11068,7 +11068,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11252,7 +11252,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11436,7 +11436,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11621,7 +11621,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11639,9 +11639,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: b1ac52906e5b5ad5723dcec9b60e147c568086ec28c7242d569403678335da97
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 2ede0a1900900b0961bb240817119e87250869f7996039a5bde539d2e413baac
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11750,7 +11750,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11761,7 +11761,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f90833ad968e05cf1eed9ca9f151c9ca97764cc3823bed45e1c809764e1adb"
+        configChecksum: "c61d64da6ce1f679fdd9bea5a856dadedc4aca08abd7411c1974365336f0844"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11770,7 +11770,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11863,7 +11863,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11934,7 +11934,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12049,7 +12049,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12180,7 +12180,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12292,7 +12292,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12420,7 +12420,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12535,7 +12535,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12661,7 +12661,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12808,7 +12808,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12937,7 +12937,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13066,7 +13066,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13216,7 +13216,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -137,7 +137,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -161,7 +161,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -197,7 +197,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -209,7 +209,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -259,7 +259,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -521,7 +521,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -624,7 +624,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -698,7 +698,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1387,7 +1387,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1421,7 +1421,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1776,7 +1776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1844,7 +1844,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1943,7 +1943,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2034,7 +2034,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2226,7 +2226,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2341,7 +2341,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2425,7 +2425,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2516,7 +2516,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2600,7 +2600,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2685,7 +2685,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2880,7 +2880,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2896,7 +2896,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8195,7 +8195,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8218,7 +8218,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8271,7 +8271,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8295,7 +8295,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8458,7 +8458,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8492,7 +8492,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8529,7 +8529,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8566,7 +8566,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8603,7 +8603,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8640,7 +8640,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8677,7 +8677,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8714,7 +8714,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8751,7 +8751,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8788,7 +8788,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8825,7 +8825,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8865,7 +8865,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8893,7 +8893,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8922,7 +8922,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8961,7 +8961,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9000,7 +9000,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9035,7 +9035,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9070,7 +9070,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9105,7 +9105,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9140,7 +9140,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9179,7 +9179,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9214,7 +9214,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9249,7 +9249,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9800,7 +9800,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9984,7 +9984,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10168,7 +10168,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10352,7 +10352,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10536,7 +10536,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10720,7 +10720,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10904,7 +10904,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11088,7 +11088,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11272,7 +11272,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11456,7 +11456,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11641,7 +11641,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11659,9 +11659,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: f655b7723fd783635d75faa558a8583f3502a9730d2a2f75536daae12925020b
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 37a829d48ac9d6c79cf210c7ae3dbe347038820bf08becc31522f6152b2896aa
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11770,7 +11770,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11781,7 +11781,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f90833ad968e05cf1eed9ca9f151c9ca97764cc3823bed45e1c809764e1adb"
+        configChecksum: "c61d64da6ce1f679fdd9bea5a856dadedc4aca08abd7411c1974365336f0844"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11791,7 +11791,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11884,7 +11884,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11956,7 +11956,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12072,7 +12072,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12204,7 +12204,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12317,7 +12317,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12446,7 +12446,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12562,7 +12562,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12689,7 +12689,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12837,7 +12837,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12967,7 +12967,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13097,7 +13097,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13242,7 +13242,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -125,7 +125,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -163,7 +163,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -175,7 +175,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -187,7 +187,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -199,7 +199,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -223,7 +223,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -235,7 +235,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -247,7 +247,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -261,7 +261,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -531,7 +531,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -634,7 +634,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -708,7 +708,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1397,7 +1397,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1431,7 +1431,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1786,7 +1786,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1859,7 +1859,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1958,7 +1958,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2049,7 +2049,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2241,7 +2241,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2356,7 +2356,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2445,7 +2445,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2536,7 +2536,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2620,7 +2620,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2705,7 +2705,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2900,7 +2900,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2916,7 +2916,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8218,7 +8218,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8241,7 +8241,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8294,7 +8294,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8318,7 +8318,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8481,7 +8481,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8515,7 +8515,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8552,7 +8552,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8589,7 +8589,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8626,7 +8626,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8663,7 +8663,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8700,7 +8700,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8737,7 +8737,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8774,7 +8774,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8811,7 +8811,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8848,7 +8848,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8888,7 +8888,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8916,7 +8916,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8945,7 +8945,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8984,7 +8984,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9023,7 +9023,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9058,7 +9058,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9093,7 +9093,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9128,7 +9128,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9163,7 +9163,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9202,7 +9202,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9237,7 +9237,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9272,7 +9272,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9823,7 +9823,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10007,7 +10007,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10191,7 +10191,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10375,7 +10375,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10559,7 +10559,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10743,7 +10743,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10927,7 +10927,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11111,7 +11111,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11295,7 +11295,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11479,7 +11479,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11664,7 +11664,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11682,9 +11682,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: f655b7723fd783635d75faa558a8583f3502a9730d2a2f75536daae12925020b
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 37a829d48ac9d6c79cf210c7ae3dbe347038820bf08becc31522f6152b2896aa
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11793,7 +11793,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11804,7 +11804,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0c981b355bce6acb72b104243ed86c6992351df7bb13b9f5fa4ec3a55757322"
+        configChecksum: "07a80be539436df2720b2ab6683781c0f8cb2dc06206b681fd36141f13503cd"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11813,7 +11813,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11906,7 +11906,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11977,7 +11977,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12092,7 +12092,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12223,7 +12223,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12335,7 +12335,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12463,7 +12463,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12589,7 +12589,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12715,7 +12715,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12862,7 +12862,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12991,7 +12991,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13120,7 +13120,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13270,7 +13270,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -257,7 +257,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -522,7 +522,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -625,7 +625,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -699,7 +699,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1388,7 +1388,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1422,7 +1422,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1757,7 +1757,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1825,7 +1825,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1928,7 +1928,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2019,7 +2019,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2211,7 +2211,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2326,7 +2326,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2410,7 +2410,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2501,7 +2501,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2585,7 +2585,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2670,7 +2670,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2865,7 +2865,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2881,7 +2881,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8180,7 +8180,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8203,7 +8203,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8256,7 +8256,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8280,7 +8280,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8443,7 +8443,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8477,7 +8477,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8514,7 +8514,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8551,7 +8551,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8588,7 +8588,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8625,7 +8625,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8662,7 +8662,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8699,7 +8699,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8736,7 +8736,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8773,7 +8773,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8810,7 +8810,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8850,7 +8850,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8878,7 +8878,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8907,7 +8907,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8946,7 +8946,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8985,7 +8985,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9020,7 +9020,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9055,7 +9055,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9090,7 +9090,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9125,7 +9125,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9164,7 +9164,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9199,7 +9199,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9234,7 +9234,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9785,7 +9785,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9969,7 +9969,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10153,7 +10153,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10337,7 +10337,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10521,7 +10521,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10705,7 +10705,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10889,7 +10889,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11073,7 +11073,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11257,7 +11257,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11441,7 +11441,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11626,7 +11626,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11644,9 +11644,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: b1ac52906e5b5ad5723dcec9b60e147c568086ec28c7242d569403678335da97
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 2ede0a1900900b0961bb240817119e87250869f7996039a5bde539d2e413baac
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11755,7 +11755,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11766,7 +11766,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5a0b23d0e0493d32008f7fa47454d7043e39c423669f8c8cac3fb0f7f024ae0"
+        configChecksum: "f2c9f35e9830078a420eb6eebb04f16486e9965078e64122ccff6bb70711301"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11775,7 +11775,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11868,7 +11868,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11939,7 +11939,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12054,7 +12054,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12185,7 +12185,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12297,7 +12297,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12425,7 +12425,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12540,7 +12540,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12666,7 +12666,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12813,7 +12813,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12942,7 +12942,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13071,7 +13071,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13221,7 +13221,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -257,7 +257,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -519,7 +519,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -622,7 +622,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -696,7 +696,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1385,7 +1385,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1419,7 +1419,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1754,7 +1754,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1822,7 +1822,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1921,7 +1921,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2012,7 +2012,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2204,7 +2204,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2319,7 +2319,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2403,7 +2403,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2494,7 +2494,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2578,7 +2578,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2663,7 +2663,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2858,7 +2858,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2874,7 +2874,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8173,7 +8173,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8196,7 +8196,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8249,7 +8249,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8273,7 +8273,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8436,7 +8436,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8470,7 +8470,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8507,7 +8507,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8544,7 +8544,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8581,7 +8581,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8618,7 +8618,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8655,7 +8655,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8692,7 +8692,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8729,7 +8729,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8766,7 +8766,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8803,7 +8803,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8843,7 +8843,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8871,7 +8871,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8900,7 +8900,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8939,7 +8939,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8978,7 +8978,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9013,7 +9013,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9048,7 +9048,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9083,7 +9083,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9118,7 +9118,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9157,7 +9157,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9192,7 +9192,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9227,7 +9227,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9778,7 +9778,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9962,7 +9962,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10146,7 +10146,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10330,7 +10330,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10514,7 +10514,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10698,7 +10698,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10882,7 +10882,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11066,7 +11066,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11250,7 +11250,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11434,7 +11434,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11619,7 +11619,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11637,9 +11637,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: b1ac52906e5b5ad5723dcec9b60e147c568086ec28c7242d569403678335da97
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 2ede0a1900900b0961bb240817119e87250869f7996039a5bde539d2e413baac
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11748,7 +11748,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11759,7 +11759,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f90833ad968e05cf1eed9ca9f151c9ca97764cc3823bed45e1c809764e1adb"
+        configChecksum: "c61d64da6ce1f679fdd9bea5a856dadedc4aca08abd7411c1974365336f0844"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11768,7 +11768,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11861,7 +11861,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11932,7 +11932,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12047,7 +12047,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12178,7 +12178,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12290,7 +12290,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12418,7 +12418,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12533,7 +12533,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12659,7 +12659,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12806,7 +12806,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12935,7 +12935,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13064,7 +13064,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13214,7 +13214,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -39,7 +39,7 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -114,7 +114,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -127,7 +127,7 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -143,7 +143,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -155,7 +155,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -169,7 +169,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -181,7 +181,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -205,7 +205,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -217,7 +217,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -229,7 +229,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -241,7 +241,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -277,7 +277,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -291,7 +291,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -553,7 +553,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -656,7 +656,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -730,7 +730,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1419,7 +1419,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1453,7 +1453,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1805,7 +1805,7 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -1855,7 +1855,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1923,7 +1923,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2034,7 +2034,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2125,7 +2125,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2317,7 +2317,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2432,7 +2432,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2516,7 +2516,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2607,7 +2607,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2691,7 +2691,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2776,7 +2776,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -2971,7 +2971,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2987,7 +2987,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8286,7 +8286,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8306,7 +8306,7 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8325,7 +8325,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8378,7 +8378,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8399,7 +8399,7 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8423,7 +8423,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8586,7 +8586,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8620,7 +8620,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8657,7 +8657,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8694,7 +8694,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8731,7 +8731,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8768,7 +8768,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8805,7 +8805,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8842,7 +8842,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8879,7 +8879,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8916,7 +8916,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8953,7 +8953,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -8989,7 +8989,7 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9016,7 +9016,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9044,7 +9044,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9073,7 +9073,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9112,7 +9112,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9151,7 +9151,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9186,7 +9186,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9221,7 +9221,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9256,7 +9256,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9291,7 +9291,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9330,7 +9330,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9365,7 +9365,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9400,7 +9400,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9951,7 +9951,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10135,7 +10135,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10319,7 +10319,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10503,7 +10503,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10687,7 +10687,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -10871,7 +10871,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11055,7 +11055,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11239,7 +11239,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11423,7 +11423,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11607,7 +11607,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11792,7 +11792,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11810,9 +11810,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 09b8aab42baf254680a1080c62af64628a5402eb96faf81b330ff16bf986f073
-        checksum/router-cds: 4c63206defad5b93addc0ef893e74010dc9c1d1f3cf8167280eb4740716ad267
-        checksum/router-lds: f655b7723fd783635d75faa558a8583f3502a9730d2a2f75536daae12925020b
+        checksum/router-bootstrap: 57d2a8605cddb6e5d2749c78a12c50ade35cb71752713cea697334d5668328fa
+        checksum/router-cds: ac18a086fdc26d8f6035e6b16b3686c9cee9cfdcfd54f5815648e1b276da9564
+        checksum/router-lds: 37a829d48ac9d6c79cf210c7ae3dbe347038820bf08becc31522f6152b2896aa
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11918,7 +11918,7 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -11936,7 +11936,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 96305a86be5b0a0c799c48b15203d042c265d0a8423b5f0d69da60d4be10852b
+        checksum/config: dcef4429b016a1e81113f7c61cfc862b4d751d84317dd6029d6f3f31adda8ab7
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -12038,7 +12038,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12049,7 +12049,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f90833ad968e05cf1eed9ca9f151c9ca97764cc3823bed45e1c809764e1adb"
+        configChecksum: "c61d64da6ce1f679fdd9bea5a856dadedc4aca08abd7411c1974365336f0844"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -12058,7 +12058,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.6.10-alpha.0
+        helm.sh/chart: controlplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12151,7 +12151,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12222,7 +12222,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12337,7 +12337,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12468,7 +12468,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12580,7 +12580,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12708,7 +12708,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12823,7 +12823,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -12949,7 +12949,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13096,7 +13096,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13225,7 +13225,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13354,7 +13354,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13498,7 +13498,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13525,7 +13525,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.6.10-alpha.0
+    helm.sh/chart: controlplane-2026.6.10-alpha.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -3242,7 +3242,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6881,7 +6881,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7270,7 +7270,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7324,7 +7324,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -3274,7 +3274,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6905,7 +6905,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7292,7 +7292,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7346,7 +7346,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3442,7 +3442,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7411,7 +7411,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7887,7 +7887,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7941,7 +7941,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -3099,6 +3099,26 @@ data:
         target_gc_percent: 70
 
 ---
+# Source: dataplane/templates/operator/configmap-connection.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: union-operator-connection
+  namespace: union
+  labels:
+    app.kubernetes.io/name: union-operator
+    app.kubernetes.io/instance: release-name
+    platform.union.ai/service-group: release-name
+    app.kubernetes.io/managed-by: Helm
+data:
+  connection_config.json: |
+    {
+      "endpoint": "dns:///dp-1.internal.union.us-west-2.union.ai:443",
+      "insecure": false,
+      "insecureSkipVerify": true
+    }
+
+---
 # Source: dataplane/templates/operator/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -3143,6 +3163,9 @@ data:
     operator:
       enabled: true
       enableTunnelService: true
+      # Path to the chart-rendered connection_config JSON the operator
+      # self-reports on every UpdateStatus call. Empty path = disabled.
+      connectionConfigPath: /etc/union/connection-config/connection_config.json
       #  enableDepot: false
       tunnel:
         enableDirectToAppIngress: true
@@ -3242,7 +3265,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6695,7 +6718,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7df80a19e1bdea109453565aa6e74fc792f56f3f580fa44b3b88b343691d1dd"
+        configChecksum: "48360f3798dd3cc41b39c51dd5a0810566bb48849a15c47927e47a6aa775d87"
         
       labels:
         
@@ -6833,7 +6856,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7df80a19e1bdea109453565aa6e74fc792f56f3f580fa44b3b88b343691d1dd"
+        configChecksum: "48360f3798dd3cc41b39c51dd5a0810566bb48849a15c47927e47a6aa775d87"
         
       labels:
         
@@ -6852,6 +6875,9 @@ spec:
         - name: secret-volume
           secret:
             secretName: union-secret-auth
+        - name: connection-config-volume
+          configMap:
+            name: union-operator-connection
       containers:
         - name: operator
           securityContext:
@@ -6871,9 +6897,12 @@ spec:
               name: config-volume
             - mountPath: /etc/union/secret
               name: secret-volume
+            - mountPath: /etc/union/connection-config
+              name: connection-config-volume
+              readOnly: true
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7091,7 +7120,7 @@ spec:
             name: kourier-internal
             port:
               number: 80
-    host: "*.apps."
+    host: "*.apps.dp-1.internal.union.us-west-2.union.ai"
 ---
 # Source: dataplane/templates/common/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -7190,6 +7219,7 @@ spec:
                 name: union-operator-proxy
                 port:
                   number: 8080
+      host: dp-1.internal.union.us-west-2.union.ai
 
 ---
 # Source: dataplane/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -7381,7 +7411,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7435,7 +7465,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -3369,7 +3369,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7338,7 +7338,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7757,7 +7757,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7811,7 +7811,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -131,7 +131,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -160,7 +160,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -174,7 +174,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -212,7 +212,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -410,7 +410,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -689,7 +689,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -904,7 +904,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -978,7 +978,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1138,7 +1138,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1277,7 +1277,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1346,7 +1346,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1606,7 +1606,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1710,7 +1710,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1798,7 +1798,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1864,7 +1864,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1949,7 +1949,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2159,7 +2159,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2283,7 +2283,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5318,7 +5318,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -5917,7 +5917,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5950,7 +5950,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5987,7 +5987,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6003,7 +6003,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6044,7 +6044,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6064,7 +6064,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6084,7 +6084,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6115,7 +6115,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6183,7 +6183,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6208,7 +6208,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6266,7 +6266,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6288,7 +6288,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6309,7 +6309,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6330,7 +6330,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6482,7 +6482,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6920,7 +6920,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7326,7 +7326,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7361,7 +7361,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7388,7 +7388,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7418,7 +7418,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7448,7 +7448,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7477,7 +7477,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7501,7 +7501,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7528,7 +7528,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8603,7 +8603,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8732,7 +8732,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8836,7 +8836,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8949,7 +8949,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9048,7 +9048,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -9064,7 +9064,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.6.10-alpha.0
+        helm.sh/chart: dataplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -9075,7 +9075,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 6ef40ce5809331adc67f6e6bfe729701ff4e607601e94c4db4ee4e425abc566d
+        checksum/bootstrap-config: bd6649b0ae17455a1f08651ec980d66362ba01cf3721494bfbc8782887bee871
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -9191,7 +9191,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9216,7 +9216,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.6.10-alpha.0
+        helm.sh/chart: dataplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9323,7 +9323,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9911,7 +9911,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -10129,7 +10129,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10164,7 +10164,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10209,7 +10209,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10396,7 +10396,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10603,7 +10603,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10648,7 +10648,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10840,7 +10840,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10875,7 +10875,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -131,7 +131,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -160,7 +160,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -174,7 +174,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -212,7 +212,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -410,7 +410,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -689,7 +689,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -904,7 +904,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -978,7 +978,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1138,7 +1138,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1277,7 +1277,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1346,7 +1346,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1606,7 +1606,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1710,7 +1710,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1798,7 +1798,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1864,7 +1864,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1949,7 +1949,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2159,7 +2159,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2283,7 +2283,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5318,7 +5318,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -5917,7 +5917,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5950,7 +5950,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5987,7 +5987,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6003,7 +6003,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6044,7 +6044,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6064,7 +6064,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6084,7 +6084,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6115,7 +6115,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6183,7 +6183,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6208,7 +6208,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6266,7 +6266,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6288,7 +6288,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6309,7 +6309,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6330,7 +6330,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6482,7 +6482,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6920,7 +6920,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7326,7 +7326,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7361,7 +7361,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7388,7 +7388,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7418,7 +7418,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7448,7 +7448,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7477,7 +7477,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7501,7 +7501,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7528,7 +7528,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8603,7 +8603,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8732,7 +8732,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8836,7 +8836,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8949,7 +8949,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9048,7 +9048,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -9064,7 +9064,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.6.10-alpha.0
+        helm.sh/chart: dataplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -9075,7 +9075,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: bec84268f843deeee3788382b53d5da0cabc1aa35f867ee8e34890401a85b9aa
+        checksum/bootstrap-config: 8be3ac8bac0682f89d54417a0e8b6e479764bd368104dba336dddc278bcbdd68
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -9191,7 +9191,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9216,7 +9216,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.6.10-alpha.0
+        helm.sh/chart: dataplane-2026.6.10-alpha.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9323,7 +9323,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9911,7 +9911,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -10129,7 +10129,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10164,7 +10164,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10209,7 +10209,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10396,7 +10396,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10603,7 +10603,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10648,7 +10648,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10840,7 +10840,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10875,7 +10875,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -3309,7 +3309,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6944,7 +6944,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7332,7 +7332,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7386,7 +7386,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -3309,7 +3309,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6944,7 +6944,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7332,7 +7332,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7386,7 +7386,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3401,7 +3401,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7076,7 +7076,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7449,7 +7449,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7503,7 +7503,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -3259,7 +3259,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6890,7 +6890,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7277,7 +7277,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7331,7 +7331,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3384,7 +3384,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7221,7 +7221,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7640,7 +7640,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7694,7 +7694,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -3264,7 +3264,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6839,7 +6839,7 @@ spec:
               name: config-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7350,7 +7350,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7404,7 +7404,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -3257,7 +3257,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6888,7 +6888,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7275,7 +7275,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7329,7 +7329,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -3282,7 +3282,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6913,7 +6913,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7300,7 +7300,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7354,7 +7354,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -4087,7 +4087,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -9027,7 +9027,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -13893,7 +13893,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -13947,7 +13947,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -3277,7 +3277,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7040,7 +7040,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7427,7 +7427,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7481,7 +7481,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3297,7 +3297,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6973,7 +6973,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7386,7 +7386,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7440,7 +7440,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -3266,7 +3266,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -6897,7 +6897,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.6.10-alpha.0"
+              value: "2026.6.10-alpha.1"
             - name: HELM_APP_VERSION
               value: "2026.6.10-alpha.0"
             - name: POD_NAME
@@ -7284,7 +7284,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.6.10-alpha.0
+    helm.sh/chart: dataplane-2026.6.10-alpha.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.6.10-alpha.0"
@@ -7338,7 +7338,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.6.10-alpha.0
+      helm.sh/chart: dataplane-2026.6.10-alpha.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.6.10-alpha.0"

--- a/tests/generated/knative-migration.adoption.yaml
+++ b/tests/generated/knative-migration.adoption.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.6.9
+        helm.sh/chart: knative-migration-2026.6.10-alpha.0
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.argocd-presync.yaml
+++ b/tests/generated/knative-migration.argocd-presync.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -76,7 +76,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -96,7 +96,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -120,7 +120,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -135,7 +135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.6.9
+        helm.sh/chart: knative-migration-2026.6.10-alpha.0
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.default.yaml
+++ b/tests/generated/knative-migration.default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.6.9
+    helm.sh/chart: knative-migration-2026.6.10-alpha.0
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.6.9
+        helm.sh/chart: knative-migration-2026.6.10-alpha.0
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/values/dataplane.aws.with-ingress.yaml
+++ b/tests/values/dataplane.aws.with-ingress.yaml
@@ -33,3 +33,9 @@ config:
 
 ingress:
   enabled: true
+  host: dp-1.internal.union.us-west-2.union.ai
+
+updateStatus:
+  connectionConfig:
+    enabled: true
+    insecureSkipVerify: true


### PR DESCRIPTION
## Overview

The dataplane `connection_config` self-report (ConfigMap + operator `connectionConfigPath` + volume + mount, added in #454) rendered whenever a DP-reachable host resolved. That host **falls back to `ingress.host`**, so nearly every real install emitted the block without opting in — and an operator image that predates `connection_config` support then receives a config key it can't consume.

This gates all four render sites behind a new `updateStatus.connectionConfig.enabled` (default `false`), via a single `dataplane.connectionConfig.emit` helper. Emission now requires an explicit opt-in **and** a resolvable host. Backward compatible: the default renders nothing, matching pre-#454 behavior. The `ingress.host` fallback is preserved for host *resolution* once enabled.

Enable only when the deployed operator image understands `connectionConfigPath`.

## Test Plan

`make test` (snapshot + kubeconform) passes. The `dataplane.aws.with-ingress` fixture opts in (`enabled: true` + a host) for positive coverage — its snapshot now renders the block; every other dataplane snapshot only changes the chart-version label, confirming the default-off gate.

## Rollout Plan

Merge; publishes charts as `2026.6.10-alpha.1` (lockstep bump). Envs that want self-registration set `updateStatus.connectionConfig.enabled: true` in their overlay.

## Rollback Plan

Revert.
