### PR TITLE
Release 2026.7.1

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,7 +3,7 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.7.0
+version: 2026.7.1
 appVersion: 2026.7.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -10,7 +10,7 @@ description: 'DEPRECATED. Use `crds/flyte-v1/` for FlyteWorkflow and `crds/kube-
 deprecated: true
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.7.0
+version: 2026.7.1
 appVersion: 2026.7.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.7.0
+version: 2026.7.1
 appVersion: 2026.7.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:
@@ -14,12 +14,6 @@ dependencies:
   condition: monitoring.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  # Newest 25.x (appVersion Prometheus v2.55.1). 25.27.0 shipped v2.54.1, whose
-  # vendored prometheus/common v0.55.0 has the oauth2 `lastSecret` bug: with a
-  # client_secret_file the remote_write token source is rebuilt on every request,
-  # discarding the cached token so every send does a fresh token POST — which can
-  # wedge remote_write on a stuck fetch. Fixed in common v0.57.0 (Prometheus
-  # 2.55.0+); 2.55.x caches the token for its full TTL.
   version: 25.30.2
   alias: prometheus
   condition: prometheus.enabled

--- a/charts/knative-migration/Chart.yaml
+++ b/charts/knative-migration/Chart.yaml
@@ -13,6 +13,6 @@ description: 'One-shot cleanup of knative-operator residue (stuck KnativeServing
   '
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.7.0
+version: 2026.7.1
 appVersion: 0.1.0
 kubeVersion: '>= 1.28.0-0'

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.7.0
+version: 2026.7.1
 appVersion: 2026.7.0
 kubeVersion: '>= 1.28.0'

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -257,7 +257,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -519,7 +519,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -622,7 +622,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -696,7 +696,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1385,7 +1385,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1419,7 +1419,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1774,7 +1774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1842,7 +1842,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1941,7 +1941,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2032,7 +2032,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2224,7 +2224,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2340,7 +2340,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2424,7 +2424,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2515,7 +2515,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2599,7 +2599,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2684,7 +2684,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2879,7 +2879,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2895,7 +2895,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8363,7 +8363,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8386,7 +8386,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8439,7 +8439,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8463,7 +8463,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8626,7 +8626,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8660,7 +8660,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8697,7 +8697,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8734,7 +8734,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8771,7 +8771,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8808,7 +8808,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8845,7 +8845,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8882,7 +8882,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8919,7 +8919,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8956,7 +8956,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8993,7 +8993,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9033,7 +9033,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9061,7 +9061,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9090,7 +9090,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9129,7 +9129,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9168,7 +9168,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9203,7 +9203,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9238,7 +9238,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9273,7 +9273,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9308,7 +9308,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9347,7 +9347,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9382,7 +9382,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9417,7 +9417,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9968,7 +9968,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10152,7 +10152,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10336,7 +10336,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10520,7 +10520,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10704,7 +10704,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10888,7 +10888,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11072,7 +11072,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11256,7 +11256,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11440,7 +11440,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11624,7 +11624,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11809,7 +11809,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11827,9 +11827,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11938,7 +11938,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11949,7 +11949,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "74799f9404d34600bd099aaab048cd5dbd7bd8826295f708bb1878579941ca0"
+        configChecksum: "6631093b4b151dfd2ec380115d0f62af0038a217b92c8adcf53bebeb4745593"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11958,7 +11958,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12051,7 +12051,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12122,7 +12122,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12237,7 +12237,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12368,7 +12368,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12480,7 +12480,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12608,7 +12608,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12723,7 +12723,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12849,7 +12849,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12996,7 +12996,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13125,7 +13125,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13254,7 +13254,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13404,7 +13404,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -137,7 +137,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -161,7 +161,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -197,7 +197,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -209,7 +209,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -259,7 +259,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -521,7 +521,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -624,7 +624,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -698,7 +698,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1387,7 +1387,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1421,7 +1421,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1776,7 +1776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1844,7 +1844,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1943,7 +1943,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2034,7 +2034,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2226,7 +2226,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2342,7 +2342,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2426,7 +2426,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2517,7 +2517,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2601,7 +2601,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2686,7 +2686,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2881,7 +2881,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2897,7 +2897,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8365,7 +8365,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8388,7 +8388,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8441,7 +8441,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8465,7 +8465,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8628,7 +8628,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8662,7 +8662,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8699,7 +8699,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8736,7 +8736,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8773,7 +8773,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8810,7 +8810,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8847,7 +8847,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8884,7 +8884,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8921,7 +8921,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8958,7 +8958,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8995,7 +8995,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9035,7 +9035,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9063,7 +9063,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9092,7 +9092,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9131,7 +9131,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9170,7 +9170,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9205,7 +9205,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9240,7 +9240,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9275,7 +9275,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9310,7 +9310,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9349,7 +9349,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9384,7 +9384,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9419,7 +9419,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9970,7 +9970,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10154,7 +10154,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10338,7 +10338,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10522,7 +10522,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10706,7 +10706,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10890,7 +10890,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11074,7 +11074,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11258,7 +11258,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11442,7 +11442,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11626,7 +11626,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11811,7 +11811,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11829,9 +11829,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11940,7 +11940,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11951,7 +11951,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "74799f9404d34600bd099aaab048cd5dbd7bd8826295f708bb1878579941ca0"
+        configChecksum: "6631093b4b151dfd2ec380115d0f62af0038a217b92c8adcf53bebeb4745593"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11960,7 +11960,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12053,7 +12053,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12124,7 +12124,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12239,7 +12239,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12370,7 +12370,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12482,7 +12482,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12610,7 +12610,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12725,7 +12725,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12851,7 +12851,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12998,7 +12998,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13127,7 +13127,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13256,7 +13256,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13406,7 +13406,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -137,7 +137,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -161,7 +161,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -197,7 +197,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -209,7 +209,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -259,7 +259,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -521,7 +521,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -624,7 +624,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -698,7 +698,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1387,7 +1387,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1421,7 +1421,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1776,7 +1776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1844,7 +1844,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1943,7 +1943,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2034,7 +2034,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2226,7 +2226,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2342,7 +2342,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2426,7 +2426,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2517,7 +2517,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2601,7 +2601,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2686,7 +2686,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2881,7 +2881,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2897,7 +2897,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8365,7 +8365,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8388,7 +8388,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8441,7 +8441,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8465,7 +8465,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8628,7 +8628,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8662,7 +8662,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8699,7 +8699,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8736,7 +8736,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8773,7 +8773,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8810,7 +8810,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8847,7 +8847,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8884,7 +8884,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8921,7 +8921,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8958,7 +8958,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8995,7 +8995,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9035,7 +9035,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9063,7 +9063,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9092,7 +9092,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9131,7 +9131,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9170,7 +9170,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9205,7 +9205,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9240,7 +9240,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9275,7 +9275,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9310,7 +9310,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9349,7 +9349,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9384,7 +9384,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9419,7 +9419,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9970,7 +9970,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10154,7 +10154,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10338,7 +10338,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10522,7 +10522,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10706,7 +10706,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10890,7 +10890,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11074,7 +11074,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11258,7 +11258,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11442,7 +11442,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11626,7 +11626,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11811,7 +11811,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11829,9 +11829,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11940,7 +11940,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11951,7 +11951,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "74799f9404d34600bd099aaab048cd5dbd7bd8826295f708bb1878579941ca0"
+        configChecksum: "6631093b4b151dfd2ec380115d0f62af0038a217b92c8adcf53bebeb4745593"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11961,7 +11961,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12054,7 +12054,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12126,7 +12126,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12242,7 +12242,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12374,7 +12374,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12487,7 +12487,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12616,7 +12616,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12732,7 +12732,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12859,7 +12859,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13007,7 +13007,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13137,7 +13137,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13267,7 +13267,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13412,7 +13412,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -125,7 +125,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -163,7 +163,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -175,7 +175,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -187,7 +187,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -199,7 +199,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -223,7 +223,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -235,7 +235,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -247,7 +247,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -261,7 +261,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -532,7 +532,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -635,7 +635,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -709,7 +709,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1398,7 +1398,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1432,7 +1432,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1787,7 +1787,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1860,7 +1860,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1959,7 +1959,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2050,7 +2050,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2242,7 +2242,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2358,7 +2358,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2447,7 +2447,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2538,7 +2538,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2622,7 +2622,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2707,7 +2707,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2902,7 +2902,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2918,7 +2918,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8389,7 +8389,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8412,7 +8412,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8465,7 +8465,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8489,7 +8489,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8652,7 +8652,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8686,7 +8686,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8723,7 +8723,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8760,7 +8760,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8797,7 +8797,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8834,7 +8834,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8871,7 +8871,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8908,7 +8908,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8945,7 +8945,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8982,7 +8982,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9019,7 +9019,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9059,7 +9059,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9087,7 +9087,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9116,7 +9116,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9155,7 +9155,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9194,7 +9194,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9229,7 +9229,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9264,7 +9264,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9299,7 +9299,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9334,7 +9334,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9373,7 +9373,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9408,7 +9408,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9443,7 +9443,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10000,7 +10000,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10184,7 +10184,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10368,7 +10368,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10552,7 +10552,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10736,7 +10736,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10920,7 +10920,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11104,7 +11104,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11288,7 +11288,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11472,7 +11472,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11656,7 +11656,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11841,7 +11841,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11859,9 +11859,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11970,7 +11970,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11981,7 +11981,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3c31ceef1d44d134a3a7d345700cf56e426395343eacd420f3f309dbfb9dace"
+        configChecksum: "222024308a5a251bd421debb41a5db7e28a4c0a3e8b1a20d8d1debb904aa3d3"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11990,7 +11990,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12083,7 +12083,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12154,7 +12154,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12269,7 +12269,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12400,7 +12400,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12512,7 +12512,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12640,7 +12640,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12766,7 +12766,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12892,7 +12892,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13039,7 +13039,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13168,7 +13168,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13297,7 +13297,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13447,7 +13447,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -257,7 +257,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -522,7 +522,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -625,7 +625,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -699,7 +699,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1388,7 +1388,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1422,7 +1422,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1777,7 +1777,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1845,7 +1845,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1948,7 +1948,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2039,7 +2039,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2231,7 +2231,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2347,7 +2347,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2431,7 +2431,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2522,7 +2522,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2606,7 +2606,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2691,7 +2691,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2886,7 +2886,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2902,7 +2902,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8370,7 +8370,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8393,7 +8393,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8446,7 +8446,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8470,7 +8470,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8633,7 +8633,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8667,7 +8667,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8704,7 +8704,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8741,7 +8741,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8778,7 +8778,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8815,7 +8815,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8852,7 +8852,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8889,7 +8889,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8926,7 +8926,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8963,7 +8963,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9000,7 +9000,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9040,7 +9040,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9068,7 +9068,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9097,7 +9097,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9136,7 +9136,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9175,7 +9175,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9210,7 +9210,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9245,7 +9245,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9280,7 +9280,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9315,7 +9315,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9354,7 +9354,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9389,7 +9389,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9424,7 +9424,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9975,7 +9975,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10159,7 +10159,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10343,7 +10343,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10527,7 +10527,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10711,7 +10711,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10895,7 +10895,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11079,7 +11079,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11263,7 +11263,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11447,7 +11447,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11631,7 +11631,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11816,7 +11816,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11834,9 +11834,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11945,7 +11945,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11956,7 +11956,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3570fcb7c945f44fca8332ebbcc14089d4707dacdd05a85d67b8e462a73ae7a"
+        configChecksum: "56aa4548f95d9d001d9c5d88098799d8407874e2e17870b7c803d1b189c1d49"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11965,7 +11965,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12058,7 +12058,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12129,7 +12129,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12244,7 +12244,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12375,7 +12375,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12487,7 +12487,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12615,7 +12615,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12730,7 +12730,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12856,7 +12856,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13003,7 +13003,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13132,7 +13132,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13261,7 +13261,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13411,7 +13411,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -257,7 +257,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -519,7 +519,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -622,7 +622,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -696,7 +696,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1385,7 +1385,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1419,7 +1419,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1774,7 +1774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1842,7 +1842,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1941,7 +1941,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2032,7 +2032,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2224,7 +2224,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2340,7 +2340,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2424,7 +2424,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2515,7 +2515,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2599,7 +2599,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2684,7 +2684,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2879,7 +2879,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2895,7 +2895,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8363,7 +8363,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8386,7 +8386,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8439,7 +8439,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8463,7 +8463,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8626,7 +8626,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8660,7 +8660,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8697,7 +8697,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8734,7 +8734,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8771,7 +8771,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8808,7 +8808,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8845,7 +8845,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8882,7 +8882,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8919,7 +8919,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8956,7 +8956,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8993,7 +8993,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9033,7 +9033,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9061,7 +9061,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9090,7 +9090,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9129,7 +9129,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9168,7 +9168,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9203,7 +9203,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9238,7 +9238,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9273,7 +9273,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9308,7 +9308,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9347,7 +9347,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9382,7 +9382,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9417,7 +9417,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9968,7 +9968,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10152,7 +10152,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10336,7 +10336,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10520,7 +10520,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10704,7 +10704,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10888,7 +10888,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11072,7 +11072,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11256,7 +11256,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11440,7 +11440,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11624,7 +11624,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11809,7 +11809,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11827,9 +11827,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11938,7 +11938,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11949,7 +11949,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "74799f9404d34600bd099aaab048cd5dbd7bd8826295f708bb1878579941ca0"
+        configChecksum: "6631093b4b151dfd2ec380115d0f62af0038a217b92c8adcf53bebeb4745593"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11958,7 +11958,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12051,7 +12051,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12122,7 +12122,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12237,7 +12237,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12368,7 +12368,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12480,7 +12480,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12608,7 +12608,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12723,7 +12723,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12849,7 +12849,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12996,7 +12996,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13125,7 +13125,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13254,7 +13254,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13404,7 +13404,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -39,7 +39,7 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -114,7 +114,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -127,7 +127,7 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -143,7 +143,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -155,7 +155,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -169,7 +169,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -181,7 +181,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -205,7 +205,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -217,7 +217,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -229,7 +229,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -241,7 +241,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -277,7 +277,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -291,7 +291,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -553,7 +553,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -656,7 +656,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -730,7 +730,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1419,7 +1419,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1453,7 +1453,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1805,7 +1805,7 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -1855,7 +1855,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1923,7 +1923,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2034,7 +2034,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2125,7 +2125,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2317,7 +2317,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2433,7 +2433,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2517,7 +2517,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2608,7 +2608,7 @@ kind: ConfigMap
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2692,7 +2692,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2777,7 +2777,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -2972,7 +2972,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2988,7 +2988,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8456,7 +8456,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8476,7 +8476,7 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8495,7 +8495,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -8548,7 +8548,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8569,7 +8569,7 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8593,7 +8593,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8756,7 +8756,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8790,7 +8790,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8827,7 +8827,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8864,7 +8864,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8901,7 +8901,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8938,7 +8938,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8975,7 +8975,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9012,7 +9012,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9049,7 +9049,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9086,7 +9086,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9123,7 +9123,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9159,7 +9159,7 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9186,7 +9186,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -9214,7 +9214,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9243,7 +9243,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9282,7 +9282,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9321,7 +9321,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9356,7 +9356,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9391,7 +9391,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9426,7 +9426,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9461,7 +9461,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9500,7 +9500,7 @@ metadata:
   name: queue
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9535,7 +9535,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9570,7 +9570,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10121,7 +10121,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10305,7 +10305,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10489,7 +10489,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10673,7 +10673,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -10857,7 +10857,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11041,7 +11041,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11225,7 +11225,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11409,7 +11409,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11593,7 +11593,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11777,7 +11777,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11962,7 +11962,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -11980,9 +11980,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 4f31532bb90886086b53e2fb3bccbb96c38106ac7ec08c82111b4ccdf4c19981
-        checksum/router-cds: 8a264b99c3d67c2a3da62bd0a08d56c3ffb40fdbc3f431597f61ae4c27ee1aa8
-        checksum/router-lds: 42cd27c78ce686a1c2b070ab5af5ec0b67b5d5cd698a96c6c99a78b131e3c7ee
+        checksum/router-bootstrap: 4a715a60bc2436e001b4da522eaaa4189c833af2a9a3f7252f9910599fd202cb
+        checksum/router-cds: 41d16a230ad957aa4bdd783eff11496c30bd0ebef33abb30f2b15641ca555886
+        checksum/router-lds: b5d2c27b5edf5c1959d491051db7be737e14a1decba7838e6b431c41ce24cc54
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -12088,7 +12088,7 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12106,7 +12106,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1991a78ea2d1a103ec0401a6c873070ebbc12ce42b4df419ab4bad6db9dfe88
+        checksum/config: 4637d9dcd2822c117473abb627b9cf5b2fad4afb665a0a3c279b1576e199e435
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -12208,7 +12208,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -12219,7 +12219,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "74799f9404d34600bd099aaab048cd5dbd7bd8826295f708bb1878579941ca0"
+        configChecksum: "6631093b4b151dfd2ec380115d0f62af0038a217b92c8adcf53bebeb4745593"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -12228,7 +12228,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.7.0
+        helm.sh/chart: controlplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -12321,7 +12321,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12392,7 +12392,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12507,7 +12507,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12638,7 +12638,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12750,7 +12750,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12878,7 +12878,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -12993,7 +12993,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13119,7 +13119,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13266,7 +13266,7 @@ kind: Deployment
 metadata:
   name: queue
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: queue
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13395,7 +13395,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13524,7 +13524,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13668,7 +13668,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -13695,7 +13695,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.7.0
+    helm.sh/chart: controlplane-2026.7.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -2862,7 +2862,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7228,7 +7228,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7617,7 +7617,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7671,7 +7671,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -2894,7 +2894,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7252,7 +7252,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7639,7 +7639,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7693,7 +7693,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3062,7 +3062,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7760,7 +7760,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -8236,7 +8236,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8290,7 +8290,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -2885,7 +2885,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7249,7 +7249,7 @@ spec:
               readOnly: true
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7758,7 +7758,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7812,7 +7812,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2989,7 +2989,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7687,7 +7687,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -8106,7 +8106,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8160,7 +8160,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -130,7 +130,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -159,7 +159,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -173,7 +173,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -211,7 +211,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -409,7 +409,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -688,7 +688,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -903,7 +903,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -977,7 +977,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1137,7 +1137,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1276,7 +1276,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1345,7 +1345,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1605,7 +1605,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1709,7 +1709,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1797,7 +1797,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1863,7 +1863,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1948,7 +1948,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2158,7 +2158,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2282,7 +2282,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -4938,7 +4938,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -6274,7 +6274,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6307,7 +6307,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6344,7 +6344,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6360,7 +6360,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6401,7 +6401,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6421,7 +6421,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6441,7 +6441,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6472,7 +6472,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6540,7 +6540,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6565,7 +6565,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6623,7 +6623,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6645,7 +6645,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6666,7 +6666,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6687,7 +6687,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6839,7 +6839,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7277,7 +7277,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7682,7 +7682,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7717,7 +7717,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7744,7 +7744,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7774,7 +7774,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7804,7 +7804,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7833,7 +7833,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7857,7 +7857,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7884,7 +7884,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8952,7 +8952,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9081,7 +9081,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9185,7 +9185,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9298,7 +9298,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9397,7 +9397,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -9413,7 +9413,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.7.0
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -9424,7 +9424,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 22393adda5717055b0a74c1e79255e3f910b8a382adc098863129b247e30a9bf
+        checksum/bootstrap-config: b7be8695706be8d78f1e46f374d358840056550d7ce8e62ac8cfff54369bb338
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -9540,7 +9540,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9565,7 +9565,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.7.0
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9672,7 +9672,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10286,7 +10286,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -10504,7 +10504,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10539,7 +10539,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10584,7 +10584,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10771,7 +10771,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10978,7 +10978,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11023,7 +11023,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11215,7 +11215,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11250,7 +11250,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -130,7 +130,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -159,7 +159,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -173,7 +173,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -211,7 +211,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -409,7 +409,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -688,7 +688,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -903,7 +903,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -977,7 +977,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1137,7 +1137,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1276,7 +1276,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1345,7 +1345,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1605,7 +1605,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1709,7 +1709,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1797,7 +1797,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1863,7 +1863,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1948,7 +1948,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2158,7 +2158,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2282,7 +2282,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -4938,7 +4938,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -6274,7 +6274,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6307,7 +6307,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6344,7 +6344,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6360,7 +6360,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6401,7 +6401,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6421,7 +6421,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6441,7 +6441,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6472,7 +6472,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6540,7 +6540,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6565,7 +6565,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6623,7 +6623,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6645,7 +6645,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6666,7 +6666,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6687,7 +6687,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6839,7 +6839,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7277,7 +7277,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7682,7 +7682,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7717,7 +7717,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7744,7 +7744,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7774,7 +7774,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7804,7 +7804,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7833,7 +7833,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7857,7 +7857,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7884,7 +7884,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8952,7 +8952,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9081,7 +9081,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9185,7 +9185,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9298,7 +9298,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9397,7 +9397,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -9413,7 +9413,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.7.0
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -9424,7 +9424,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 3f240d72894214db42a988137de848b91a287f3971ec2127a6e58872a6c48a16
+        checksum/bootstrap-config: 934b4d40638e5994229dd8d17019b4ee097a8f31edc77f683a72ff6daac8fc86
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -9540,7 +9540,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9565,7 +9565,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.7.0
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9672,7 +9672,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10286,7 +10286,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -10504,7 +10504,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10539,7 +10539,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10584,7 +10584,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10771,7 +10771,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10978,7 +10978,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11023,7 +11023,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11215,7 +11215,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11250,7 +11250,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -2929,7 +2929,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7291,7 +7291,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7679,7 +7679,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7733,7 +7733,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -2929,7 +2929,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7291,7 +7291,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7679,7 +7679,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7733,7 +7733,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3033,7 +3033,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7436,7 +7436,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7809,7 +7809,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7863,7 +7863,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -2879,7 +2879,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7237,7 +7237,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7624,7 +7624,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7678,7 +7678,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3004,7 +3004,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7570,7 +7570,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7989,7 +7989,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8043,7 +8043,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.flytepropeller.yaml
+++ b/tests/generated/dataplane.flytepropeller.yaml
@@ -2914,7 +2914,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7413,7 +7413,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7895,7 +7895,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7949,7 +7949,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -2884,7 +2884,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7186,7 +7186,7 @@ spec:
               name: config-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7697,7 +7697,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7751,7 +7751,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -2877,7 +2877,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7235,7 +7235,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7622,7 +7622,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7676,7 +7676,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -2902,7 +2902,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7260,7 +7260,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7647,7 +7647,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7701,7 +7701,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -3707,7 +3707,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9374,7 +9374,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -14240,7 +14240,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -14294,7 +14294,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -2897,7 +2897,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7387,7 +7387,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7774,7 +7774,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7828,7 +7828,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -2917,7 +2917,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7320,7 +7320,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7733,7 +7733,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7787,7 +7787,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -2886,7 +2886,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7244,7 +7244,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.0"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7631,7 +7631,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.0
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7685,7 +7685,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.0
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/knative-migration.adoption.yaml
+++ b/tests/generated/knative-migration.adoption.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.7.0
+        helm.sh/chart: knative-migration-2026.7.1
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.argocd-presync.yaml
+++ b/tests/generated/knative-migration.argocd-presync.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -76,7 +76,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -96,7 +96,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -120,7 +120,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -135,7 +135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.7.0
+        helm.sh/chart: knative-migration-2026.7.1
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.default.yaml
+++ b/tests/generated/knative-migration.default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.7.0
+    helm.sh/chart: knative-migration-2026.7.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.7.0
+        helm.sh/chart: knative-migration-2026.7.1
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
# Release 2026.7.1

