### PR TITLE
controlplane: apiKeyOverrides as a list for per-cluster seeded API keys

### DIFF
--- a/charts/MIGRATION.md
+++ b/charts/MIGRATION.md
@@ -4,6 +4,71 @@ Tracking the migration story for the helm-charts cloud overlays. New entries at 
 
 ---
 
+## controlplane — `services.identity.apiKeyOverrides` map → list (per-cluster seeded API keys)
+
+### What changed
+
+`services.identity.apiKeyOverrides` changes from a **map keyed by system-key name** to a
+**list** of entries, each identified by `key` + optional `clusterName`. This lets one control
+plane seed a *different* OAuth client per dataplane for the same system key — the map shape
+allowed only one entry per key.
+
+Before (map):
+
+```yaml
+services:
+  identity:
+    apiKeyOverrides:
+      EAGER_API_KEY:
+        existingSecret:
+          name: eager-client-creds
+```
+
+After (list):
+
+```yaml
+services:
+  identity:
+    apiKeyOverrides:
+      - key: EAGER_API_KEY            # cluster-nameless default (serves any dataplane)
+        existingSecret:
+          name: eager-client-creds
+      - key: EAGER_API_KEY            # optional per-cluster override
+        clusterName: dp-1
+        existingSecret:
+          name: eager-dp1-creds
+```
+
+`clusterName` is optional. An entry without it is the **cluster-nameless default** that serves
+any dataplane lacking its own entry (identical to the old single-entry behavior). A
+cluster-scoped entry takes precedence for that dataplane. This mirrors the backend
+`identity.config.ApiKeyOverride`, which keys on `(org, key, clusterName)` and, on `CreateKey`,
+prefers a cluster-scoped override then falls back to the nameless one — required because the
+operator sends `cluster_name` on every mint (FAB-241), so a nameless entry must still serve
+cluster-named requests.
+
+Mount paths are now per-entry: `/etc/secrets/apikey/<KEY>` for a nameless entry and
+`/etc/secrets/apikey/<KEY>-<clusterName>` for a cluster-scoped one.
+
+### Migration
+
+| Audience | Action |
+|---|---|
+| Not using `apiKeyOverrides` (default `[]`) | None. |
+| Selfhosted with a single seeded key | Convert the one map entry to a one-element list (prefix `- key: <NAME>`; the `existingSecret` block is unchanged). Behavior is identical. Cloud-managed overlays regenerate this automatically from `union_extension/{aws,gcp}` — re-apply terraform after bumping to this chart. |
+| Selfhosted wanting per-cluster keys | Add one list entry per cluster with a distinct `clusterName` + `existingSecret`; optionally keep one nameless entry as the fallback. Seed one Secret per cluster out-of-band. |
+
+**Breaking:** an env whose control-plane `values.yaml` still carries the map shape renders an
+empty/invalid override list against this chart. Regenerate the env overlay (terraform re-apply
+for selfmanaged) in lockstep with the chart bump.
+
+### References
+
+- helm-charts PR: <link tbd>
+- cloud `union_extension` (terraform emits the list) + `identity` (`ClusterName` override parameter) PR: <link tbd>
+
+---
+
 ## controlplane — `actionsLeasor.enabled` toggle (queue/executor deprecation)
 
 ### What changed

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -440,15 +440,17 @@ IfNotPresent
 {{- if and (eq .key "identity") .config.apiKeyOverrides }}
   {{- $identity := index $merged "identity" | default dict }}
   {{- $app := index $identity "app" | default dict }}
-  {{- /* List with the key as a value, not a map: config loading lowercases map
-         keys, which would mangle the case-sensitive system key name. Each entry
-         is scoped to this deployment's org so the override only serves that
-         tenant's key. */}}
+  {{- /* Backend config (identity.config.ApiKeyOverride) is a flat list of
+         {org, key, clusterName, clientIdLocation, clientSecretLocation}. Render it
+         from the seeded-secret references on services.identity (mounted by
+         deployment.yaml). Each entry is scoped to this deployment's org; an empty
+         clusterName is the default that serves any cluster without its own entry. */}}
   {{- $org := .Values.global.UNION_ORG | default "" }}
   {{- $overrides := list }}
