### PR TITLE
fix(dataplane): stop dropping flapping providerID from kube_node_labels

### DIFF
--- a/charts/dataplane/README.md
+++ b/charts/dataplane/README.md
@@ -115,8 +115,8 @@ helm upgrade --install unionai-dataplane unionai/dataplane \
 ### Push prometheus metrics to the control plane
 
 In zero-trust mode (`zero_trust.enabled: true`) the in-cluster
-operator-prometheus automatically pushes its metrics to the control-plane
-metrics-gateway via Prometheus `remote_write`, authenticated with the
+operator-prometheus automatically pushes its metrics to the control plane
+via Prometheus `remote_write`, authenticated with the
 dataplane's OAuth2 client credentials. With the default configuration **there is
 nothing to configure** — the endpoint, `client_id`
 (`<ORG_NAME>-<CLUSTER_NAME>-operator`) and `token_url`

--- a/charts/dataplane/templates/prometheus/configmap.yaml
+++ b/charts/dataplane/templates/prometheus/configmap.yaml
@@ -21,7 +21,7 @@ Keep this in sync with the upstream prometheus subchart's templates/cm.yaml on s
 {{- if .Values.zero_trust.enabled }}
 {{- $externalLabels := $global.external_labels | default dict }}
 {{- /* __replica__ dedups THIS cluster's prometheus replicas against each other. The
-       control-plane metrics-gateway derives cluster/tenant identity from the OAuth2
+       control plane derives cluster/tenant identity from the OAuth2
        client_id (<org>-<cluster>-operator), so no stable cluster external label is
        needed here. ${POD_NAME} is expanded at runtime via --enable-feature=expand-external-labels. */ -}}
 {{- $_ := set $externalLabels "__replica__" "${POD_NAME}" }}

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -178,7 +178,7 @@ config:
         project: '{{ .Values.global.GOOGLE_PROJECT_ID }}'
 
     # Persisted log source for the operator-proxy's TailLogs / TailTaskExecutionLogs
-    # handlers (cloud/operator/dataproxy/log_service.go). When the client requests
+    # handlers. When the client requests
     # LogsSource=PERSISTED_ONLY, the proxy reads historical task pod logs from the
     # Cloud Logging API instead of the (live) Kubernetes pod log stream — which
     # is what lets the UI keep showing logs after task pods are garbage-collected.

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1747,12 +1747,14 @@ prometheus:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -3825,12 +3825,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -3857,12 +3857,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -4025,12 +4025,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -3848,12 +3848,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -3952,12 +3952,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -5911,12 +5911,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -5911,12 +5911,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -3892,12 +3892,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -3892,12 +3892,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3984,12 +3984,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -3842,12 +3842,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3967,12 +3967,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -3847,12 +3847,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -3840,12 +3840,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -3865,12 +3865,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -4670,12 +4670,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -3860,12 +3860,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -3880,12 +3880,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -3849,12 +3849,14 @@ data:
         - source_labels: [__name__]
           regex: "kube_node_labels|kube_pod_labels|node_total_hourly_cost|node_ram_hourly_cost|node_cpu_hourly_cost|node_gpu_hourly_cost"
           action: keep
-        # Drop unused node-label bloat (NFD/azure/karpenter feature labels,
-        # providerID, noisiest NVIDIA GFD labels) to keep kube_node_labels small.
-        # providerID is emitted as label_providerID; the bare-providerID alternative
-        # covers DP versions that emit it unprefixed.
+        # Drop node-label bloat (NFD/azure/karpenter feature labels, noisiest NVIDIA
+        # GFD timestamp) so kube_node_labels stays under AMP's per-series size limit.
+        # providerID and nvidia_com_gpu_deploy_* are intentionally kept: dropping the
+        # flapping providerID collapses opencost's two kube_node_labels variants onto
+        # one identity and triggers AMP "duplicate sample … NaN" 400s. Keep this regex
+        # in sync with the control plane's corresponding labeldrop.
         - action: labeldrop
-          regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+          regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
     - job_name: 'union-services'
       metrics_path: /metrics
       scrape_interval: 1m


### PR DESCRIPTION
## What

Narrow the opencost scrape's `labeldrop` regex in the dataplane prometheus config to **keep** `providerID` and `nvidia_com_gpu_deploy_*`:

```
- regex: "(label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_(gfd_timestamp|gpu_deploy_.+))|(label_)?providerID)"
+ regex: "label_(feature_node_kubernetes_io_.+|kubernetes_azure_com_.+|karpenter_k8s_aws_.+|nvidia_com_gfd_timestamp)"
```

## Why

`providerID` flaps between opencost's two `kube_node_labels` variants. Dropping it collapses those two variants onto one series identity, producing a StaleNaN + real-value collision at a single timestamp that the remote-write backend rejects with `duplicate sample ... existing 1, new value NaN` 400s — taking down the whole batch. Keeping `providerID` (and `nvidia_com_gpu_deploy_*`) leaves the two variants distinct. We still drop the genuinely-unbounded NFD/azure/karpenter feature labels and the `nvidia_com_gfd_timestamp` to stay under the per-series size limit.

## Also

- Dropped control-plane component/source references from the dataplane chart docs/comments (generic "control plane" phrasing).
- Regenerated the `tests/generated` snapshots to match.

## Test

- `helm template charts/dataplane` renders the narrowed regex.
- `tests/generated/*` re-synced; `make test` diffs against them.