### PR TITLE
dataplane: correct Azure/GCP overlay defaults (namespace mapping key + Azure operator secret backend)

### DIFF
--- a/charts/dataplane/templates/propeller/configmap.yaml
+++ b/charts/dataplane/templates/propeller/configmap.yaml
@@ -50,7 +50,7 @@ data:
     namespace_mapping:
       template: {{ .Release.Namespace }}
 {{- end }}
-{{- if and (not .Values.config.namespace_config) .Values.namespace_mapping }}
+{{- if and (not (include "singleNamespace" .)) (not .Values.config.namespace_config) .Values.namespace_mapping }}
   namespace_config.yaml: |
     namespace_config:
       namespace_mapping:

--- a/charts/dataplane/values.azure.yaml
+++ b/charts/dataplane/values.azure.yaml
@@ -238,9 +238,13 @@ config:
       sourceType: AzureLogAnalytics
       azureLogAnalytics:
         logAnalyticsWorkspaceResourceIdTemplate: "/subscriptions/{{.Values.global.AZURE_SUBSCRIPTION_ID}}/resourceGroups/{{.Values.global.AZURE_RESOURCE_GROUP}}/providers/Microsoft.OperationalInsights/workspaces/union-{{.Values.global.ORG_NAME}}"
+    # Operator secret manager. Inherit the base `type: K8s` (embedded k8s) like
+    # values.aws.yaml / values.gcp.yaml — the flyte-pod-webhook that reads the
+    # eager API key uses the embedded k8s manager, so the operator must write
+    # there too. Setting `type: Azure` here routed operator secrets to Key Vault
+    # while the webhook still read embedded k8s, so task pods were denied the
+    # EAGER_API_KEY secret. azureConfig is retained (inert unless type=Azure).
     smConfig:
-      enabled: true
-      type: Azure
       azureConfig:
         vaultURI: '{{ .Values.global.AZURE_KEY_VAULT_URI }}'
 

--- a/charts/dataplane/values.azure.yaml
+++ b/charts/dataplane/values.azure.yaml
@@ -206,10 +206,19 @@ additionalPodLabels:
 # ----------------------------------------------------------------------------
 # Configuration for Azure services including Key Vault, Log Analytics, and scheduling.
 
-# Namespace configuration
-namespace_config:
-  namespace_mapping:
-    template: '{{`{{ domain }}`}}'
+# Task namespace mapping (multi-namespace / low_privilege=false only).
+# Azure Workload Identity federated credentials have no wildcard subject support
+# (unlike AWS IRSA's `*:ksa`), so worker FICs must enumerate explicit
+# `namespace:ksa` subjects. Pin the task namespace to `{{ domain }}` (a bounded
+# set: development / staging / production) rather than Flyte's unbounded default
+# `{{ project }}-{{ domain }}`, so the FICs in
+# modules/selfmanaged/azure/dataplane/user_assigned_identities.tf can enumerate
+# them. Must be the top-level `namespace_mapping` key the propeller configmap
+# reads (the previous top-level `namespace_config` key was ignored, which is why
+# azure fell through to the project-domain default). Ignored under
+# low_privilege=true (singleNamespace).
+namespace_mapping:
+  template: "{{ `{{ domain }}` }}"
 config:
 #--------------------------------------------------------------
   ## Optional integration with Azure Key Vault secrets manager

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -206,6 +206,20 @@ config:
         endpoint: 'http://union-operator-proxy:10254'
 
 # ----------------------------------------------------------------------------
+# Task namespace mapping (multi-namespace / low_privilege=false only)
+# ----------------------------------------------------------------------------
+# GKE Workload Identity has no wildcard subject support (unlike AWS IRSA's
+# `*:ksa`), so worker WI bindings must enumerate explicit `[namespace/ksa]`
+# members. Pin the task namespace to `{{ domain }}` (a bounded set:
+# development / staging / production) rather than Flyte's unbounded default
+# `{{ project }}-{{ domain }}`, so the bindings in
+# modules/selfmanaged/gcp/dataplane/union_iam.tf can enumerate them.
+# Ignored under low_privilege=true (singleNamespace pins tasks to the release
+# namespace via limit-namespace).
+namespace_mapping:
+  template: "{{ `{{ domain }}` }}"
+
+# ----------------------------------------------------------------------------
 # Executor Configuration
 # ----------------------------------------------------------------------------
 # Configure how workflow tasks are executed.


### PR DESCRIPTION
## Overview

Two dataplane overlay defaults for `values.azure.yaml` / `values.gcp.yaml` that either didn't take effect or weren't cloud-appropriate:

**1. Namespace mapping (Azure + GCP).** GKE Workload Identity and Azure federated credentials have no wildcard subject support (unlike AWS IRSA's `*:ksa`), so task namespaces must be a bounded, enumerable set. These overlays pin `namespace_mapping.template` to `{{ domain }}` (development / staging / production) rather than Flyte's unbounded `{{project}}-{{domain}}`. On Azure this was previously nested under a `namespace_config` key the propeller ConfigMap never reads (it reads top-level `namespace_mapping`, or `config.namespace_config`), so it was silently ignored and Azure fell through to the unbounded default. This moves it to the correct top-level `namespace_mapping` key and gates `.Values.namespace_mapping` on `not singleNamespace` in the propeller ConfigMap, so the `{{ domain }}` template applies only in multi-namespace mode (`low_privilege=false`) and never collides with the singleNamespace limit-namespace override.

**2. Azure operator secret backend.** The Azure overlay routed the operator's secret manager to Key Vault, but the flyte pod webhook reads the embedded K8s secret. Default the Azure operator to the embedded K8s secret manager, matching the AWS/GCP overlays.

## Test Plan

- `./tests/run.sh generate` produces no diff against the committed `tests/generated` snapshots — the changes touch only the platform overlays and a `singleNamespace`-gated ConfigMap path not exercised by existing fixtures.
- `helm template` with `values.azure.yaml` / `values.gcp.yaml` renders top-level `namespace_mapping.template: '{{ domain }}'` into the propeller ConfigMap under `low_privilege=false`, and omits it under `low_privilege=true` (singleNamespace).

## Rollout

Chart-only; consumers pick it up via their pinned chart revision. No forced rollout.