-  {{- range $keyName, $entry := .config.apiKeyOverrides }}
-    {{- $dir := include "controlplane.apiKeyOverride.mountDir" $keyName }}
-    {{- $overrides = append $overrides (dict "org" $org "key" $keyName "clientIdLocation" (printf "%s/client_id" $dir) "clientSecretLocation" (printf "%s/client_secret" $dir)) }}
+  {{- range $entry := .config.apiKeyOverrides }}
+    {{- $ident := dict "key" $entry.key "clusterName" ($entry.clusterName | default "") }}
+    {{- $dir := include "controlplane.apiKeyOverride.mountDir" $ident }}
+    {{- $overrides = append $overrides (dict "org" $org "key" $entry.key "clusterName" ($entry.clusterName | default "") "clientIdLocation" (printf "%s/client_id" $dir) "clientSecretLocation" (printf "%s/client_secret" $dir)) }}
   {{- end }}
   {{- $_ := set $app "apiKeyOverrides" $overrides }}
   {{- $_ := set $identity "app" $app }}
@@ -478,17 +480,27 @@ IfNotPresent
 
 {{/*
 apiKeyOverrides helpers — secret-by-reference overrides for system API keys.
-Each entry references a pre-created K8s Secret holding the OAuth client_id +
-client_secret; the chart mounts it and renders identity.app.apiKeyOverrides with
-the resulting file paths. Mount dir and config locations both derive from
-controlplane.apiKeyOverride.mountDir so they cannot drift.
+apiKeyOverrides is a LIST; each entry references a pre-created K8s Secret holding
+the OAuth client_id + client_secret and is identified by (key, optional
+clusterName). The chart mounts each one and renders identity.app.apiKeyOverrides
+with the resulting file paths. Mount dir and config locations both derive from
+controlplane.apiKeyOverride.slug so they cannot drift.
+
+slug: stable per-entry identifier. Cluster-nameless entries slug to just the key;
+cluster-scoped entries append the cluster so distinct dataplanes get distinct
+seeded clients (and distinct mount paths) under the same system key. Input dict:
+{ key, clusterName }.
 */}}
+{{- define "controlplane.apiKeyOverride.slug" -}}
+{{- .key }}{{- if .clusterName }}-{{ .clusterName }}{{- end -}}
+{{- end -}}
+
 {{- define "controlplane.apiKeyOverride.mountDir" -}}
-/etc/secrets/apikey/{{ . }}
+/etc/secrets/apikey/{{ include "controlplane.apiKeyOverride.slug" . }}
 {{- end -}}
 
 {{- define "controlplane.apiKeyOverride.volumeName" -}}
-apikey-{{ . | lower | replace "_" "-" }}
+apikey-{{ include "controlplane.apiKeyOverride.slug" . | lower | replace "_" "-" }}
 {{- end -}}
 
 {{- define "controlplane.apiKeyOverride.clientIdKey" -}}
@@ -499,13 +511,23 @@ apikey-{{ . | lower | replace "_" "-" }}
 {{- default "client_secret" .existingSecret.clientSecretKey -}}
 {{- end -}}
 
-{{/* Fail fast if any apiKeyOverrides entry omits existingSecret.name (reference is mandatory). */}}
+{{/* Fail fast on a malformed apiKeyOverrides list: each entry needs a key and an
+     existingSecret.name, and (key, clusterName) must be unique per service. */}}
 {{- define "controlplane.apiKeyOverrides.validate" -}}
 {{- range $svcKey, $svc := .Values.services -}}
