### PR TITLE
feat(dataplane): drop node-label bloat at prometheus scrape

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1747,6 +1747,12 @@ prometheus:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -3825,6 +3825,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -3857,6 +3857,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -4025,6 +4025,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -3848,6 +3848,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -3952,6 +3952,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -5911,6 +5911,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -5911,6 +5911,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -3892,6 +3892,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -3892,6 +3892,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3984,6 +3984,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -3842,6 +3842,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3967,6 +3967,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -3847,6 +3847,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -3840,6 +3840,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -3865,6 +3865,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -4670,6 +4670,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -3860,6 +3860,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3880,6 +3880,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -3849,6 +3849,12 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
+        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
+        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
+        # providerID is emitted as label_providerID; the bare-providerID alternative
+        # covers DP versions that emit it unprefixed.
+        - action: labeldrop
+          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m


### PR DESCRIPTION
## Overview

Add a `labeldrop` rule to the dataplane `opencost` prometheus scrape job so `kube_node_labels` stays under AMP's per-series size limit.

The rule drops node-label bloat before the series are forwarded:
- NFD feature labels (`label_feature_node_kubernetes_io_*`)
- Azure node labels (`label_kubernetes_azure_com_*`)
- Karpenter labels (`label_karpenter_k8s_aws_*`)
- The noisiest NVIDIA GFD labels (`label_nvidia_com_gfd_timestamp`, `label_nvidia_com_gpu_deploy_*`)
- `providerID` — emitted as `label_providerID`; the bare-`providerID` alternative covers DP versions that emit it unprefixed

## Test Plan

- `make generate-expected` + `make test` — change propagates into all dataplane snapshots; all tests pass.