### PR TITLE
dataplane: defer the chart version bump (keep 2026.7.1)

### DIFF
--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.7.2
+version: 2026.7.1
 appVersion: 2026.7.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -2864,7 +2864,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7230,7 +7230,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7619,7 +7619,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7673,7 +7673,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -2896,7 +2896,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7254,7 +7254,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7641,7 +7641,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7695,7 +7695,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -3064,7 +3064,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7762,7 +7762,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -8238,7 +8238,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8292,7 +8292,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -2887,7 +2887,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7251,7 +7251,7 @@ spec:
               readOnly: true
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7760,7 +7760,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7814,7 +7814,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2991,7 +2991,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7689,7 +7689,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -8108,7 +8108,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8162,7 +8162,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -130,7 +130,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -159,7 +159,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -173,7 +173,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -211,7 +211,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -409,7 +409,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -688,7 +688,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -903,7 +903,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -977,7 +977,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1137,7 +1137,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1276,7 +1276,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1345,7 +1345,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1605,7 +1605,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1709,7 +1709,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1797,7 +1797,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1863,7 +1863,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1948,7 +1948,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2158,7 +2158,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2282,7 +2282,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -4940,7 +4940,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -6276,7 +6276,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6309,7 +6309,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6346,7 +6346,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6362,7 +6362,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6403,7 +6403,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6423,7 +6423,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6443,7 +6443,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6474,7 +6474,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6542,7 +6542,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6567,7 +6567,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6625,7 +6625,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6647,7 +6647,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6668,7 +6668,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6689,7 +6689,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6841,7 +6841,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7279,7 +7279,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7684,7 +7684,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7719,7 +7719,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7746,7 +7746,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7776,7 +7776,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7806,7 +7806,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7835,7 +7835,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7859,7 +7859,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7886,7 +7886,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8954,7 +8954,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9083,7 +9083,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9187,7 +9187,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9300,7 +9300,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9399,7 +9399,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -9415,7 +9415,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.7.2
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -9426,7 +9426,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 5b7f31da59239fd1bce182a240d76e773152ee8735618206e1ba28e7d539b032
+        checksum/bootstrap-config: b7be8695706be8d78f1e46f374d358840056550d7ce8e62ac8cfff54369bb338
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -9542,7 +9542,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9567,7 +9567,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.7.2
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9674,7 +9674,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10288,7 +10288,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -10506,7 +10506,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10541,7 +10541,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10586,7 +10586,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10773,7 +10773,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10980,7 +10980,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11025,7 +11025,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11217,7 +11217,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11252,7 +11252,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -130,7 +130,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -159,7 +159,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -173,7 +173,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -211,7 +211,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -409,7 +409,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -688,7 +688,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -903,7 +903,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -977,7 +977,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1137,7 +1137,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1276,7 +1276,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1345,7 +1345,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1605,7 +1605,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1709,7 +1709,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1797,7 +1797,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1863,7 +1863,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1948,7 +1948,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2158,7 +2158,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2282,7 +2282,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -4940,7 +4940,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -6276,7 +6276,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6309,7 +6309,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6346,7 +6346,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6362,7 +6362,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6403,7 +6403,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6423,7 +6423,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6443,7 +6443,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6474,7 +6474,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6542,7 +6542,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6567,7 +6567,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6625,7 +6625,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6647,7 +6647,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6668,7 +6668,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6689,7 +6689,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6841,7 +6841,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7279,7 +7279,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7684,7 +7684,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7719,7 +7719,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7746,7 +7746,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7776,7 +7776,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7806,7 +7806,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7835,7 +7835,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7859,7 +7859,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7886,7 +7886,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8954,7 +8954,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9083,7 +9083,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9187,7 +9187,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9300,7 +9300,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9399,7 +9399,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -9415,7 +9415,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.7.2
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -9426,7 +9426,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 99074f80fe24b98a6c43dda0d0acdb0013aa7ff1530b674f86c5b105fcc7a71b
+        checksum/bootstrap-config: 934b4d40638e5994229dd8d17019b4ee097a8f31edc77f683a72ff6daac8fc86
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -9542,7 +9542,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9567,7 +9567,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.7.2
+        helm.sh/chart: dataplane-2026.7.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -9674,7 +9674,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10288,7 +10288,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -10506,7 +10506,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10541,7 +10541,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -10586,7 +10586,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10773,7 +10773,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -10980,7 +10980,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11025,7 +11025,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11217,7 +11217,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -11252,7 +11252,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -2931,7 +2931,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7293,7 +7293,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7681,7 +7681,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7735,7 +7735,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -2931,7 +2931,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7293,7 +7293,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7681,7 +7681,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7735,7 +7735,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -3035,7 +3035,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7438,7 +7438,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7811,7 +7811,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7865,7 +7865,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -2881,7 +2881,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7239,7 +7239,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7626,7 +7626,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7680,7 +7680,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -3006,7 +3006,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7572,7 +7572,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7991,7 +7991,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -8045,7 +8045,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.flytepropeller.yaml
+++ b/tests/generated/dataplane.flytepropeller.yaml
@@ -2916,7 +2916,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7416,7 +7416,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7898,7 +7898,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7952,7 +7952,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -2886,7 +2886,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7188,7 +7188,7 @@ spec:
               name: config-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7699,7 +7699,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7753,7 +7753,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -2879,7 +2879,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7237,7 +7237,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7624,7 +7624,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7678,7 +7678,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -2904,7 +2904,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7262,7 +7262,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7649,7 +7649,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7703,7 +7703,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -3709,7 +3709,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -9376,7 +9376,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -14242,7 +14242,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -14296,7 +14296,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -2899,7 +2899,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7389,7 +7389,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7776,7 +7776,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7830,7 +7830,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -2919,7 +2919,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7322,7 +7322,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7735,7 +7735,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7789,7 +7789,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -2888,7 +2888,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7246,7 +7246,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.7.2"
+              value: "2026.7.1"
             - name: HELM_APP_VERSION
               value: "2026.7.0"
             - name: POD_NAME
@@ -7633,7 +7633,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.7.2
+    helm.sh/chart: dataplane-2026.7.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.7.0"
@@ -7687,7 +7687,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.7.2
+      helm.sh/chart: dataplane-2026.7.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.7.0"


### PR DESCRIPTION
## Overview

Stacked on top of the eager-key cluster-scoping branch. Reverts the `charts/dataplane/Chart.yaml` version bump (`2026.7.2` → back to `2026.7.1`) so this change doesn't carry its own release bump.

Per review feedback on the parent PR: version bumps + release notes are better handled as a **separate, batched release step** — collect a set of changes, update the PR description with release notes, review, and cut the release version then. This keeps feature PRs release-neutral.

Diff is version-string only (Chart.yaml + regenerated snapshot `helm.sh/chart` labels); no functional/template changes.

## Testing

`make generate-expected` — the only snapshot delta is `dataplane-2026.7.2` → `dataplane-2026.7.1`.

- `main` <!-- branch-stack -->
  - \#486
    - **dataplane: defer the chart version bump (keep 2026.7.1)** :point\_left:
