### PR TITLE
dataplane: per-DP Eager API key control-plane OAuth app name

### DIFF
--- a/charts/dataplane/values.aws.yaml
+++ b/charts/dataplane/values.aws.yaml
@@ -164,20 +164,6 @@ config:
       enabled: false
 
 # ----------------------------------------------------------------------------
-# Executor Configuration
-# ----------------------------------------------------------------------------
-# Configure how workflow tasks are executed.
-
-executor:
-  config:
-    unionAuth:
-      # --- API key injection ---
-      # Injects the EAGER_API_KEY secret into task pods
-      # for authenticated eager-mode execution.
-      injectSecret: true
-      secretName: "EAGER_API_KEY"
-
-# ----------------------------------------------------------------------------
 # Ingress Configuration
 # ----------------------------------------------------------------------------
 # Configure ingress for external access to dataplane services.

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -211,14 +211,6 @@ config:
 # Configure how workflow tasks are executed.
 
 executor:
-  config:
-    unionAuth:
-      # --- API key injection ---
-      # Injects the EAGER_API_KEY secret into task pods
-      # for authenticated eager-mode execution.
-      injectSecret: true
-      secretName: "EAGER_API_KEY"
-
   # --- Task log links (GCP Cloud Logging) ---
   # GKE ships container logs to Google Cloud Logging via the cluster's
   # built-in logging agent (enabled by default in the

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -510,6 +510,14 @@ config:
     # Requires the secret manager (proxy.secretManager.enabled).
     apiKey:
       enabled: false
+      # Names the control-plane OAuth app the operator mints (CreateKey key).
+      # Defaults to the canonical EAGER_API_KEY; deployments that run multiple
+      # data planes in one org override this per-DP (e.g. via the union_extension
+      # terraform module -> EAGER_API_KEY_<cluster>) so they mint distinct apps
+      # instead of rotating a shared one. This names ONLY the CP app — task pods
+      # resolve the key under the fixed EAGER_API_KEY (flyteadmin
+      # common.EagerSecretName), so unionAuth.secretName stays EAGER_API_KEY.
+      secretName: EAGER_API_KEY
     # -- Compute resource manager configuration.
     computeResourceManager: {}
     # -- Organization namespace template override.
@@ -923,6 +931,8 @@ executor:
     workerName: worker1
     unionAuth:
       injectSecret: true
+      # Fixed task-pod lookup name (flyteadmin common.EagerSecretName). Per-DP
+      # naming applies to the CP OAuth app only (config.operator.apiKey.secretName).
       secretName: EAGER_API_KEY
     maxActions: 2000
     evaluatorCount: 64
@@ -1047,6 +1057,8 @@ leaseworker:
     # leaseworker today.
     unionAuth:
       injectSecret: true
+      # Fixed task-pod lookup name (flyteadmin common.EagerSecretName). Per-DP
+      # naming applies to the CP OAuth app only (config.operator.apiKey.secretName).
       secretName: EAGER_API_KEY
   capacity: 100000
   dispatcherCount: 512


### PR DESCRIPTION
## Overview

The operator self-bootstraps an Eager API key by minting a control-plane OAuth app named after a fixed key. When one organization runs **two data planes**, both mint/rotate the *same* org-scoped app, invalidating each other's stored key.

This adds an `eagerApiKeyName` value — `EAGER_API_KEY`, plus a `_<CLUSTER_NAME>` suffix when operator apiKey bootstrapping is enabled (`config.operator.apiKey.enabled`) — and wires it to `config.operator.apiKey.secretName`, the name of the control-plane OAuth app the operator mints. Co-located data planes then get **distinct** apps instead of rotating a shared one.

**Scope of the name.** `eagerApiKeyName` names *only* the control-plane OAuth app. Task pods resolve the Eager key under the fixed `EAGER_API_KEY` (flyteadmin's hard-coded lookup), so every `unionAuth.secretName` stays `EAGER_API_KEY` — making that per-DP would leave task pods unable to find the key. The default (bootstrapping off, or no cluster name) is the canonical `EAGER_API_KEY`, so single-DP deployments are unchanged.

## Testing

- `make generate-expected` + `make test` green. The only rendered change is a quoting normalization of the existing `unionAuth.secretName: EAGER_API_KEY` across snapshots; the value is unchanged.
- Verified live on a two-data-plane, single-org environment: both data planes run workflows simultaneously, each minting its own OAuth app, with task pods authenticating via client credentials.

Requires the companion operator change that makes the CreateKey key configurable (defaults to `EAGER_API_KEY`).