### PR TITLE
dataplane: bump prometheus subchart to 25.30.2 (Prometheus v2.55.1)

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -14,7 +14,13 @@ dependencies:
   condition: monitoring.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 25.27.0
+  # Newest 25.x (appVersion Prometheus v2.55.1). 25.27.0 shipped v2.54.1, whose
+  # vendored prometheus/common v0.55.0 has the oauth2 `lastSecret` bug: with a
+  # client_secret_file the remote_write token source is rebuilt on every request,
+  # discarding the cached token so every send does a fresh token POST — which can
+  # wedge remote_write on a stuck fetch. Fixed in common v0.57.0 (Prometheus
+  # 2.55.0+); 2.55.x caches the token for its full TTL.
+  version: 25.30.2
   alias: prometheus
   condition: prometheus.enabled
 - name: metrics-server

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5745,13 +5744,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5775,9 +5774,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6296,13 +6294,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6315,13 +6313,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6340,7 +6338,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6360,7 +6358,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6384,9 +6382,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6410,16 +6407,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6447,7 +6443,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5777,13 +5776,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5807,9 +5806,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6328,13 +6326,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6347,13 +6345,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6372,7 +6370,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6392,7 +6390,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6416,9 +6414,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6442,16 +6439,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6479,7 +6475,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -82,13 +82,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -100,9 +100,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6029,13 +6028,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -6059,9 +6058,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6836,13 +6834,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6855,13 +6853,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6880,7 +6878,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6900,7 +6898,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6924,9 +6922,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6950,16 +6947,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6987,7 +6983,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5768,13 +5767,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5798,9 +5797,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6319,13 +6317,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6338,13 +6336,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6363,7 +6361,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6383,7 +6381,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6407,9 +6405,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6433,16 +6430,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6470,7 +6466,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -82,13 +82,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -100,9 +100,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5956,13 +5955,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5986,9 +5985,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6763,13 +6761,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6782,13 +6780,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6807,7 +6805,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6827,7 +6825,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6851,9 +6849,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6877,16 +6874,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6914,7 +6910,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -51,13 +51,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -69,9 +69,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -7428,13 +7427,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -7458,9 +7457,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -8415,13 +8413,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -8434,13 +8432,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -8459,7 +8457,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -8479,7 +8477,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -8503,9 +8501,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -8529,16 +8526,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -8566,7 +8562,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -51,13 +51,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -69,9 +69,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -7428,13 +7427,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -7458,9 +7457,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -8415,13 +8413,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -8434,13 +8432,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -8459,7 +8457,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -8479,7 +8477,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -8503,9 +8501,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -8529,16 +8526,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -8566,7 +8562,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5812,13 +5811,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5842,9 +5841,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6363,13 +6361,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6382,13 +6380,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6407,7 +6405,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6427,7 +6425,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6451,9 +6449,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6477,16 +6474,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6514,7 +6510,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5812,13 +5811,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5842,9 +5841,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6363,13 +6361,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6382,13 +6380,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6407,7 +6405,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6427,7 +6425,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6451,9 +6449,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6477,16 +6474,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6514,7 +6510,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -89,13 +89,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -107,9 +107,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5841,13 +5840,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5871,9 +5870,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6392,13 +6390,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6411,13 +6409,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6436,7 +6434,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6456,7 +6454,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6480,9 +6478,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6506,16 +6503,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6543,7 +6539,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5762,13 +5761,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5792,9 +5791,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6313,13 +6311,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6332,13 +6330,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6357,7 +6355,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6377,7 +6375,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6401,9 +6399,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6427,16 +6424,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6464,7 +6460,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -82,13 +82,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -100,9 +100,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5971,13 +5970,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -6001,9 +6000,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6646,13 +6644,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6665,13 +6663,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6690,7 +6688,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6710,7 +6708,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6734,9 +6732,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6760,16 +6757,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6797,7 +6793,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5767,13 +5766,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5797,9 +5796,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6318,13 +6316,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6337,13 +6335,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6362,7 +6360,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6382,7 +6380,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6406,9 +6404,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6432,16 +6429,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6469,7 +6465,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5760,13 +5759,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5790,9 +5789,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6311,13 +6309,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6330,13 +6328,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6355,7 +6353,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6375,7 +6373,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6399,9 +6397,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6425,16 +6422,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6462,7 +6458,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5785,13 +5784,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5815,9 +5814,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6336,13 +6334,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6355,13 +6353,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6380,7 +6378,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6400,7 +6398,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6424,9 +6422,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6450,16 +6447,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6487,7 +6483,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -143,13 +143,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -161,9 +161,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -7349,13 +7348,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -7379,9 +7378,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -8450,13 +8448,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -8469,13 +8467,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -8494,7 +8492,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -8514,7 +8512,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -8538,9 +8536,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -8564,16 +8561,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -8601,7 +8597,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5808,13 +5807,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5838,9 +5837,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6463,13 +6461,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6482,13 +6480,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6507,7 +6505,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6527,7 +6525,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6551,9 +6549,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6577,16 +6574,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6614,7 +6610,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5800,13 +5799,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5830,9 +5829,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6351,13 +6349,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6370,13 +6368,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6395,7 +6393,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6415,7 +6413,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6439,9 +6437,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6465,16 +6462,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6502,7 +6498,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -53,13 +53,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   name: release-name-kube-state-metrics
   namespace: union
 ---
