### PR TITLE
fix: envoy selfhosted routing and TLS fixes

### DIFF
--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Switches between envoy and nginx based on the ingress provider.
 */}}
 {{- define "controlPlaneLibrary.ingressFqdn" -}}
 {{- if eq (default "nginx" .Values.global.INGRESS_PROVIDER) "envoy" -}}
-envoy-controlplane.envoy-gateway.svc.cluster.local
+{{ .Values.global.ENVOY_INGRESS_FQDN | default "envoy-controlplane.envoy-gateway.svc.cluster.local" }}
 {{- else -}}
 controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local
 {{- end -}}

--- a/charts/controlplane/templates/common/_gateway.yaml
+++ b/charts/controlplane/templates/common/_gateway.yaml
@@ -30,6 +30,11 @@ spec:
             name: {{ .Values.global.TLS_SECRET_NAME }}
     {{- end }}
     {{- $intraHost := .Values.global.CONTROLPLANE_INTRA_CLUSTER_HOST }}
+    {{- /* Internal listeners (DP→CP private DNS, CP→CP svc FQDN) use a
+           self-signed cert because LE cannot issue certs for cluster-local
+           names (.svc.cluster.local). Falls back to the LE cert when
+           INTERNAL_TLS_SECRET_NAME is not set (e.g. managed clusters). */}}
+    {{- $internalTlsSecret := .Values.global.INTERNAL_TLS_SECRET_NAME | default .Values.global.TLS_SECRET_NAME }}
     {{- if and $intraHost (ne $intraHost .Values.global.UNION_HOST) }}
     - name: https-intracluster
       protocol: HTTPS
@@ -40,7 +45,7 @@ spec:
         certificateRefs:
           - kind: Secret
             namespace: {{ .Values.global.TLS_SECRET_NAMESPACE }}
-            name: {{ .Values.global.TLS_SECRET_NAME }}
+            name: {{ $internalTlsSecret }}
     {{- end }}
     {{- $ingressFqdn := include "controlPlaneLibrary.ingressFqdn" . }}
     {{- if and $ingressFqdn (ne $ingressFqdn .Values.global.UNION_HOST) (ne $ingressFqdn $intraHost) }}
@@ -53,6 +58,6 @@ spec:
         certificateRefs:
           - kind: Secret
             namespace: {{ .Values.global.TLS_SECRET_NAMESPACE }}
-            name: {{ .Values.global.TLS_SECRET_NAME }}
+            name: {{ $internalTlsSecret }}
     {{- end }}
 {{- end }}

--- a/charts/controlplane/templates/common/_grpcroute-protected.yaml
+++ b/charts/controlplane/templates/common/_grpcroute-protected.yaml
@@ -74,7 +74,7 @@ spec:
         - method: {service: "cloudidl.identity.IdentityService"}
       backendRefs:
         - name: identity
-          port: 83
+          port: 80
     - matches:
         - method: {service: "cloudidl.identity.SelfServe"}
       backendRefs:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -790,7 +790,8 @@ services:
         metrics:
           scope: "dataproxy:"
       dataproxy:
-        secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80 # http://ingress-nginx-internal.ingress-nginx.svc.cluster.local
+        # CP→DP secure tunnel URL. Selfhosted overrides via global.DATAPLANE_HOST.
+        secureTunnelTenantURLPattern: '{{ default "http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80" .Values.global.DATAPLANE_HOST }}'
         clusterSelector:
           type: local
         # Task metrics query templates for GetActionAttemptMetrics / GetAppMetrics RPCs.
@@ -2118,8 +2119,9 @@ flyte:
           idpQueryParameter: "idp"
 
       admin:
-        # CP-internal: through controlplane ingress controller for gRPC routing.
-        endpoint: 'dns:///controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local'
+        # CP-internal: all CP services dial each other via gRPC through the ingress.
+        # Switches between envoy and nginx based on global.INGRESS_PROVIDER.
+        endpoint: 'dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}{{- if eq (default "nginx" .Values.global.INGRESS_PROVIDER) "envoy" }}:443{{- end }}'
         insecure: true
         clientId: '{{ .Values.global.INTERNAL_CLIENT_ID }}'
         clientSecretLocation: "/etc/secrets/client_secret"

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -2065,7 +2065,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -2047,7 +2047,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -2067,7 +2067,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2082,7 +2082,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -2052,7 +2052,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -2045,7 +2045,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -2158,7 +2158,7 @@ data:
     dataproxy:
       clusterSelector:
         type: local
-      secureTunnelTenantURLPattern: http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80
+      secureTunnelTenantURLPattern: 'http://ingress-nginx-internal.ingress-nginx.svc.cluster.local:80'
       taskMetrics:
         agentQuery:
           mappings:


### PR DESCRIPTION
## Summary
Follow-up fixes for envoy gateway selfhosted support (PR #459). These were discovered while testing on `chloe-selfhosted`.

- **ENVOY_INGRESS_FQDN global**: Make the envoy proxy service FQDN configurable via `global.ENVOY_INGRESS_FQDN` instead of hardcoded. Unlike nginx (whose service name is deterministic from `Release.Namespace`), the envoy proxy lives in a separate namespace and its name is derived from the Gateway CR by the Envoy Gateway controller.
- **Self-signed cert for internal listeners**: The `https-intracluster` (DP→CP private DNS) and `https-local` (CP→CP svc FQDN) Gateway listeners now use `INTERNAL_TLS_SECRET_NAME` instead of the LE cert. LE cannot issue certs for `.svc.cluster.local` names. Falls back to `TLS_SECRET_NAME` when unset (managed clusters).
- **Identity GRPCRoute port fix**: route `cloudidl.identity.IdentityService` to port 80 (identity's gRPC port) instead of 83, which belongs to authorizer/organizations.
- **admin.endpoint + secureTunnelTenantURLPattern**: `admin.endpoint` was hardcoded to the nginx service FQDN — now uses the `controlPlaneLibrary.ingressFqdn` helm helper which switches between nginx and envoy based on `global.INGRESS_PROVIDER` (set by terraform). `secureTunnelTenantURLPattern` was hardcoded to a managed-cluster nginx address — now reads from `global.DATAPLANE_HOST` (also set by terraform) with fallback.

## Test plan
- [x] Tested on `chloe-selfhosted` with envoy-only mode
- [x] Verify no impact on nginx-only environments (all changes are gated or have fallbacks)
- [x] Regenerate golden test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)