### PR TITLE
dataplane: default operator.apiKey.enabled=true (eager API key bootstrap)

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -505,11 +505,14 @@ config:
     limitNamespace: ""
     # -- Disable cluster-wide permissions. Auto-set when low_privilege is true.
     disableClusterPermissions: false
-    # -- Eager API key bootstrap. When enabled, the operator mints the eager API
-    # key on the control plane and writes it to the task-pod secret store.
-    # Requires the secret manager (proxy.secretManager.enabled).
+    # -- Eager API key bootstrap. The operator mints the eager API key on the
+    # control plane and writes it to the task-pod secret store, so the
+    # union-pod-webhook can inject it into task pods. Required for v2/actions
+    # (eager) execution — nothing mints the key without this. Requires the secret
+    # manager (proxy.secretManager.enabled, chart default true). Default on as of
+    # the v2-actions switch-over; set false to opt a dataplane out.
     apiKey:
-      enabled: false
+      enabled: true
     # -- Compute resource manager configuration.
     computeResourceManager: {}
     # -- Organization namespace template override.

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -2806,6 +2806,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7046,7 +7048,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "49949c651a232c06d7c54e314481a3d213f345e25e7321783ef137b60dd85cb"
+        configChecksum: "66645984ebfd7044bd9bea269ca6136e3838d21746a42d7be4f441267fab5aa"
         prometheus.io/scrape: "true"
       labels:
         
@@ -7186,7 +7188,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "49949c651a232c06d7c54e314481a3d213f345e25e7321783ef137b60dd85cb"
+        configChecksum: "66645984ebfd7044bd9bea269ca6136e3838d21746a42d7be4f441267fab5aa"
         prometheus.io/scrape: "true"
       labels:
         

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -2826,6 +2826,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7074,7 +7076,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f570f29ae93780ed03a5b9c71f5f7f510fbbbb6bee8bea38bef87fbb98b7fa"
+        configChecksum: "78e56482ff573ddd7738182fdc84f4d0c3519c60697d7ab6dd6cce5a5d9a5eb"
         
       labels:
         
@@ -7212,7 +7214,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6f570f29ae93780ed03a5b9c71f5f7f510fbbbb6bee8bea38bef87fbb98b7fa"
+        configChecksum: "78e56482ff573ddd7738182fdc84f4d0c3519c60697d7ab6dd6cce5a5d9a5eb"
         
       labels:
         

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3006,6 +3006,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7582,7 +7584,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0fb440fd8b858d80e8b9ddf6dec3ebcc7a22a120bbca8f4fbf4e3c957933fa6"
+        configChecksum: "1026fe992b5c8313cf9180d55444c01a55215709a24c60612beaf56c5a99221"
         
       labels:
         
@@ -7720,7 +7722,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "0fb440fd8b858d80e8b9ddf6dec3ebcc7a22a120bbca8f4fbf4e3c957933fa6"
+        configChecksum: "1026fe992b5c8313cf9180d55444c01a55215709a24c60612beaf56c5a99221"
         
       labels:
         

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -2829,6 +2829,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7065,7 +7067,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9a3961c44eefb5c08ee82f7532f02832a3ca1152cab763e863b8f2358adebd7"
+        configChecksum: "8d6238984f402a02802d737ff35478e60dcb8b0de4628fcd352c3c2fb4782a3"
         
       labels:
         
@@ -7203,7 +7205,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9a3961c44eefb5c08ee82f7532f02832a3ca1152cab763e863b8f2358adebd7"
+        configChecksum: "8d6238984f402a02802d737ff35478e60dcb8b0de4628fcd352c3c2fb4782a3"
         
       labels:
         

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2933,6 +2933,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7509,7 +7511,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "18cc015159fe154e0380317e8a8dad2b4bcddc89e9f7636e0dbbcef0ef47e83"
+        configChecksum: "8c5bf59e07f65c856c026cfc09a4aa410fabecd7857d2e7173d55ac3c492962"
         
       labels:
         
