### PR TITLE
controlplane: default actionsLeasor.enabled=true (v2-actions switch-over)

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1466,23 +1466,25 @@ services:
 #   - Sub-2.0.4 SDK CreateRun requests are hard-rejected
 #     (rejectLegacySDKVersions = true), exercising the queue/executor
 #     decommissioning path.
-# Chart default is off so chart upgrades don't break existing legacy-SDK users
-# in managed multi-tenant deployments. Fresh single-tenant selfhosted envs flip
-# this true in their per-env values-overrides.yaml — no need to duplicate the
-# executions.configMap block. The injection happens in templates/_helpers.tpl
+# Chart default is on as of the 2026-07-31 switch-over (see timeline below): every
+# deployment routes its own UNION_ORG through the v2 actions service and rejects
+# sub-2.0.4 SDK CreateRun. Envs that must stay on the legacy queue path (e.g. still
+# on SDK <2.0.4) set `enabled: false` explicitly in their per-env
+# values-overrides.yaml. The injection happens in templates/_helpers.tpl
 # (unionai.configMap), see actionsLeasor block there.
 #
 # DEPRECATION TIMELINE
 #   2026-06-30 — queue + executor services formally deprecated. SDK <2.0.4 still
 #                works through the legacy path but customers should migrate.
-#   2026-07-31 — complete switch-over: chart default flips to `enabled: true`,
-#                queue + executor templates are removed, and this knob becomes
-#                a no-op (kept briefly for compatibility, then removed). Any env
-#                still on SDK <2.0.4 after this date will hard-fail CreateRun.
+#   2026-07-31 — complete switch-over. Chart default flips to `enabled: true`
+#                (this change). Still pending: queue + executor templates are
+#                removed and this knob becomes a no-op (kept briefly for
+#                compatibility, then removed). Any env still on SDK <2.0.4 will
+#                hard-fail CreateRun once the default is on.
 # After 2026-07-31, env overlays that set `actionsLeasor.enabled: true`
 # explicitly can drop the override entirely.
 actionsLeasor:
-  enabled: false
+  enabled: true
 
 # Self-hosted runs 10 fixed shards (the same count Union's managed control
 # planes run). Each shard is its own single-replica Deployment owning a

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -440,10 +440,10 @@ data:
       httpPort: 8088
       port: 8089
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       internalConnectionConfig:
         enabled: true
@@ -591,10 +591,10 @@ data:
       metrics:
         scope: 'actions:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1590,6 +1590,16 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1742,6 +1752,16 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1853,7 +1873,7 @@ data:
         - staging
         - production
         maxRetries: 30
-        organization: ''
+        organization: 'test-org'
         projects: []
         retryInterval: 5s
         serviceAccounts: []
@@ -1890,10 +1910,10 @@ data:
       metrics:
         scope: 'authorizer:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1981,10 +2001,10 @@ data:
       metrics:
         scope: 'cluster:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2172,10 +2192,10 @@ data:
       metrics:
         scope: 'dataproxy:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2273,8 +2293,9 @@ data:
           ttl: 10m
         enabled: true
         enrichIdentities: false
-        rejectLegacySDKVersions: false
-        useActionsServiceForOrgs: []
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
     logger:
       formatter:
         type: json
@@ -2286,10 +2307,10 @@ data:
       metrics:
         scope: 'executions:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2374,10 +2395,10 @@ data:
     sharedService:
       connectPort: 8081
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2454,7 +2475,7 @@ data:
     organizations:
       bootStrapConfig:
         organizations:
-        - ''
+        - 'test-org'
         tenantType: SELF_MANAGED
     otel:
       type: noop
@@ -2463,10 +2484,10 @@ data:
       metrics:
         scope: 'organizations:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2547,10 +2568,10 @@ data:
       metrics:
         scope: 'queue:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2632,10 +2653,10 @@ data:
       metrics:
         scope: 'run-scheduler:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2711,10 +2732,10 @@ data:
       metrics:
         scope: 'usage:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2932,10 +2953,10 @@ data:
       metrics:
         scope: 'leasor:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -9455,7 +9476,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f0b6018534f9f726c266419f098e5de4a134c764e8e453a06ee8aa64548fd77"
+        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin
@@ -11810,7 +11831,7 @@ spec:
       annotations:
         checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
         checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 8b7ce0e83c9fabc54123c45a773b199735ba23af909e72059c44770ed86d3ea9
+        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -12086,7 +12107,7 @@ spec:
           protocol: TCP
         env:
           - name: UNION_ORG_OVERRIDE
-            value: ''
+            value: 'test-org'
         resources:
           limits:
             cpu: 500m
@@ -16369,7 +16390,7 @@ data:
       endpoint: 'test.example.com'
       insecure: false
     task:
-      org: ""
+      org: "test-org"
       project: "system"
       domain: "production"
 

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -2293,8 +2293,9 @@ data:
           ttl: 10m
         enabled: true
         enrichIdentities: false