@@ -71,9 +71,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -5769,13 +5768,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -5799,9 +5798,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6320,13 +6318,13 @@ metadata:
   name: release-name-kube-state-metrics
   namespace: union
   labels:    
-    helm.sh/chart: kube-state-metrics-5.25.1
+    helm.sh/chart: kube-state-metrics-5.27.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.13.0"
+    app.kubernetes.io/version: "2.14.0"
 spec:
   selector:
     matchLabels:      
@@ -6339,13 +6337,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.25.1
+        helm.sh/chart: kube-state-metrics-5.27.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "2.13.0"
+        app.kubernetes.io/version: "2.14.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -6364,7 +6362,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --namespaces=union
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -6384,7 +6382,7 @@ spec:
           httpGet:
             httpHeaders:
             path: /readyz
-            port: 8080
+            port: 8081
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -6408,9 +6406,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: v2.54.1
-    helm.sh/chart: prometheus-25.27.0
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: prometheus-25.30.2
     app.kubernetes.io/part-of: prometheus
   name: union-operator-prometheus
   namespace: union
@@ -6434,16 +6431,15 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: v2.54.1
-        helm.sh/chart: prometheus-25.27.0
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: prometheus-25.30.2
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: union-operator-prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -6471,7 +6467,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.54.1"
+          image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: POD_NAME


### PR DESCRIPTION
## What

Bumps the dataplane chart's community `prometheus` subchart `25.27.0 → 25.30.2`, moving `union-operator-prometheus` from Prometheus **v2.54.1 → v2.55.1**.

## Why

2.54.x vendors `prometheus/common` **v0.55.0**, which has the oauth2 `lastSecret` bug: with a `client_secret_file`, the `remote_write` token source is rebuilt on **every request**, discarding the cached token so each send does a fresh token POST. That widens the window for a stuck token fetch to wedge the `remote_write` queue (recovery needs a pod restart).

The fix shipped in `common` **v0.57.0**; the smallest Prometheus carrying it is **2.55.0**. On 2.55.x the token caches for its full TTL, dropping token fetches from per-request to ~once/day.

## Approach

Bumped the subchart rather than overriding `prometheus.server.image.tag`, so `app.kubernetes.io/version` stays consistent with the running image. `25.30.2` is the newest 25.x (appVersion `v2.55.1`); later chart lines move to Prometheus 3.x.

## Bundled sub-subchart bumps (carried by the version move, all upstream-tested)

- config-reloader `v0.76.0 → v0.78.1`
- kube-state-metrics `5.25.1 → 5.27.0` (image `v2.13.0 → v2.14.0`; readiness probe now `/readyz` on telemetry port `8081`)

Regenerated snapshots contain only these image/label changes and the KSM probe port — no other template drift.