@@ -7647,7 +7649,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "18cc015159fe154e0380317e8a8dad2b4bcddc89e9f7636e0dbbcef0ef47e83"
+        configChecksum: "8c5bf59e07f65c856c026cfc09a4aa410fabecd7857d2e7173d55ac3c492962"
         
       labels:
         

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -4873,6 +4873,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -8777,7 +8779,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "eff49a8b4224a61e5be253e6249e30afa9ba543c03a359673a428447557d6bd"
+        configChecksum: "f7b9144672445f1489242224b6e6b0d17e6856f365f874f68d7ec1a3f1e424c"
         
       labels:
         
@@ -10108,7 +10110,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "eff49a8b4224a61e5be253e6249e30afa9ba543c03a359673a428447557d6bd"
+        configChecksum: "f7b9144672445f1489242224b6e6b0d17e6856f365f874f68d7ec1a3f1e424c"
         
       labels:
         
@@ -10246,7 +10248,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "eff49a8b4224a61e5be253e6249e30afa9ba543c03a359673a428447557d6bd"
+        configChecksum: "f7b9144672445f1489242224b6e6b0d17e6856f365f874f68d7ec1a3f1e424c"
         
       labels:
         

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -4873,6 +4873,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -8777,7 +8779,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ada0239b44d0d6389b8d893352a28d56d811608648740d46d3830e4390ab42f"
+        configChecksum: "46d0ffee2e90d6524fcb2f04426367d0c2b638924b51cb2f1ddcf5b389124d1"
         
       labels:
         
@@ -10108,7 +10110,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ada0239b44d0d6389b8d893352a28d56d811608648740d46d3830e4390ab42f"
+        configChecksum: "46d0ffee2e90d6524fcb2f04426367d0c2b638924b51cb2f1ddcf5b389124d1"
         
       labels:
         
@@ -10246,7 +10248,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ada0239b44d0d6389b8d893352a28d56d811608648740d46d3830e4390ab42f"
+        configChecksum: "46d0ffee2e90d6524fcb2f04426367d0c2b638924b51cb2f1ddcf5b389124d1"
         
       labels:
         

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -2865,6 +2865,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         azureLogAnalytics:
@@ -7111,7 +7113,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "49a64764da3505068a80ae607454be38186061a8441bfbeea447a9cc6ffccdb"
+        configChecksum: "30a95791e569b9f7333c496f8fc1d24395cd6526d6d30c3f79b2bbb87d6690e"
         
       labels:
         
@@ -7250,7 +7252,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "49a64764da3505068a80ae607454be38186061a8441bfbeea447a9cc6ffccdb"
+        configChecksum: "30a95791e569b9f7333c496f8fc1d24395cd6526d6d30c3f79b2bbb87d6690e"
         
       labels:
         

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -2865,6 +2865,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         azureLogAnalytics:
@@ -7111,7 +7113,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c78e17cbbec7eda672048d8e7dd06f9fad80a08db080feeb3a14db7d26c4770"
+        configChecksum: "12ef773e11826ca00cf6fd22865ecef9bacd039589f1eb0f809cb8e84e16add"
         
       labels:
         
@@ -7250,7 +7252,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c78e17cbbec7eda672048d8e7dd06f9fad80a08db080feeb3a14db7d26c4770"
+        configChecksum: "12ef773e11826ca00cf6fd22865ecef9bacd039589f1eb0f809cb8e84e16add"
         
       labels:
         

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -2965,6 +2965,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7256,7 +7258,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "701425142ac61a626ff0719211c036fb65aef5ce7cc0abcc80fefc18526fae0"
+        configChecksum: "f1d85fc7d88cc6902f84765220dee1b8b44cdbe03d3de33e03ba198104f7228"
         
       labels:
         
