### PR TITLE
dataplane: leaseworker PriorityClass — custom (non-system) class, BYO + low_privilege aware

### DIFF
--- a/charts/dataplane/templates/leaseworker/deployment.yaml
+++ b/charts/dataplane/templates/leaseworker/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: {{ include "leaseworker.serviceAccountName" . }}
+      {{- if and .Values.leaseworker.priorityClassName (or (not .Values.leaseworker.priorityClass.create) (not .Values.low_privilege)) }}
+      priorityClassName: {{ .Values.leaseworker.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.leaseworker.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume

--- a/charts/dataplane/templates/leaseworker/deployment.yaml
+++ b/charts/dataplane/templates/leaseworker/deployment.yaml
@@ -28,9 +28,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: {{ include "leaseworker.serviceAccountName" . }}
-      {{- if .Values.leaseworker.priorityClassName }}
-      priorityClassName: {{ .Values.leaseworker.priorityClassName }}
-      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.leaseworker.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume

--- a/charts/dataplane/templates/leaseworker/priorityclass.yaml
+++ b/charts/dataplane/templates/leaseworker/priorityclass.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.leaseworker.priorityClass.create .Values.leaseworker.priorityClassName (not .Values.low_privilege) }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.leaseworker.priorityClassName }}
+  labels:
+    {{- include "leaseworker.labels" . | nindent 4 }}
+value: {{ .Values.leaseworker.priorityClass.value | int }}
+globalDefault: false
+description: "Priority for the Union leaseworker (a Recreate singleton) so it schedules ahead of task pods and leases keep flowing during node scale-up. Uses a custom class rather than a reserved system class (e.g. system-cluster-critical), which GKE restricts to kube-system."
+{{- end }}

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -436,16 +436,9 @@ opencost:
 # ----------------------------------------------------------------------------
 # SECTION 8: Override priority class due to GKE restriction where it doesn't
 #            allow running pods with system-cluster-critical other core kube
-#            components. (GKE gates the reserved class behind a matching
-#            PriorityClass-scoped ResourceQuota; blanking the class sidesteps it
-#            without needing resourcequota.create.)
+#            components.
 # ----------------------------------------------------------------------------
 flytepropeller:
-  priorityClassName: ""
-
-# leaseworker defaults to system-cluster-critical (chart values.yaml, added in
-# PR #474). Same GKE restriction as flytepropeller above — blank it here.
-leaseworker:
   priorityClassName: ""
 
 flytepropellerwebhook: {}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1093,8 +1093,6 @@ leaseworker:
   additionalVolumeMounts: []
   # -- Appends additional environment variables to the leaseworker container's spec.
   podEnv: []
-  # -- Sets priorityClassName for the leaseworker pod.
-  priorityClassName: "system-cluster-critical"
   # -- nodeSelector for leaseworker deployment
   nodeSelector: { }
   # -- tolerations for leaseworker deployment

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -1093,6 +1093,25 @@ leaseworker:
   additionalVolumeMounts: []
   # -- Appends additional environment variables to the leaseworker container's spec.
   podEnv: []
+  # -- PriorityClass the leaseworker pod runs under. The leaseworker is a Recreate
+  # singleton; a priority class keeps leases flowing when a replacement pod would
+  # otherwise sit Pending behind node scale-up. Defaults to the chart-managed class
+  # below. To bring your own existing class, set this to its name and
+  # priorityClass.create: false. Set to "" to run without one. Do NOT use a reserved
+  # system class (e.g. system-cluster-critical): GKE's gcp-critical-pods
+  # ResourceQuota restricts those to kube-system. The pod still references this class
+  # under low_privilege when it is externally managed (priorityClass.create: false) —
+  # referencing needs no cluster RBAC; only creation does (see priorityClass.create).
+  priorityClassName: union-leaseworker
+  # -- Whether the chart creates the (cluster-scoped) PriorityClass named by
+  # priorityClassName above. Skipped under low_privilege (namespace-only installs
+  # can't create cluster resources) — pair with a class you create out-of-band. Set
+  # create: false to bring your own class, or in multi-dataplane-per-cluster setups
+  # (the PriorityClass would otherwise be created once per dataplane). value is used
+  # only when create: true.
+  priorityClass:
+    create: true
+    value: 1000000
   # -- nodeSelector for leaseworker deployment
   nodeSelector: { }
   # -- tolerations for leaseworker deployment

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -6845,7 +6845,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -6875,7 +6875,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -7383,7 +7383,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -6866,7 +6866,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -7310,7 +7310,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -9909,7 +9909,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -9909,7 +9909,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -6911,7 +6911,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -6911,7 +6911,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -7044,7 +7044,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: dataplane/templates/leaseworker/priorityclass.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: union-leaseworker
+  labels:
+    app: leaseworker
+value: 1000000
+globalDefault: false
+description: "Priority for the Union leaseworker (a Recreate singleton) so it schedules ahead of task pods and leases keep flowing during node scale-up. Uses a custom class rather than a reserved system class (e.g. system-cluster-critical), which GKE restricts to kube-system."
+
+---
 # Source: dataplane/templates/common/namespaces.yaml
 apiVersion: v1
 kind: Namespace