-        rejectLegacySDKVersions: false
-        useActionsServiceForOrgs: []
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
     logger:
       formatter:
         type: json

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2309,8 +2309,9 @@ data:
           ttl: 10m
         enabled: true
         enrichIdentities: false
-        rejectLegacySDKVersions: false
-        useActionsServiceForOrgs: []
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
     logger:
       formatter:
         type: json

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -441,10 +441,10 @@ data:
       httpPort: 8088
       port: 8089
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       internalConnectionConfig:
         enabled: true
@@ -592,10 +592,10 @@ data:
       metrics:
         scope: 'actions:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1591,6 +1591,16 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1743,6 +1753,16 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1854,7 +1874,7 @@ data:
         - staging
         - production
         maxRetries: 30
-        organization: ''
+        organization: 'test-org'
         projects: []
         retryInterval: 5s
         serviceAccounts: []
@@ -1895,10 +1915,10 @@ data:
       metrics:
         scope: 'authorizer:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1986,10 +2006,10 @@ data:
       metrics:
         scope: 'cluster:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2177,10 +2197,10 @@ data:
       metrics:
         scope: 'dataproxy:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2278,8 +2298,9 @@ data:
           ttl: 10m
         enabled: true
         enrichIdentities: false
-        rejectLegacySDKVersions: false
-        useActionsServiceForOrgs: []
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
     logger:
       formatter:
         type: json
@@ -2291,10 +2312,10 @@ data:
       metrics:
         scope: 'executions:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2379,10 +2400,10 @@ data:
     sharedService:
       connectPort: 8081
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2459,7 +2480,7 @@ data:
     organizations:
       bootStrapConfig:
         organizations:
-        - ''
+        - 'test-org'
         tenantType: SELF_MANAGED
     otel:
       type: noop
@@ -2468,10 +2489,10 @@ data:
       metrics:
         scope: 'organizations:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2552,10 +2573,10 @@ data:
       metrics:
         scope: 'queue:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2637,10 +2658,10 @@ data:
       metrics:
         scope: 'run-scheduler:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2716,10 +2737,10 @@ data:
       metrics:
         scope: 'usage:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2937,10 +2958,10 @@ data:
       metrics:
         scope: 'leasor:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -9460,7 +9481,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "518e4c507cda03a17cb6788cc0ffed084ba5bfd1c5b95fd11c0f10a7ad57c25"
+        configChecksum: "75607c68c256979d7b2a8d9cd1a5c6bc240cc520cbec45bf36135ac37befef2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin
@@ -11815,7 +11836,7 @@ spec:
       annotations:
         checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
         checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 8b7ce0e83c9fabc54123c45a773b199735ba23af909e72059c44770ed86d3ea9
+        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -12091,7 +12112,7 @@ spec:
           protocol: TCP
         env:
           - name: UNION_ORG_OVERRIDE
-            value: ''
+            value: 'test-org'
         resources:
           limits:
             cpu: 500m
@@ -16360,7 +16381,7 @@ data:
       endpoint: 'test.example.com'
       insecure: false
     task:
-      org: ""
+      org: "test-org"
       project: "system"
       domain: "production"
 

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -438,10 +438,10 @@ data:
       httpPort: 8088
       port: 8089
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       internalConnectionConfig:
         enabled: true
@@ -589,10 +589,10 @@ data:
       metrics:
         scope: 'actions:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1588,6 +1588,16 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1740,6 +1750,16 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
+                    # Match the actions ConfigMap's sharedService.security so the
+                    # router and the in-service interceptor agree on org before
+                    # any Host-header fallback. Without this, intra-cluster Host
+                    # (controlplane-nginx-controller.<ns>.svc...) yields the
+                    # wrong org and the router picks the wrong shard. Only set
+                    # when UNION_ORG is configured (single-tenant deployments);
+                    # multi-tenant installs fall through to header-based org
+                    # resolution.
+                    security:
+                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1851,7 +1871,7 @@ data:
         - staging
         - production
         maxRetries: 30
-        organization: ''
+        organization: 'test-org'
         projects: []
         retryInterval: 5s
         serviceAccounts: []
@@ -1888,10 +1908,10 @@ data:
       metrics:
         scope: 'authorizer:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1979,10 +1999,10 @@ data:
       metrics:
         scope: 'cluster:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2170,10 +2190,10 @@ data:
       metrics:
         scope: 'dataproxy:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2271,8 +2291,9 @@ data:
           ttl: 10m
         enabled: true
         enrichIdentities: false
-        rejectLegacySDKVersions: false
-        useActionsServiceForOrgs: []
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
     logger:
       formatter:
         type: json
@@ -2284,10 +2305,10 @@ data:
       metrics:
         scope: 'executions:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2372,10 +2393,10 @@ data:
     sharedService:
       connectPort: 8081
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2452,7 +2473,7 @@ data:
     organizations:
       bootStrapConfig:
         organizations:
-        - ''
+        - 'test-org'
         tenantType: SELF_MANAGED
     otel:
       type: noop