@@ -7396,7 +7398,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "701425142ac61a626ff0719211c036fb65aef5ce7cc0abcc80fefc18526fae0"
+        configChecksum: "f1d85fc7d88cc6902f84765220dee1b8b44cdbe03d3de33e03ba198104f7228"
         
       labels:
         

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -2811,6 +2811,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7059,7 +7061,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6fc1d308eb81cd3bf1b384bde8ee895942d8a4bc3bdca7f44db7ce69164fd5e"
+        configChecksum: "28121416b918ab139b353ca4150818407f1e08122890c69a5bb577cf061e451"
         
       labels:
         
@@ -7197,7 +7199,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6fc1d308eb81cd3bf1b384bde8ee895942d8a4bc3bdca7f44db7ce69164fd5e"
+        configChecksum: "28121416b918ab139b353ca4150818407f1e08122890c69a5bb577cf061e451"
         
       labels:
         

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -2936,6 +2936,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7392,7 +7394,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6fc1d308eb81cd3bf1b384bde8ee895942d8a4bc3bdca7f44db7ce69164fd5e"
+        configChecksum: "28121416b918ab139b353ca4150818407f1e08122890c69a5bb577cf061e451"
         
       labels:
         
@@ -7530,7 +7532,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6fc1d308eb81cd3bf1b384bde8ee895942d8a4bc3bdca7f44db7ce69164fd5e"
+        configChecksum: "28121416b918ab139b353ca4150818407f1e08122890c69a5bb577cf061e451"
         
       labels:
         

--- a/tests/generated/dataplane.flytepropeller.yaml
+++ b/tests/generated/dataplane.flytepropeller.yaml
@@ -2852,6 +2852,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7235,7 +7237,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e46f5fb9952316f9d75f12e97b8f909d2f2d0255df96ec998a16a04e5b32943"
+        configChecksum: "46df08c6c65a33cdc81cacee2c9f3e209c252f9f2a6afeed8ae28858be0c0bc"
         
       labels:
         
@@ -7373,7 +7375,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e46f5fb9952316f9d75f12e97b8f909d2f2d0255df96ec998a16a04e5b32943"
+        configChecksum: "46df08c6c65a33cdc81cacee2c9f3e209c252f9f2a6afeed8ae28858be0c0bc"
         
       labels:
         

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -2816,6 +2816,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7044,7 +7046,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "576ab15c68ed92fd3deed67082135788b6a9af844d278291bcb2f8292dd2b4d"
+        configChecksum: "462af1d77a7c557e4c967f2f68bb3b8db4404f9bd3f13467de21faccf0868e5"
         
       labels:
         
@@ -7151,7 +7153,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "576ab15c68ed92fd3deed67082135788b6a9af844d278291bcb2f8292dd2b4d"
+        configChecksum: "462af1d77a7c557e4c967f2f68bb3b8db4404f9bd3f13467de21faccf0868e5"
         
       labels:
         

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -2815,6 +2815,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7057,7 +7059,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f9851af1d9c505a9f2301068ab03bcae7be6a71ad82f38df1f130a6a026febf"
+        configChecksum: "b6c0cef0841fee29ce20b9270f5a15179c67ed511f219d5641b869f7f06920a"
         
       labels:
         
@@ -7195,7 +7197,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f9851af1d9c505a9f2301068ab03bcae7be6a71ad82f38df1f130a6a026febf"
+        configChecksum: "b6c0cef0841fee29ce20b9270f5a15179c67ed511f219d5641b869f7f06920a"
         
       labels:
         

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -2834,6 +2834,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7082,7 +7084,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "264037ad53b9e629d7a1610d6a80ed274e1cc465acff5d1aec335bc28aef22c"
+        configChecksum: "120272e0ba706a110c67954998c595da5c6d2cd901c066258bb5e12087ba339"
         
       labels:
         
