### PR TITLE
controlplane: document dataplaneClusters operators/viewers bootstrap interface

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -668,10 +668,30 @@ services:
           # Organization identifier for this deployment.
           organization: '{{ .Values.global.UNION_ORG }}'
 
-          # Dataplane clusters to bootstrap as authz cluster resources under the org
+          # Dataplane clusters to bootstrap as authz cluster resources under the org.
+          # Each entry is either a bare cluster name (legacy — registers the cluster
+          # resource only) or an object that also grants per-cluster roles to the
+          # OAuth apps that need them. Org Admin does NOT inherit onto cluster
+          # resources, so these grants must be explicit:
+          #   operators — client IDs granted the cluster-manager role. Required for
+          #               the union-operator's Heartbeat/UpdateStatus, which need
+          #               ACTION_MANAGE_CLUSTER (otherwise the cluster reads
+          #               UNHEALTHY and its heartbeat freezes).
+          #   viewers   — client IDs granted the viewer role. Required for the
+          #               internal service-to-service identity to resolve a
+          #               dataplane by name via GetCluster, which enforces
+          #               ACTION_VIEW_FLYTE_EXECUTIONS on the cluster resource
+          #               (e.g. execution logs / agent / data endpoints).
+          # clientId semantics match serviceAccounts below (the IdP `sub` claim).
           dataplaneClusters: []
-          # Example:
-          # - dp-1
+          # Example (legacy name-only form — resource registered, no role grants):
+          #   - dp-1
+          # Example (object form with role grants):
+          #   - name: "dp-1"
+          #     operators:
+          #       - "<union-operator App sub claim>"
+          #     viewers:
+          #       - "<service-to-service App sub claim>"
 
           # Authorization domains to create. Each domain is an isolation boundary
           # for workflow executions (e.g. dev vs prod).

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -668,30 +668,18 @@ services:
           # Organization identifier for this deployment.
           organization: '{{ .Values.global.UNION_ORG }}'
 
-          # Dataplane clusters to bootstrap as authz cluster resources under the org.
-          # Each entry is either a bare cluster name (legacy — registers the cluster
-          # resource only) or an object that also grants per-cluster roles to the
-          # OAuth apps that need them. Org Admin does NOT inherit onto cluster
-          # resources, so these grants must be explicit:
-          #   operators — client IDs granted the cluster-manager role. Required for
-          #               the union-operator's Heartbeat/UpdateStatus, which need
-          #               ACTION_MANAGE_CLUSTER (otherwise the cluster reads
-          #               UNHEALTHY and its heartbeat freezes).
-          #   viewers   — client IDs granted the viewer role. Required for the
-          #               internal service-to-service identity to resolve a
-          #               dataplane by name via GetCluster, which enforces
-          #               ACTION_VIEW_FLYTE_EXECUTIONS on the cluster resource
-          #               (e.g. execution logs / agent / data endpoints).
-          # clientId semantics match serviceAccounts below (the IdP `sub` claim).
+          # Dataplane clusters to bootstrap as authz cluster resources. Each entry is
+          # a bare cluster name (legacy) or an object granting per-cluster roles to
+          # OAuth apps by client ID (the IdP `sub`); org Admin does not inherit onto
+          # cluster resources, so grants are explicit:
+          #   operators — cluster-manager role (union-operator Heartbeat/UpdateStatus, ACTION_MANAGE_CLUSTER).
+          #   viewers   — viewer role (internal service-to-service GetCluster-by-name, ACTION_VIEW_FLYTE_EXECUTIONS).
           dataplaneClusters: []
-          # Example (legacy name-only form — resource registered, no role grants):
-          #   - dp-1
-          # Example (object form with role grants):
-          #   - name: "dp-1"
-          #     operators:
-          #       - "<union-operator App sub claim>"
-          #     viewers:
-          #       - "<service-to-service App sub claim>"
+          # Example:
+          #   - dp-1                                   # legacy: resource only
+          #   - name: "dp-1"                           # object: with role grants
+          #     operators: ["<union-operator sub>"]
+          #     viewers: ["<service-to-service sub>"]
 
           # Authorization domains to create. Each domain is an isolation boundary
           # for workflow executions (e.g. dev vs prod).


### PR DESCRIPTION
## Overview

Documents the authorizer bootstrap `dataplaneClusters` object form (`{name, operators, viewers}`) in `charts/controlplane/values.yaml` comments; previously only the legacy bare-string example was shown. Comment-only — the `dataplaneClusters: []` default is unchanged, so there is no rendered-output change.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('charts/controlplane/values.yaml'))"` parses clean.
- Diff is comment-only; snapshot tests unaffected.

## Notes

The Go type (`DataplaneClusterBootstrap`) and the Terraform that emits the object form live in `unionai/cloud`; the chart passes the bootstrap block through as opaque YAML, so no template change is needed.