Chart-only patch release on top of `2026.7.0`. Notes below are the diff against the **last stable release, `2026.7.0`**. Bumps `version` to `2026.7.1` on controlplane, dataplane, dataplane-crds, knative-migration, sandbox — **`appVersion` stays `2026.7.0`**, so no new control-plane / data-plane images are required; every change here is chart templating, defaults, and docs.

## Highlights — zero-trust is GA for self-managed users
Zero-trust mode is now generally available for self-managed / bring-your-own-cloud dataplanes. Shipped with a ready-to-use reference overlay and end-to-end setup docs.

**To enable it, follow the [Zero-trust mode section in the dataplane README](https://github.com/unionai/helm-charts/blob/main/charts/dataplane/README.md#zero-trust-mode-byoc-only)** and apply the [`examples/values.zero-trust.yaml`](https://github.com/unionai/helm-charts/blob/main/charts/dataplane/examples/values.zero-trust.yaml) overlay. In zero-trust mode the in-cluster operator-prometheus pushes metrics to the control plane over `remote_write` (authenticated with the dataplane's OAuth2 client credentials) with nothing extra to configure — endpoint, `client_id`, and `token_url` are all derived from your existing `global` values.

> Still **not supported** for selfhosted-intracluster deployments. Existing dataplanes must run the [`knative-migration` chart](https://github.com/unionai/helm-charts/blob/main/charts/knative-migration/README.md) before upgrading.

## Configuration changes (helm-charts)

### dataplane
- **Zero-trust overlay simplified.** [`examples/values.zero-trust.yaml`](https://github.com/unionai/helm-charts/blob/main/charts/dataplane/examples/values.zero-trust.yaml).
- **Single canonical tunnel-service toggle.** `operator.enableTunnelService` is now the one switch, read by both the operator config and the operator-proxy tunnel container. The duplicate `config.operator.enableTunnelService` and `proxy.enableTunnelService` keys were removed. Defaults to `true` (everyone except selfhosted / intra-cluster).
- **Control-plane host resolution consolidated** in `_connection.tpl` with explicit precedence: `global.CONTROLPLANE_HOST` > `host` > `global.UNION_CONTROL_PLANE_HOST`. Rendering now **fails fast** if none is set. `host` defaults to empty (was a templated fallback to `UNION_CONTROL_PLANE_HOST`), and serving `hostOverride` / operator `cloudHostName` now flow through the `dataplane.cp.host` helper.
- **New `config.operator.connection.rootTenantURLPattern`** — the root-tenant (control plane) gRPC dial URL, defaulting to the derived CP endpoint (`dns:///<host>:443`, honoring `global.CONTROLPLANE_GRPC_ENDPOINT`); override the same key to set it explicitly.
- **Chart-managed PriorityClasses for `leaseworker` and `flytepropeller`.** New cluster-scoped classes `union-leaseworker` / `union-flytepropeller` (value `1000000`) replace `system-cluster-critical`, which GKE's `gcp-critical-pods` ResourceQuota forbids outside `kube-system`. Each has `priorityClass.create` (skipped under `low_privilege`, and settable to `false` to bring your own class or avoid duplicate creation in multi-dataplane-per-cluster setups). Blanked automatically on GCP where the reserved class is restricted.
- **Cost recording rules** are now loaded via the standard `recording_rules.yml` file instead of an `extraConfigmapMounts` entry.
- Dropped the now-stale Prometheus-subchart pin comment (the subchart is already `25.30.2` / Prometheus v2.55.1 from `2026.7.0`).

### controlplane
- **`actionsLeasor.enabled` now defaults to `true`** — the 2026-07-31 v2-actions switch-over. Every deployment routes its `UNION_ORG` through the v2 actions service and hard-rejects sub-`2.0.4` SDK `CreateRun`. Envs that must stay on the legacy queue path (still on SDK <2.0.4) now set `enabled: false` explicitly.
- **Dedicated flyteadmin OIDC `clientSecretFile` (optional).** You can give flyteadmin the browser-login OIDC client secret via its own single-writer Secret (mounted volume + `auth.userAuth.openId.clientSecretFile`), decoupled from the init-container-managed `flyte-admin-secrets`. New reference overlay [`examples/values.oidc-client-secret.yaml`](https://github.com/unionai/helm-charts/blob/main/charts/controlplane/examples/values.oidc-client-secret.yaml).

## Backward compatibility / migration

Upgrading to `2026.7.1` is a chart-only bump (`appVersion` unchanged). Two behavior-affecting defaults changed:

- **v2 actions is now the default on the control plane.** If your env is still on SDK <2.0.4 and must keep the legacy queue path, set `services.executions.configMap.executions.actionsLeasor.enabled: false` explicitly. Otherwise sub-`2.0.4` `CreateRun` requests are rejected.
- **Data-plane control-plane host is now required.** With `host` no longer defaulting, at least one of `global.CONTROLPLANE_HOST`, `host`, or `global.UNION_CONTROL_PLANE_HOST` must be set — rendering fails otherwise. Existing envs that already populate `global.CONTROLPLANE_HOST` (or the legacy `UNION_CONTROL_PLANE_HOST`) are unaffected.
- **PriorityClasses renamed.** If you relied on `system-cluster-critical` for the leaseworker / flytepropeller, the chart now creates and references `union-leaseworker` / `union-flytepropeller`. To bring your own, set `priorityClassName` and `priorityClass.create: false`; set `priorityClassName: ""` to run without one.

## Test Plan

`make test` (snapshot generation + kubeconform) passes with Helm `v4.2.3`. Snapshot goldens under `tests/generated/` are regenerated and committed alongside the template changes.