@@ -7044,6 +7056,7 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
+      priorityClassName: union-leaseworker
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -6860,7 +6860,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -7193,7 +7193,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -6865,7 +6865,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -6858,7 +6858,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -6883,7 +6883,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -8997,7 +8997,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -7010,7 +7010,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -6904,7 +6904,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -6867,7 +6867,6 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: union-system
-      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 75
       volumes:
         - name: config-volume


### PR DESCRIPTION
## Summary

The leaseworker `priorityClassName` default of `system-cluster-critical` (#474) is a **reserved Kubernetes system class**. GKE's `gcp-critical-pods` ResourceQuota restricts system priority classes to `kube-system`, so on GKE the leaseworker's ReplicaSet fails with `insufficient quota to match these scopes: [{PriorityClass In [system-node-critical system-cluster-critical]}]` and the pod never schedules — no leases flow. #475's `values.gcp.yaml` blank doesn't help the ArgoCD selfmanaged path (which loads the chart `values.yaml` + the env values.yaml, not `values.gcp.yaml`).

This PR:
1. **Reverts** #474 + #475.
2. **Adds a chart-managed custom PriorityClass** (`union-leaseworker`, value `1000000`) and points the leaseworker at it — preserving the original intent (a Recreate singleton shouldn't sit Pending behind node scale-up) with a class that isn't quota-restricted, so it works on GKE/EKS/etc.
3. Makes it **bring-your-own capable** and **`low_privilege`-aware**.

## Configuration

- `leaseworker.priorityClassName` — the class the pod runs under. Default `union-leaseworker`. Set to an existing class name to **bring your own**; set `""` for none.
- `leaseworker.priorityClass.create` — whether the chart creates the (cluster-scoped) PriorityClass named above (default `true`). Set `false` to BYO, or in multi-dataplane-per-cluster setups (the PriorityClass is cluster-scoped).
- `leaseworker.priorityClass.value` — value used when `create: true`.

One shared name (no separate create/reference names — they always refer to the same class).

## `low_privilege` behavior

`low_privilege` gates **only creation** of the cluster-scoped PriorityClass (namespace-only installs lack the RBAC to create cluster resources). **Referencing** an externally-managed class needs no cluster RBAC, so it is still honored:

| `create` | `low_privilege` | Creates class | Pod references it |
|---|---|---|---|
| true | false | ✅ | ✅ |
| true | true | ❌ | ❌ (avoids a dangling reference to an uncreated class) |
| false (BYO) | either | ❌ | ✅ (externally managed) |
| — (`priorityClassName: ""`) | — | ❌ | ❌ |

## Test Plan

- `tests/run.sh helm` (dataplane snapshots): every non-`low_privilege` snapshot gains the PriorityClass + `priorityClassName`; `low_privilege` snapshots (the chart default) render neither; no other diff.
- Verified via `helm template --set`: BYO under `low_privilege` (`priorityClass.create=false`) references the class without creating it; chart-managed under `low_privilege` renders neither (no dangling reference).
- **Validated live on mike-apple-gcp (GKE, `low_privilege: false`), both data planes:** `union-leaseworker` PriorityClass created, leaseworker references it, pods `1/1 Running` — no quota rejection (vs the `system-cluster-critical` FailedCreate it replaces).

## Rollback

`git revert` — leaseworker returns to default priority (schedules fine, no scheduling priority).