@@ -2461,10 +2482,10 @@ data:
       metrics:
         scope: 'organizations:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2545,10 +2566,10 @@ data:
       metrics:
         scope: 'queue:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2630,10 +2651,10 @@ data:
       metrics:
         scope: 'run-scheduler:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2709,10 +2730,10 @@ data:
       metrics:
         scope: 'usage:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2930,10 +2951,10 @@ data:
       metrics:
         scope: 'leasor:'
       security:
-        singleTenantOrgID: ''
+        singleTenantOrgID: 'test-org'
       selfServeConfig:
         legacyHosts:
-        - ''
+        - 'test-org'
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -9453,7 +9474,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "016f6fe8ded80dab4090244e4967be6cb548a976675ea9a02f753faff8b3a88"
+        configChecksum: "a47f70dd39aa636afb5d25ffe53ec0785c33272fcc33b02d5f2066d8e65eeeb"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin
@@ -11808,7 +11829,7 @@ spec:
       annotations:
         checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
         checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 8b7ce0e83c9fabc54123c45a773b199735ba23af909e72059c44770ed86d3ea9
+        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -12084,7 +12105,7 @@ spec:
           protocol: TCP
         env:
           - name: UNION_ORG_OVERRIDE
-            value: ''
+            value: 'test-org'
         resources:
           limits:
             cpu: 500m
@@ -16264,7 +16285,7 @@ data:
       endpoint: 'test.example.com'
       insecure: false
     task:
-      org: ""
+      org: "test-org"
       project: "system"
       domain: "production"
 

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -2384,8 +2384,9 @@ data:
           ttl: 10m
         enabled: true
         enrichIdentities: false
-        rejectLegacySDKVersions: false
-        useActionsServiceForOrgs: []
+        rejectLegacySDKVersions: true
+        useActionsServiceForOrgs:
+        - test-org
     logger:
       formatter:
         type: json

--- a/tests/values/controlplane.aws.billing-enable.yaml
+++ b/tests/values/controlplane.aws.billing-enable.yaml
@@ -1,5 +1,6 @@
 global:
   UNION_HOST: "test.example.com"
+  UNION_ORG: "test-org"
   INTERNAL_CLIENT_ID: "test-internal-client-id"
   AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
 

--- a/tests/values/controlplane.external-authz.yaml
+++ b/tests/values/controlplane.external-authz.yaml
@@ -1,5 +1,6 @@
 global:
   UNION_HOST: "test.example.com"
+  UNION_ORG: "test-org"
   INTERNAL_CLIENT_ID: "test-internal-client-id"
   AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
   USE_EXTERNAL_IDENTITY: "true"

--- a/tests/values/controlplane.no-auth.yaml
+++ b/tests/values/controlplane.no-auth.yaml
@@ -1,5 +1,6 @@
 global:
   UNION_HOST: "test.example.com"
+  UNION_ORG: "test-org"
   INTERNAL_CLIENT_ID: "test-internal-client-id"
   AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
 


### PR DESCRIPTION
## Overview

Flips the `actionsLeasor.enabled` controlplane chart default `false → true`, per the switch-over timeline documented in `charts/controlplane/values.yaml`. With the default on, every selfhosted control plane routes its own `UNION_ORG` through the v2 actions service and stops depending on the legacy queue engine for eager/fan-out flows.

This is the "chart default flips to `enabled: true`" step of the **2026-07-31** milestone. The queue + executor template removal (the other half of that milestone) is intentionally **not** in this PR. The paired dataplane default (`operator.apiKey.enabled`) is split into its own PR: #482.

## Behavior change

For any deployment that does not set `actionsLeasor.enabled` explicitly, the `executions` configmap now renders:
- `useActionsServiceForOrgs: [<UNION_ORG>]` (was `[]`) — the deployment's own org routes to the v2 actions service.
- `rejectLegacySDKVersions: true` (was `false`) — **CreateRun from SDK < 2.0.4 is hard-rejected.**

The `rejectLegacySDKVersions` flip is the real blast radius: an env still on a sub-2.0.4 SDK will hard-fail CreateRun. Opt out with `actionsLeasor.enabled: false`.

The actions / leasor / scylla stack templates already rendered unconditionally, so there is **no** deployment/stack churn — the routing-config injection is the only functional delta.

## Note on timing

The values.yaml timeline schedules this flip for **2026-07-31**; this lands it ahead of that date deliberately. Merging is a conscious call by the switch-over owner.

## Test Plan

- Rebased onto latest `main`; `make generate-expected` + `make test` (helm-test + kubeconform) — green.
- 6 controlplane snapshots change: the two routing keys above. The `no-auth`, `external-authz`, and `aws.billing-enable` fixtures gain `global.UNION_ORG: test-org` (they previously omitted it, so the default-on flag rendered an empty org); those snapshots now reflect a real single-tenant deployment.

## Rollback

Revert this PR (`actionsLeasor.enabled: true → false`) and regenerate snapshots. State is reversible; no data migration.