@@ -7220,7 +7222,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "264037ad53b9e629d7a1610d6a80ed274e1cc465acff5d1aec335bc28aef22c"
+        configChecksum: "120272e0ba706a110c67954998c595da5c6d2cd901c066258bb5e12087ba339"
         
       labels:
         

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -3639,6 +3639,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -9196,7 +9198,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3a0666694365dc80b0f1b3c9392f1a81f512022b2f22c29b90062d2447ec48d"
+        configChecksum: "94b07b9fdbc60ce9916786cbd811088a251ed4ad733f336f0c97435e51fc917"
         
       labels:
         
@@ -9334,7 +9336,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3a0666694365dc80b0f1b3c9392f1a81f512022b2f22c29b90062d2447ec48d"
+        configChecksum: "94b07b9fdbc60ce9916786cbd811088a251ed4ad733f336f0c97435e51fc917"
         
       labels:
         

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -2829,6 +2829,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7209,7 +7211,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6fc1d308eb81cd3bf1b384bde8ee895942d8a4bc3bdca7f44db7ce69164fd5e"
+        configChecksum: "28121416b918ab139b353ca4150818407f1e08122890c69a5bb577cf061e451"
         
       labels:
         
@@ -7347,7 +7349,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6fc1d308eb81cd3bf1b384bde8ee895942d8a4bc3bdca7f44db7ce69164fd5e"
+        configChecksum: "28121416b918ab139b353ca4150818407f1e08122890c69a5bb577cf061e451"
         
       labels:
         

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -2849,6 +2849,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7129,7 +7131,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cfab2aeed5e668139522e31785b1ea03f31fac95f101e0250cf97ac17e2f741"
+        configChecksum: "40a5da7e71c44c935befd0feeb7b4fe20a86e739b024dbc362b719958d9bb88"
         
       labels:
         
@@ -7280,7 +7282,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "cfab2aeed5e668139522e31785b1ea03f31fac95f101e0250cf97ac17e2f741"
+        configChecksum: "40a5da7e71c44c935befd0feeb7b4fe20a86e739b024dbc362b719958d9bb88"
         
       labels:
         

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -2822,6 +2822,8 @@ data:
           union.ai/namespace-type: flyte
         referenceConfigmapName: union-operator
         targetConfigMapName: "build-image-config"
+      apiKey:
+        enabled: true
     proxy:
       persistedLogs:
         objectStore:
@@ -7066,7 +7068,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "400dee38218429397099fc38519bee320d14a61006bfefabb523e635a98162e"
+        configChecksum: "933d38aa5934a13f17c59344887bd9b2d4415ccbbf117e6506745cc7db73e89"
         
       labels:
         
@@ -7204,7 +7206,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "400dee38218429397099fc38519bee320d14a61006bfefabb523e635a98162e"
+        configChecksum: "933d38aa5934a13f17c59344887bd9b2d4415ccbbf117e6506745cc7db73e89"
         
       labels:
         


### PR DESCRIPTION
## Overview

Flips the dataplane chart default `config.operator.apiKey.enabled: false → true`. With it on, the operator mints the eager API key on the control plane and writes it to the task-pod secret store, so the union-pod-webhook can inject it into task pods. Nothing mints the key without this, and it is **required for v2/actions (eager) execution** — see [cloud#17056 review](https://github.com/unionai/cloud/pull/17056#discussion_r3598822621).

Split out of #481 as an isolated change so the controlplane `actionsLeasor` default and this dataplane default land independently.

## Behavior change

The operator configmap now renders the `apiKey` block (`enabled: true`). The prereq `proxy.secretManager.enabled` is already the chart default (`true`), so no dataplane loses functionality. A dataplane that must opt out sets `config.operator.apiKey.enabled: false`.

No deployments are added or removed — the operator already rendered unconditionally; the delta is the configmap block plus the operator deployment's recomputed `configChecksum`.

## Test Plan

- `make generate-expected` + `make test` (helm-test + kubeconform) — green.
- 20 dataplane snapshots regenerated; delta limited to the `apiKey: {enabled: true}` block and the recomputed `configChecksum`.

## Rollback

Revert this PR (`enabled: true → false`) and regenerate snapshots. State is reversible; no data migration.