-{{- range $keyName, $entry := ($svc.apiKeyOverrides | default dict) -}}
-{{- if not (($entry.existingSecret).name) -}}
-{{- fail (printf "services.%s.apiKeyOverrides.%s: existingSecret.name is required (reference-only, no inline secret)" $svcKey $keyName) -}}
+{{- $seen := dict -}}
+{{- range $entry := ($svc.apiKeyOverrides | default list) -}}
+{{- if not $entry.key -}}
+{{- fail (printf "services.%s.apiKeyOverrides: each entry requires 'key'" $svcKey) -}}
 {{- end -}}
+{{- if not (($entry.existingSecret).name) -}}
+{{- fail (printf "services.%s.apiKeyOverrides[key=%s]: existingSecret.name is required (reference-only, no inline secret)" $svcKey $entry.key) -}}
+{{- end -}}
+{{- $dedup := printf "%s\x00%s" $entry.key ($entry.clusterName | default "") -}}
+{{- if hasKey $seen $dedup -}}
+{{- fail (printf "services.%s.apiKeyOverrides: duplicate entry for key %q clusterName %q" $svcKey $entry.key ($entry.clusterName | default "")) -}}
+{{- end -}}
+{{- $_ := set $seen $dedup true -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/controlplane/templates/deployment.yaml
+++ b/charts/controlplane/templates/deployment.yaml
@@ -64,8 +64,9 @@ spec:
       - name: config
         configMap:
           name: {{ include "unionai.fullname" $service }}
-      {{- range $keyName, $entry := ($service.config.apiKeyOverrides | default dict) }}
-      - name: {{ include "controlplane.apiKeyOverride.volumeName" $keyName }}
+      {{- range $entry := ($service.config.apiKeyOverrides | default list) }}
+      {{- $ident := dict "key" $entry.key "clusterName" ($entry.clusterName | default "") }}
+      - name: {{ include "controlplane.apiKeyOverride.volumeName" $ident }}
         secret:
           secretName: {{ $entry.existingSecret.name }}
           items:
@@ -137,9 +138,10 @@ spec:
               mountPath: /etc/secrets/union
             - name: config
               mountPath: /etc/config/
-            {{- range $keyName, $entry := ($service.config.apiKeyOverrides | default dict) }}
-            - name: {{ include "controlplane.apiKeyOverride.volumeName" $keyName }}
-              mountPath: {{ include "controlplane.apiKeyOverride.mountDir" $keyName }}
+            {{- range $entry := ($service.config.apiKeyOverrides | default list) }}
+            {{- $ident := dict "key" $entry.key "clusterName" ($entry.clusterName | default "") }}
+            - name: {{ include "controlplane.apiKeyOverride.volumeName" $ident }}
+              mountPath: {{ include "controlplane.apiKeyOverride.mountDir" $ident }}
               readOnly: true
             {{- end }}
           {{- $env := include "unionai.env" $service }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1060,13 +1060,17 @@ services:
     # the IdP; use this when the control plane can't register clients on an
     # operator-controlled IdP (selfhosted Okta/Entra). An out-of-band process
     # seeds the pre-created OAuth client credentials as a K8s Secret, and the
-    # identity service reads them instead of contacting the IdP. The map key MUST
-    # be a recognized system key name (e.g. EAGER_API_KEY). Reference-only: never
-    # put a client secret inline here — this file renders into a committed overlay.
-    apiKeyOverrides: {}
-    #   EAGER_API_KEY:
+    # identity service reads them instead of contacting the IdP. Scope an entry to
+    # a single dataplane cluster to give different dataplanes different seeded
+    # clients; omit clusterName for one client shared across all clusters.
+    # Reference-only: never put a client secret inline here — this file renders
+    # into a committed overlay.
+    apiKeyOverrides: []
+    #   - key: EAGER_API_KEY               # system key name (required)
+    #     clusterName: dp-1                # optional; scope to one dataplane cluster.
+    #                                      # Omit for the client shared across all clusters.
     #     existingSecret:
-    #       name: eager-client-creds       # pre-created Secret (required)
+    #       name: eager-dp1-creds          # pre-created Secret (required)
     #       clientIdKey: client_id         # optional; data key, defaults to client_id
     #       clientSecretKey: client_secret # optional; data key, defaults to client_secret
     service:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -2402,6 +2402,12 @@ data:
         apiKeyOverrides:
         - clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY/client_id
           clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY/client_secret
+          clusterName: ""
+          key: EAGER_API_KEY
+          org: test-org
+        - clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY-dp-1/client_id
+          clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY-dp-1/client_secret
+          clusterName: dp-1
           key: EAGER_API_KEY
           org: test-org
         identityProviderConfig:
@@ -12687,6 +12693,14 @@ spec:
             path: client_id
           - key: oauth_client_secret
             path: client_secret
+      - name: apikey-eager-api-key-dp-1
+        secret:
+          secretName: eager-dp1-creds
+          items:
+          - key: client_id
+            path: client_id
+          - key: client_secret
+            path: client_secret
       containers:
         - name: identity
           image: registry.unionai.cloud/controlplane/services:2026.7.0
@@ -12718,6 +12732,9 @@ spec:
               mountPath: /etc/config/
             - name: apikey-eager-api-key
               mountPath: /etc/secrets/apikey/EAGER_API_KEY
+              readOnly: true
+            - name: apikey-eager-api-key-dp-1
+              mountPath: /etc/secrets/apikey/EAGER_API_KEY-dp-1
               readOnly: true
           env:
             - name: GOMEMLIMIT

--- a/tests/values/controlplane.custom-oidc.yaml
+++ b/tests/values/controlplane.custom-oidc.yaml
@@ -93,7 +93,11 @@ flyte:
 services:
   identity:
     apiKeyOverrides:
-      EAGER_API_KEY:
+      - key: EAGER_API_KEY
         existingSecret:
           name: eager-client-creds
           clientSecretKey: oauth_client_secret
+      - key: EAGER_API_KEY
+        clusterName: dp-1
+        existingSecret:
+          name: eager-dp1-creds


### PR DESCRIPTION
## Overview

`services.identity.apiKeyOverrides` changes from a **map keyed by system-key name** to a **list** of `{key, clusterName?, existingSecret}` entries, so a control plane can seed a distinct OAuth client per data plane for the same system key (e.g. a per-cluster `EAGER_API_KEY`). An entry without `clusterName` is the cluster-nameless default; a cluster-scoped entry takes precedence for that data plane. Mount paths are now per-entry (`/etc/secrets/apikey/<KEY>` or `<KEY>-<clusterName>`).

This is the chart half of per-dataplane operator + eager OAuth clients; the cloud terraform that emits the per-cluster list is unionai/cloud#17168. The identity backend already keys `apiKeyOverride` lookup on org+key+clusterName with a nameless fallback.

## Breaking change / migration

Values-shape change (map to list) — documented in `charts/MIGRATION.md`. Chart `version` bumped. Env overlays that still carry the map shape must regenerate (terraform re-apply for selfmanaged) in lockstep with bumping to this chart version.

## Test Plan

- `helm lint` + `helm template` render clean; snapshot `tests/generated/controlplane.custom-oidc.yaml` regenerated and now exercises two entries (a nameless default + a cluster-scoped `dp-1`), producing distinct volumes, mount dirs, and referenced secrets.
- Rendered end-to-end via the cloud terraform on `mike-apple-aws` (per-cluster `apiKeyOverrides` for dp-1/dp-2) and deployed via `internal-selfmanaged-staging-sync` #1046.

## Rollout

Per-env, gated by each env's chart-revision pin. `mike-apple-aws` perennial bumped to this branch; other envs adopt on their next bump (with a coordinated terraform re-apply).

## Rollback

`git revert`; envs pinned to the prior chart revision are unaffected until they re-pin.