### PR TITLE
controlplane: dedicated flyteadmin OIDC clientSecretFile (docs + example + test)

### DIFF
--- a/charts/controlplane/examples/values.oidc-client-secret.yaml
+++ b/charts/controlplane/examples/values.oidc-client-secret.yaml
@@ -1,0 +1,54 @@
+# ============================================================================
+# flyteadmin browser-login OIDC client secret — dedicated Secret
+# ============================================================================
+# This file contains ONLY the wiring that lets flyteadmin read the browser-login
+# (App 1) OIDC client secret from its OWN dedicated, single-writer Kubernetes
+# Secret, mounted at /etc/secrets/oauth, via userAuth.openId.clientSecretFile.
+#
+# Why: by default flyteadmin reads `oidc_client_secret` from `flyte-admin-secrets`
+# at /etc/secrets/. That Secret is (re)created by the flyteadmin `generate-secrets`
+# init container for the token-signing / cookie keys, so co-locating the OIDC
+# client secret there forces a multi-writer merge. A dedicated Secret keeps the
+# externally-managed OIDC client secret separate from the auto-generated keys, so
+# any secret tool (ExternalSecrets, sealed-secrets, manual, etc.) can fully own it.
+#
+# You must supply the Secret yourself. Either create it directly:
+#
+#   kubectl create secret generic flyteadmin-oidc-client-secret \
+#     --from-literal=client_secret='<BROWSER_LOGIN_CLIENT_SECRET>' \
+#     -n <controlplane-namespace>
+#
+# or sync it from your cloud secret manager with an ExternalSecret (recommended
+# for production) targeting `flyteadmin-oidc-client-secret` with a `client_secret`
+# key.
+#
+# Usage:
+#   helm upgrade --install unionai-controlplane ./charts/controlplane \
+#     --namespace union-cp \
+#     -f charts/controlplane/values.gcp.selfhosted-intracluster.yaml \
+#     -f charts/controlplane/examples/values.oidc-client-secret.yaml \
+#     -f your-overrides.yaml
+# ============================================================================
+
+flyte:
+  flyteadmin:
+    # NOTE: additionalVolumes / additionalVolumeMounts are list-valued, so Helm
+    # REPLACES (not merges) them. Include the chart's default volumes here too if
+    # you rely on them (e.g. union-secrets, private-config).
+    additionalVolumes:
+      - name: oauth-client-secret
+        secret:
+          secretName: flyteadmin-oidc-client-secret
+    additionalVolumeMounts:
+      - name: oauth-client-secret
+        mountPath: /etc/secrets/oauth
+        readOnly: true
+
+  configmap:
+    adminServer:
+      auth:
+        userAuth:
+          openId:
+            # Read the browser-login client secret from the mounted file above,
+            # instead of the default secret-manager lookup in flyte-admin-secrets.
+            clientSecretFile: /etc/secrets/oauth/client_secret

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1782,6 +1782,15 @@ flyte:
       - name: private-config
         configMap:
           name: flyte-admin-private-config
