### PR TITLE
dataplane: blank leaseworker priorityClassName on GCP (GKE reserved-class restriction)

### DIFF
--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -436,9 +436,16 @@ opencost:
 # ----------------------------------------------------------------------------
 # SECTION 8: Override priority class due to GKE restriction where it doesn't
 #            allow running pods with system-cluster-critical other core kube
-#            components.
+#            components. (GKE gates the reserved class behind a matching
+#            PriorityClass-scoped ResourceQuota; blanking the class sidesteps it
+#            without needing resourcequota.create.)
 # ----------------------------------------------------------------------------
 flytepropeller:
+  priorityClassName: ""
+
+# leaseworker defaults to system-cluster-critical (chart values.yaml, added in
+# PR #474). Same GKE restriction as flytepropeller above — blank it here.
+leaseworker:
   priorityClassName: ""
 
 flytepropellerwebhook: {}


### PR DESCRIPTION
## Problem

PR #474 (`[Leaseworker] Add priority class`) set the chart default
`leaseworker.priorityClassName: system-cluster-critical`.

On **GKE**, pods using the reserved `system-node-critical` / `system-cluster-critical`
priority classes in a non-`kube-system` namespace are rejected at admission unless the
namespace has a matching `PriorityClass`-scoped `ResourceQuota`. The dataplane release
namespace (`union`) has none by default, so the leaseworker Deployment never creates its
pod:

```
ReplicaFailure / FailedCreate:
insufficient quota to match these scopes:
[{PriorityClass In [system-node-critical system-cluster-critical]}]
```

The leaseworker stays `0/1`, no actions are dispatched, and flyte v2 runs are created but
**never scheduled** (task pods never spawn).

## Fix

`values.gcp.yaml` SECTION 8 already blanks `flytepropeller.priorityClassName` for this
exact GKE restriction — it just never got extended when #474 added the leaseworker
priority class. This blanks `leaseworker.priorityClassName` the same way.

## Scope: GCP-only

The reserved-class admission gate is GKE-specific. The AWS (`values.aws.yaml` →
`flytepropeller: {}`) and Azure overlays intentionally keep `system-cluster-critical`
— EKS/AKS don't gate reserved classes — so no change is needed (or wanted) there.

## Alternative considered

The same GKE restriction can also be satisfied by setting `resourcequota.create: true`,
which renders the `union-critical-pods` `ResourceQuota` (keeping `system-cluster-critical`
and its eviction protection). Blanking the class instead matches this chart's own existing
SECTION 8 pattern and avoids the extra quota + `pods` cap; the trade-off is the leaseworker
runs at default priority on GKE.

## Testing

Verified on a live GKE self-managed cluster (dataplane 2026.7.0): blanking
`leaseworker.priorityClassName` lets the Deployment schedule `1/1` (it was `0/1`,
`FailedCreate`, before). With the leaseworker running, a flyte v2 eager smoke
(`flyte.map` fan-out) dispatched child task pods into `development` and reached
`SUCCEEDED`.
