### PR TITLE
Fix stow settings

### DIFF
--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -574,13 +574,15 @@ storage:
 {{- if eq .Values.flyte.storage.type "s3" }}
   type: s3
   container: {{ .Values.flyte.storage.bucketName | quote }}
-  connection:
-    auth-type: {{ .Values.flyte.storage.s3.authType }}
-    region: {{ .Values.flyte.storage.s3.region }}
-    {{- if eq .Values.flyte.storage.s3.authType "accesskey" }}
-    access-key: {{ .Values.flyte.storage.s3.accessKey }}
-    secret-key: {{ .Values.flyte.storage.s3.secretKey }}
-    {{- end }}
+  stow:
+    kind: s3
+    config:
+      auth_type: {{ .Values.flyte.storage.s3.authType }}
+      region: {{ .Values.flyte.storage.s3.region }}
+      {{- if eq .Values.flyte.storage.s3.authType "accesskey" }}
+      access_key_id: {{ .Values.flyte.storage.s3.accessKey }}
+      secret_key: {{ .Values.flyte.storage.s3.secretKey }}
+      {{- end }}
 {{- else if eq .Values.flyte.storage.type "gcs" }}
   type: stow
   stow:

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -1841,9 +1841,11 @@ data:
     storage:
       type: s3
       container: ""
-      connection:
-        auth-type: iam
-        region: 
+      stow:
+        kind: s3
+        config:
+          auth_type: iam
+          region: 
       enable-multicontainer: false
       limits:
         maxDownloadMBs: 10
@@ -11987,7 +11989,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "222024308a5a251bd421debb41a5db7e28a4c0a3e8b1a20d8d1debb904aa3d3"
+        configChecksum: "e5847799d9a3b0efc4a145387af302b218152d1815605eff9bd75b090af5c87"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"


### PR DESCRIPTION
## Overview
unionai/cloud#17179's flyte2 bump (flyteorg/flyte#7699) deleted flytestdlib's legacy `storage.connection` config, so CP images built after it can't boot with the old shape. This migrates the s3 branch of `cacheservice-storage.base` to the `stow:` form.

Works with old images too — flytestdlib has always preferred `stow:` when present — so chart and image can roll in either order, including self-hosted envs on pinned chart revisions.

Companion to unionai/cloud#17190 (same fix for the dataplane/tenant renderers; the BYOC dataplane chart here already uses stow).

Context: [Slack thread](https://unionai.slack.com/archives/C03SJ1VH8MV/p1784909452866649) — today's leaseworker/executor crashloop.