+      # -- OPTIONAL: give flyteadmin the browser-login OIDC client secret via its
+      # own dedicated, single-writer Secret, decoupled from flyte-admin-secrets
+      # (which the generate-secrets init container manages for signing/cookie keys).
+      # Create the Secret yourself (or via ExternalSecrets) with a `client_secret`
+      # key, mount it here, and point flyteadmin at the file with
+      # `configmap.adminServer.auth.userAuth.openId.clientSecretFile` (see below).
+      # - name: oauth-client-secret
+      #   secret:
+      #     secretName: flyteadmin-oidc-client-secret
     # Override configPath to include both config directories
     configPath: /etc/flyte/*/*.yaml
     additionalVolumeMounts:
@@ -1791,6 +1800,11 @@ flyte:
       - name: private-config
         mountPath: /etc/flyte/private
         readOnly: true
+      # -- OPTIONAL: mount for the dedicated OIDC client secret above. flyteadmin
+      # then reads it via userAuth.openId.clientSecretFile: /etc/secrets/oauth/client_secret
+      # - name: oauth-client-secret
+      #   mountPath: /etc/secrets/oauth
+      #   readOnly: true
   flytescheduler:
     image:
       repository: "registry.unionai.cloud/controlplane/services"
@@ -2113,6 +2127,13 @@ flyte:
             # Entra ID example: "f0b2667d-5e99-45f2-ae4a-2ab47cb5fa12"
             baseUrl: ""
             clientId: ""
+            # -- OPTIONAL: read the browser-login client secret from a mounted file
+            # instead of the default secret-manager lookup (`oidc_client_secret` in
+            # flyte-admin-secrets at /etc/secrets/). Use this with a dedicated
+            # `flyteadmin.additionalVolumes`/`additionalVolumeMounts` entry (see above)
+            # so the OIDC secret has its own single-writer Secret and never collides
+            # with the init-container-managed signing/cookie keys.
+            # clientSecretFile: /etc/secrets/oauth/client_secret
             # Browser login scopes.
             # Okta: ["profile", "openid", "offline_access"] (default)
             # Entra ID: ["profile", "openid", "offline_access", "api://my-app/all"]

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -387,6 +387,7 @@ data:
         openId:
           baseUrl: ""
           clientId: ""
+          clientSecretFile: /etc/secrets/oauth/client_secret
           scopes:
           - profile
           - openid
@@ -9498,7 +9499,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8a0dc4262b1652bb93b744d53852ed8f264a1f6353e5293f56fdf76f73c6e4a"
+        configChecksum: "9ba12634f13b7d4907c344ff751168385ecd5909a6a12f6c36760971d14faf8"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin
@@ -9633,6 +9634,9 @@ spec:
         - mountPath: /etc/flyte/private
           name: private-config
           readOnly: true
+        - mountPath: /etc/secrets/oauth
+          name: oauth-client-secret
+          readOnly: true
       serviceAccountName: flyteadmin
       volumes:
       - name: union-controlplane-secrets
@@ -9663,6 +9667,9 @@ spec:
       - configMap:
           name: flyte-admin-private-config
         name: private-config
+      - name: oauth-client-secret
+        secret:
+          secretName: flyteadmin-oidc-client-secret
 
 ---
 # Source: controlplane/charts/flyte/templates/console/deployment.yaml

--- a/tests/values/controlplane.custom-oidc.yaml
+++ b/tests/values/controlplane.custom-oidc.yaml
@@ -44,6 +44,32 @@ flyte:
       tls:
         secretName: fake-host-tls-secret
       host: fake-host.domain
+  # Read the browser-login OIDC client secret from a dedicated, single-writer
+  # Secret mounted at /etc/secrets/oauth (see examples/values.oidc-client-secret.yaml)
+  # instead of merging it into the init-container-managed flyte-admin-secrets.
+  # additionalVolumes/Mounts are list-valued (Helm replaces), so the chart's own
+  # union-secrets / private-config entries are repeated here alongside the new one.
+  flyteadmin:
+    additionalVolumes:
+      - name: union-secrets
+        secret:
+          secretName: '{{ .Values.global.KUBERNETES_SECRET_NAME }}'
+      - name: private-config
+        configMap:
+          name: flyte-admin-private-config
+      - name: oauth-client-secret
+        secret:
+          secretName: flyteadmin-oidc-client-secret
+    additionalVolumeMounts:
+      - name: union-secrets
+        mountPath: /etc/secrets/union
+        readOnly: true
+      - name: private-config
+        mountPath: /etc/flyte/private
+        readOnly: true
+      - name: oauth-client-secret
+        mountPath: /etc/secrets/oauth
+        readOnly: true
   configmap:
     admin:
       admin:
@@ -57,6 +83,9 @@ flyte:
           identityTypeClaimsForApps:
             idtyp:
             - app
+        userAuth:
+          openId:
+            clientSecretFile: /etc/secrets/oauth/client_secret
 
 # Eager-key secret-by-reference override on the identity service: CreateKey reads
 # seeded OAuth client creds from a mounted Secret instead of registering an IdP app.


### PR DESCRIPTION
## Summary

Document and cover an opt-in way to give flyteadmin the browser-login OIDC client secret via its **own dedicated, single-writer Secret** mounted at `/etc/secrets/oauth`, read through `userAuth.openId.clientSecretFile` — decoupled from `flyte-admin-secrets`, which the flyteadmin `generate-secrets` init container manages for the token-signing / cookie keys.

## Why

By default flyteadmin reads `oidc_client_secret` from `flyte-admin-secrets`. Since the init container (re)creates that Secret for the crypto keys, co-locating the OIDC client secret there forces a multi-writer merge and is fragile for operators whose secret tooling does a full-replace. A dedicated Secret + `clientSecretFile` keeps the externally-managed OIDC secret separate.

## Changes

- `values.yaml`: commented opt-in examples on `flyteadmin.additionalVolumes`/`additionalVolumeMounts` and `userAuth.openId.clientSecretFile` (inert — no rendered-output change).
- `examples/values.oidc-client-secret.yaml`: focused, self-contained example (how to create/sync the Secret + wire the mount + `clientSecretFile`).
- Tests: the `custom-oidc` fixture now sets the oauth volume/mount + `clientSecretFile`; the regenerated snapshot covers the rendered flyteadmin deployment mount and admin config.

## Test Plan

- `bash tests/run.sh helm` — passes (only the `custom-oidc` snapshot changes: +`clientSecretFile`, +oauth mount/volume, configChecksum; `union-secrets` / `private-config` preserved).
- Verified live on a self-hosted control plane (cloud `union_extension` produces this exact wiring): flyteadmin reads the browser secret from `/etc/secrets/oauth/client_secret`, browser login works.

## Notes

This is the chart-side documentation; the terraform `union_extension` modules produce this wiring for self-hosted envs (separate cloud PR).