### PR TITLE
controlplane: make cloud overlays cloud-only (start — drop redundant OIDC auth block)

### DIFF
--- a/charts/controlplane/values.aws.yaml
+++ b/charts/controlplane/values.aws.yaml
@@ -40,39 +40,9 @@ flyte:
     adminServer:
       connection:
         region: '{{ .Values.global.AWS_REGION }}'
-
-      # --- OIDC Authentication ---
-      # Fill in the IdP-specific fields below. Defaults beyond these (claims,
-      # cookie settings, etc.) live in base values.yaml's
-      # `flyte.configmap.adminServer.auth` block.
-      auth:
-        appAuth:
-          externalAuthServer:
-            # OIDC issuer base URL.
-            #   Okta:      https://dev-123456.okta.com/oauth2/default
-            #   Entra ID:  https://login.microsoftonline.com/{tenant-id}/v2.0
-            baseUrl: ""
-            # OIDC metadata discovery path (relative to baseUrl).
-            #   Okta:      .well-known/oauth-authorization-server  (default)
-            #   Entra ID:  .well-known/openid-configuration
-            metadataUrl: ".well-known/oauth-authorization-server"
-          thirdPartyConfig:
-            flyteClient:
-              # CLI / SDK PKCE client.
-              #   Okta:      "0oa..."
-              #   Entra ID:  "<app-uuid>"
-              clientId: ""
-              # Entra ID only — leave empty for Okta.
-              audience: ""
-        userAuth:
-          openId:
-            # Browser login.
-            #   Okta:      https://dev-123456.okta.com/oauth2/default
-            #   Entra ID:  https://login.microsoftonline.com/{tenant-id}/v2.0
-            baseUrl: ""
-            #   Okta:      "0oa..."
-            #   Entra ID:  "<app-uuid>"
-            clientId: ""
+      # OIDC auth (appAuth / userAuth) is IdP-specific, not cloud-specific — it
+      # lives in base values.yaml under flyte.configmap.adminServer.auth (with
+      # the Okta/Entra fill-in guidance). Set it there or at the env layer.
 
   # --- AWS IRSA Annotations ---
   flyteadmin:

--- a/charts/controlplane/values.gcp.yaml
+++ b/charts/controlplane/values.gcp.yaml
@@ -41,33 +41,9 @@ flyte:
     adminServer:
       connection:
         region: '{{ .Values.global.GCP_REGION }}'
-
-      # --- OIDC Authentication ---
-      # Fill in the IdP-specific fields below. Defaults beyond these (claims,
-      # cookie settings, etc.) live in base values.yaml's
-      # `flyte.configmap.adminServer.auth` block.
-      auth:
-        appAuth:
-          externalAuthServer:
-            # OIDC issuer base URL.
-            #   Okta:      https://dev-123456.okta.com/oauth2/default
-            #   Entra ID:  https://login.microsoftonline.com/{tenant-id}/v2.0
-            baseUrl: ""
-            # OIDC metadata discovery path (relative to baseUrl).
-            #   Okta:      .well-known/oauth-authorization-server  (default)
-            #   Entra ID:  .well-known/openid-configuration
-            metadataUrl: ".well-known/oauth-authorization-server"
-          thirdPartyConfig:
-            flyteClient:
-              # CLI / SDK PKCE client.
-              clientId: ""
-              # Entra ID only — leave empty for Okta.
-              audience: ""
-        userAuth:
-          openId:
-            # Browser login.
-            baseUrl: ""
-            clientId: ""
+      # OIDC auth (appAuth / userAuth) is IdP-specific, not cloud-specific — it
+      # lives in base values.yaml under flyte.configmap.adminServer.auth (with
+      # the Okta/Entra fill-in guidance). Set it there or at the env layer.
 
   # --- GCP Workload Identity Annotations ---
   flyteadmin:


### PR DESCRIPTION
## Overview

Applies the same cloud-only-overlay cleanup as helm-charts #497 (dataplane) to the **controlplane** cloud overlays (`charts/controlplane/values.{aws,gcp}.yaml`), removing config that is duplicated across clouds or not cloud-specific.

**First cut — OIDC auth block.** The `flyte.configmap.adminServer.auth` block (appAuth / userAuth OIDC placeholders) was duplicated **identically** in both the aws and gcp overlays, and is a strict subset of base `values.yaml`'s richer auth block (same empty `baseUrl` / `clientId` / `audience` + `metadataUrl` default, but base has fuller Okta/Entra guidance). OIDC auth is **IdP-specific, not cloud-specific**, so it belongs in base — the overlay copies added nothing but duplication. Replaced with a pointer comment.

**Intentionally kept:** the `monitoring` kube-disable block stays in the overlays. Base defaults those components `enabled: true` (bare-k8s-safe); the overlays disable them for managed k8s (EKS/GKE). That is a real per-cloud override, not redundancy — hoisting it to base would break kube-control-plane scraping for a bare-k8s selfhosted CP.

## Testing

`make helm-test` green, **zero snapshot drift** — base already provides the identical auth values (incl. the `controlplane.custom-oidc` fixture), so the render is unchanged.

## Stack

Stacked on #497 (`mike/dataplane-overlay-dedup`). Part of the selfmanaged overlay cloud-only cleanup.

- `main` <!-- branch-stack -->
  - **controlplane: make cloud overlays cloud-only (start — drop redundant OIDC auth block)** :point\_left:
    - \#499
