### PR TITLE
dataplane: consolidate control-plane host to a single CONTROLPLANE_HOST

### DIFF
--- a/charts/MIGRATION.md
+++ b/charts/MIGRATION.md
@@ -111,9 +111,8 @@ A new `charts/dataplane/templates/_connection.tpl` exposes three helpers that al
 
 | Helper | Returns |
 |---|---|
-| `dataplane.cp.host` | Bare hostname. Coalesces `global.CONTROLPLANE_HOST` (selfmanaged convention) with `Values.host` (legacy / BYOK convention). |
-| `dataplane.cp.endpoint` | gRPC dial endpoint. Defaults to `dns:///<host>:443`; respects `global.CONTROLPLANE_GRPC_ENDPOINT` override. |
-| `dataplane.cp.queueEndpoint` | Task-pod queue endpoint. Cascades `global.QUEUE_GRPC_ENDPOINT` → `global.CONTROLPLANE_GRPC_ENDPOINT` → default. |
+| `dataplane.cp.host` | Bare hostname. `global.CONTROLPLANE_HOST` (preferred); deprecated fallbacks `Values.host` and `global.UNION_CONTROL_PLANE_HOST`. |
+| `dataplane.cp.endpoint` | gRPC dial endpoint `dns:///<host>` (port omitted; grpc/https default to 443). The `CONTROLPLANE_GRPC_ENDPOINT` / `QUEUE_GRPC_ENDPOINT` globals and the `dataplane.cp.queueEndpoint` helper were removed — the endpoint derives solely from the host. |
 
 Existing deployments don't need any values change — the helpers coalesce both old and new globals, so `host:` (legacy) and `global.CONTROLPLANE_HOST` (new) both work without modification.
 

--- a/charts/dataplane/RELEASE.md
+++ b/charts/dataplane/RELEASE.md
@@ -19,10 +19,16 @@
 
   **Overlay (`values.{aws,gcp,azure}.yaml`) defaults removed:** the admin `clientId` restatements; the monitoring + `enableMultiContainer` defaults; `config.union.auth.enable`, `clusterresourcesync.…auth`, and catalog-cache `use-admin-auth` (the cross-cloud conflict above); `secrets.admin`; `serving.auth.enabled`; `dcgm-exporter.enabled` (the overlays keep only their cloud-specific node affinity); `controlplaneNamespace`; `ingress` / `ingress-nginx` enablement; the task-pod `_U_EP_OVERRIDE` / `_U_INSECURE` `default-env-vars` (the leaseworker and executor already inject these from `config.union.connection`); and the dead `billableUsageCollector` / `singleTenantOrgID` keys.
 
+- **Control-plane host: one global instead of four.** The DP→CP destination is now a single host global, `global.CONTROLPLANE_HOST` (moved to the top of the globals — it's the first thing to configure). Everything derives from it: the gRPC endpoint and the app-callback URL. Removed:
+  - **`global.CONTROLPLANE_GRPC_ENDPOINT`** — `dataplane.cp.endpoint` derives `dns:///<host>` from `CONTROLPLANE_HOST`. The `:443` port is omitted; grpc-go's DNS resolver and Connect/HTTPS both default to 443.
+  - **`global.QUEUE_GRPC_ENDPOINT`** and the **`dataplane.cp.queueEndpoint`** helper — the task-pod endpoint is injected by the leaseworker/executor from `config.union.connection`; there is no separate queue global. Authless / direct-service routing (skip nginx + OAuth, dial the in-cluster Service on `:80`) is configured explicitly via `config.union.auth` + `config.union.connection`, documented in the new **`examples/values.authless.yaml`**.
+  - **`global.UNION_CONTROL_PLANE_HOST`** and the top-level **`.Values.host`** are now **DEPRECATED** — both are still honored as fallbacks (precedence `CONTROLPLANE_HOST` > `.Values.host` > `UNION_CONTROL_PLANE_HOST`) but should be migrated to `CONTROLPLANE_HOST`; they will be removed in a future release. `.Values.host` is the pre-globals top-level knob; no terraform-generated env sets it. The intracluster examples are simplified to just set `CONTROLPLANE_HOST`.
+
 ### Migration / action required
 
 - **Behavior-preserving where a deployment already sets the value.** The removed overlay keys now come from base `values.yaml` defaults. If you relied on an overlay-set value that differs from the new base default, set it in your environment values instead. The one cross-cloud behavior change is catalog-cache `use-admin-auth`, which is now consistently enabled (previously `false` in the GCP overlay).
 - **fluentbit `ServiceAccount` renamed** to `union-system` (from `fluentbit-system`). No action unless you bound external policy (e.g. a cloud IAM trust) to the old ServiceAccount name.
+- **Regenerate before adopting if your env still sets the retired CP-host globals.** An environment whose generated `values.yaml` still contains `global.CONTROLPLANE_GRPC_ENDPOINT` / `global.QUEUE_GRPC_ENDPOINT`, or a task-pod `default-env-vars` `_U_EP_OVERRIDE: "{{ include \`dataplane.cp.queueEndpoint\` . }}"`, must be regenerated (terraform apply) before moving to this chart — the `queueEndpoint` helper is removed, so the stale `include` fails to render. The retired globals are inert if set; drop them. Authless deployments move to `config.union.auth`/`config.union.connection` per `examples/values.authless.yaml`.
 
 ## 2026.7.2
 

--- a/charts/dataplane/examples/values.authless.yaml
+++ b/charts/dataplane/examples/values.authless.yaml
@@ -1,0 +1,60 @@
+# ============================================================================
+# Authless dataplane example
+# ============================================================================
+# Shared-cluster deployment that SKIPS auth and routes DP -> CP traffic directly
+# to in-cluster Kubernetes Services, bypassing the control-plane nginx ingress
+# and OAuth entirely. This is the historical "shared cluster, skip auth, route
+# to k8s services" topology.
+#
+# Only safe when the control plane and data plane share a cluster and the CP
+# Services are not reachable from outside it — the control plane trusts these
+# in-cluster requests via identity claims instead of an OAuth token.
+#
+# How it works:
+#   - The single host global CONTROLPLANE_HOST still names the CP for the
+#     serving / app-callback URLs and cloudHostName.
+#   - The DP -> CP gRPC connection is overridden to the in-cluster Service on
+#     :80 with insecure transport. The `…svc.cluster.local:80` + insecure
+#     combination is exactly what selects the control plane's trusted-identity
+#     (no-OAuth) code path — so no token is required.
+#   - Auth is turned off explicitly via config.union.auth.enable (and the
+#     sibling toggles), NOT derived from the host. These are the individual
+#     auth toggles the interface exposes.
+#
+# Replace `union-cp` with the actual CP release namespace, and the Service names
+# with the CP's exposed gRPC Services, if they differ in your deployment.
+#
+# Apply on top of values.yaml + a cloud overlay:
+#   helm template charts/dataplane \
+#     -f charts/dataplane/values.yaml \
+#     -f charts/dataplane/values.gcp.yaml \
+#     -f charts/dataplane/examples/values.authless.yaml ...
+# ============================================================================
+
+global:
+  # CP host for serving / app-callback URLs + cloudHostName. In a shared
+  # cluster this is the CP nginx Service FQDN.
+  CONTROLPLANE_HOST: "controlplane-nginx-controller.union-cp.svc.cluster.local"
+
+config:
+  union:
+    # No OAuth token on DP -> CP calls.
+    auth:
+      enable: false
+    # Dial the control plane directly in-cluster, plaintext. The
+    # svc.cluster.local:80 authority + insecure activates the CP's
+    # trusted-in-cluster-identity path (no OAuth, no nginx).
+    connection:
+      host: "dns:///union.union-cp.svc.cluster.local:80"
+      insecure: true
+
+# Run FULLY authless by mirroring the same connection + disabling auth on every
+# other DP -> CP client:
+#   clusterresourcesync.config.union.auth.enable: false
+#   clusterresourcesync.config.union.connection: { host: dns:///…svc…:80, insecure: true }
+#   config.admin.admin:            { endpoint: dns:///…svc…:80, insecure: true }
+#   config.catalog.catalog-cache:  { use-admin-auth: false, insecure: true, endpoint/cache-endpoint: dns:///…svc…:80 }
+#   config.authorizer.authorizerClient.grpcConfig: { host: dns:///…svc…:80, insecure: true }
+# Also disable serving.auth.enabled / gateway.auth.enable if apps must not
+# require auth. Leave the whole block out to keep the default authenticated
+# (nginx :443 + OAuth) deployment.

--- a/charts/dataplane/examples/values.authless.yaml
+++ b/charts/dataplane/examples/values.authless.yaml
@@ -36,25 +36,57 @@ global:
   # cluster this is the CP nginx Service FQDN.
   CONTROLPLANE_HOST: "controlplane-nginx-controller.union-cp.svc.cluster.local"
 
+# Every DP -> CP client must be pointed at the CP's in-cluster gRPC Service on
+# :80 with `insecure: true`, and have its auth turned off. Each block below is a
+# separate client. Replace the Service names with the CP's actual in-cluster
+# gRPC Services (flyteadmin / cacheservice / authorizer) and `union-cp` with the
+# CP release namespace. The `…svc.cluster.local:80` + insecure combination is
+# what selects the CP's trusted-in-cluster-identity path (no OAuth, no nginx).
 config:
+  # union.connection — operator / executor / leaseworker -> flyteadmin.
   union:
-    # No OAuth token on DP -> CP calls.
     auth:
       enable: false
-    # Dial the control plane directly in-cluster, plaintext. The
-    # svc.cluster.local:80 authority + insecure activates the CP's
-    # trusted-in-cluster-identity path (no OAuth, no nginx).
     connection:
-      host: "dns:///union.union-cp.svc.cluster.local:80"
+      host: "dns:///flyteadmin.union-cp.svc.cluster.local:80"
       insecure: true
 
-# Run FULLY authless by mirroring the same connection + disabling auth on every
-# other DP -> CP client:
-#   clusterresourcesync.config.union.auth.enable: false
-#   clusterresourcesync.config.union.connection: { host: dns:///…svc…:80, insecure: true }
-#   config.admin.admin:            { endpoint: dns:///…svc…:80, insecure: true }
-#   config.catalog.catalog-cache:  { use-admin-auth: false, insecure: true, endpoint/cache-endpoint: dns:///…svc…:80 }
-#   config.authorizer.authorizerClient.grpcConfig: { host: dns:///…svc…:80, insecure: true }
-# Also disable serving.auth.enabled / gateway.auth.enable if apps must not
-# require auth. Leave the whole block out to keep the default authenticated
-# (nginx :443 + OAuth) deployment.
+  # admin client — same flyteadmin gRPC API.
+  admin:
+    admin:
+      endpoint: "dns:///flyteadmin.union-cp.svc.cluster.local:80"
+      insecure: true
+
+  # catalog cache — reuse-admin-auth off, dial the cacheservice directly.
+  catalog:
+    catalog-cache:
+      use-admin-auth: false
+      insecure: true
+      endpoint: "dns:///cacheservice.union-cp.svc.cluster.local:80"
+      cache-endpoint: "dns:///cacheservice.union-cp.svc.cluster.local:80"
+
+  # authorizer client.
+  authorizer:
+    authorizerClient:
+      grpcConfig:
+        host: "dns:///authorizer.union-cp.svc.cluster.local:80"
+        insecure: true
+
+# clusterresourcesync (union-syncresources) -> flyteadmin, same authless path.
+clusterresourcesync:
+  config:
+    union:
+      auth:
+        enable: false
+      connection:
+        host: "dns:///flyteadmin.union-cp.svc.cluster.local:80"
+        insecure: true
+
+# App serving / zero-trust gateway auth — disable ONLY if served apps must not
+# require auth. Omit these two blocks to keep app auth on while DP->CP is authless.
+serving:
+  auth:
+    enabled: false
+gateway:
+  auth:
+    enable: false

--- a/charts/dataplane/examples/values.aws.intracluster.yaml
+++ b/charts/dataplane/examples/values.aws.intracluster.yaml
@@ -1,36 +1,31 @@
 # ============================================================================
 # AWS intracluster example — Dataplane
 # ============================================================================
-# Overlay for the topology where controlplane and dataplane run in the same
-# Kubernetes cluster. Routes DP -> CP traffic through cluster-local Services
-# (svc.cluster.local) instead of through the public CP ingress.
+# Overlay for the topology where control plane and data plane run in the same
+# Kubernetes cluster. Point the single CP host at the cluster-local CP nginx
+# Service so DP -> CP gRPC (dns:///<host>, derived) stays in-cluster instead
+# of routing through the public CP ingress.
+#
+# For terraform module-driven deployments this is set automatically when the
+# control plane's ingress LB mode is ClusterIP; this example is for manual helm
+# installs.
+#
+# For a fully AUTH-LESS shared-cluster deployment (skip OAuth, direct Service
+# routing on :80), see examples/values.authless.yaml instead.
+#
+# Replace `union-cp` with the actual CP release namespace if it differs.
 #
 # Apply on top of:
 #   helm template charts/dataplane \
 #     -f charts/dataplane/values.yaml \
 #     -f charts/dataplane/values.aws.yaml \
-#     -f charts/dataplane/examples/values.aws.intracluster.yaml \
-#     ...
-#
-# Replace `union-cp` below with the actual CP release namespace if it differs
-# in your deployment (historical AWS default has been `union-cp`).
+#     -f charts/dataplane/examples/values.aws.intracluster.yaml ...
 # ============================================================================
 
 global:
-  # Bare CP host consumed by dataplane.cp.host (serving auth callback URLs,
-  # serving ingress hostOverride, cloudHostName). Points at the same
-  # cluster-local CP nginx Service as the gRPC endpoint below — intracluster
-  # keeps this traffic in-cluster rather than routing through the public host.
-  # This is only a default: override CONTROLPLANE_HOST (or ingress.serving.
-  # hostOverride) with a public hostname if served apps must be reachable by
-  # browsers outside the cluster.
+  # Cluster-local CP nginx Service FQDN. dataplane.cp.endpoint derives
+  # dns:///<host> from this, keeping DP -> CP gRPC in-cluster (still auth'd
+  # + TLS through nginx). Override with a public hostname (or set
+  # ingress.serving.hostOverride) if served apps must be reachable by browsers
+  # outside the cluster.
   CONTROLPLANE_HOST: "controlplane-nginx-controller.union-cp.svc.cluster.local"
-
-  # All DP -> CP gRPC traffic dials the CP nginx Service directly. Bypasses
-  # the public LB + auth, and works without DNS hops outside the cluster.
-  CONTROLPLANE_GRPC_ENDPOINT: "dns:///controlplane-nginx-controller.union-cp.svc.cluster.local:443"
-
-  # Task pods can't carry OAuth credentials, so queue calls must hit an
-  # auth-less path. The queue Service in the CP namespace exposes :80 with no
-  # auth — safe only because nothing outside the cluster can reach it.
-  QUEUE_GRPC_ENDPOINT: "dns:///queue.union-cp.svc.cluster.local:80"

--- a/charts/dataplane/examples/values.gcp.intracluster.yaml
+++ b/charts/dataplane/examples/values.gcp.intracluster.yaml
@@ -1,36 +1,31 @@
 # ============================================================================
 # GCP intracluster example — Dataplane
 # ============================================================================
-# Overlay for the topology where controlplane and dataplane run in the same
-# Kubernetes cluster. Routes DP -> CP traffic through cluster-local Services
-# (svc.cluster.local) instead of through the public CP ingress.
+# Overlay for the topology where control plane and data plane run in the same
+# Kubernetes cluster. Point the single CP host at the cluster-local CP nginx
+# Service so DP -> CP gRPC (dns:///<host>, derived) stays in-cluster instead
+# of routing through the public CP ingress.
+#
+# For terraform module-driven deployments this is set automatically when the
+# control plane's ingress LB mode is ClusterIP; this example is for manual helm
+# installs.
+#
+# For a fully AUTH-LESS shared-cluster deployment (skip OAuth, direct Service
+# routing on :80), see examples/values.authless.yaml instead.
+#
+# Replace `controlplane` with the actual CP release namespace if it differs.
 #
 # Apply on top of:
 #   helm template charts/dataplane \
 #     -f charts/dataplane/values.yaml \
 #     -f charts/dataplane/values.gcp.yaml \
-#     -f charts/dataplane/examples/values.gcp.intracluster.yaml \
-#     ...
-#
-# Replace `controlplane` below with the actual CP release namespace if it
-# differs in your deployment.
+#     -f charts/dataplane/examples/values.gcp.intracluster.yaml ...
 # ============================================================================
 
 global:
-  # Bare CP host consumed by dataplane.cp.host (serving auth callback URLs,
-  # serving ingress hostOverride, cloudHostName). Points at the same
-  # cluster-local CP nginx Service as the gRPC endpoint below — intracluster
-  # keeps this traffic in-cluster rather than routing through the public host.
-  # This is only a default: override CONTROLPLANE_HOST (or ingress.serving.
-  # hostOverride) with a public hostname if served apps must be reachable by
-  # browsers outside the cluster.
+  # Cluster-local CP nginx Service FQDN. dataplane.cp.endpoint derives
+  # dns:///<host> from this, keeping DP -> CP gRPC in-cluster (still auth'd
+  # + TLS through nginx). Override with a public hostname (or set
+  # ingress.serving.hostOverride) if served apps must be reachable by browsers
+  # outside the cluster.
   CONTROLPLANE_HOST: "controlplane-nginx-controller.controlplane.svc.cluster.local"
-
-  # All DP -> CP gRPC traffic dials the CP nginx Service directly. Bypasses
-  # the public LB + auth, and works without DNS hops outside the cluster.
-  CONTROLPLANE_GRPC_ENDPOINT: "dns:///controlplane-nginx-controller.controlplane.svc.cluster.local:443"
-
-  # Task pods can't carry OAuth credentials, so queue calls must hit an
-  # auth-less path. The queue Service in the CP namespace exposes :80 with no
-  # auth — safe only because nothing outside the cluster can reach it.
-  QUEUE_GRPC_ENDPOINT: "dns:///queue.controlplane.svc.cluster.local:80"

--- a/charts/dataplane/templates/_connection.tpl
+++ b/charts/dataplane/templates/_connection.tpl
@@ -7,32 +7,29 @@ posture. Consumers (`config.admin.admin`, `config.catalog.catalog-cache`,
 `clusterresourcesync.config.union.connection`, etc.) reference these
 helpers so the host, port, and TLS settings stay in sync across the chart.
 
-Override surface (globals declared at the top of values.yaml):
-  CONTROLPLANE_HOST           bare CP hostname (no scheme, no port). Host precedence:
-                              CONTROLPLANE_HOST > .Values.host > UNION_CONTROL_PLANE_HOST.
-                              At least one must be set or rendering fails.
-  CONTROLPLANE_GRPC_ENDPOINT  override the default `dns:///<host>:443`
-  QUEUE_GRPC_ENDPOINT         override the task-pod queue endpoint
-                              (cascades from CONTROLPLANE_GRPC_ENDPOINT)
+Single control-plane host interface:
+  CONTROLPLANE_HOST           bare CP hostname (no scheme, no port). The one host
+                              global; everything derives from it.
+  DEPRECATED fallbacks (still honored for backward compatibility; migrate to
+  CONTROLPLANE_HOST): top-level .Values.host and global.UNION_CONTROL_PLANE_HOST.
+  One of the three must be set or render fails.
+
+The gRPC endpoint is always `dns:///<host>` — the port is omitted, so grpc
+(dns resolver) and Connect (https) both default to 443. There is no separate
+endpoint or queue-endpoint global. Authless / direct-service routing is
+configured explicitly via `config.union.connection` + the auth toggles (see
+examples/values.authless.yaml), not via a host override.
 */}}
 
 {{- define "dataplane.cp.host" -}}
-{{- $cp     := tpl (default "" .Values.global.CONTROLPLANE_HOST) . -}}
-{{- $host   := tpl (default "" .Values.host) . -}}
-{{- $legacy := tpl (default "" .Values.global.UNION_CONTROL_PLANE_HOST) . -}}
-{{- required "A control plane host is required: set global.CONTROLPLANE_HOST (preferred), host, or global.UNION_CONTROL_PLANE_HOST" (coalesce $cp $host $legacy) -}}
+{{- $cp      := tpl (default "" .Values.global.CONTROLPLANE_HOST) . -}}
+{{- $host    := tpl (default "" .Values.host) . -}}
+{{- $legacy  := tpl (default "" .Values.global.UNION_CONTROL_PLANE_HOST) . -}}
+{{- required "A control plane host is required: set global.CONTROLPLANE_HOST (the deprecated .Values.host and global.UNION_CONTROL_PLANE_HOST are still honored)" (coalesce $cp $host $legacy) -}}
 {{- end -}}
 
 {{- define "dataplane.cp.endpoint" -}}
-{{- $override := tpl (default "" .Values.global.CONTROLPLANE_GRPC_ENDPOINT) . -}}
-{{- if $override -}}{{- $override -}}
-{{- else -}}{{- printf "dns:///%s:443" (include "dataplane.cp.host" .) -}}{{- end -}}
-{{- end -}}
-
-{{- define "dataplane.cp.queueEndpoint" -}}
-{{- $override := tpl (default "" .Values.global.QUEUE_GRPC_ENDPOINT) . -}}
-{{- if $override -}}{{- $override -}}
-{{- else -}}{{- include "dataplane.cp.endpoint" . -}}{{- end -}}
+{{- printf "dns:///%s" (include "dataplane.cp.host" .) -}}
 {{- end -}}
 
 {{/*

--- a/charts/dataplane/values.aws.yaml
+++ b/charts/dataplane/values.aws.yaml
@@ -12,8 +12,10 @@
 # union_extension module. Keep this overlay cloud-only.
 
 global:
+  # --- Control plane (configure first) ---
+  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
+
   # --- Identity ---
-  UNION_CONTROL_PLANE_HOST: ""  # Public CP hostname for Knative app auth callbacks
   CLUSTER_NAME: ""              # Unique cluster identifier
   ORG_NAME: ""                  # Organization name (must match controlplane)
 
@@ -29,18 +31,6 @@ global:
   # Format: arn:aws:iam::<account>:role/<role-name>
   BACKEND_IAM_ROLE_ARN: ""      # IAM role for Union backend services
   WORKER_IAM_ROLE_ARN: ""       # IAM role for workflow execution pods
-
-  # --- DP -> CP routing ---
-  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
-  CONTROLPLANE_GRPC_ENDPOINT: "" # Override; defaults to dns:///{CONTROLPLANE_HOST}:443
-
-  # DEPRECATED — long-term plan is to remove this once propeller injects
-  # OAuth credentials into task pods. Until then it
-  # remains as the auth-less escape hatch task pods need (their queue events
-  # bypass nginx auth via this endpoint). Empty falls through to
-  # CONTROLPLANE_GRPC_ENDPOINT; for intracluster set the queue Service URL
-  # via examples/values.aws.intracluster.yaml.
-  QUEUE_GRPC_ENDPOINT: ""
 
   # --- Dataplane to Controlplane Auth ---
   AUTH_CLIENT_ID: ""            # client_credentials client ID

--- a/charts/dataplane/values.azure.yaml
+++ b/charts/dataplane/values.azure.yaml
@@ -22,8 +22,10 @@
 # all subcharts. Replace each "" below.
 
 global:
+  # --- Control plane (configure first) ---
+  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
+
   # --- Identity ---
-  UNION_CONTROL_PLANE_HOST: ""  # Public CP hostname (no scheme), e.g. "mycompany.union.ai"
   CLUSTER_NAME: ""              # Unique cluster identifier
   ORG_NAME: ""                  # Organization name (must match controlplane)
 
@@ -40,11 +42,6 @@ global:
   AZURE_BACKEND_CLIENT_ID: ""   # Managed Identity client ID for Union backend services
   AZURE_WORKER_CLIENT_ID: ""    # Managed Identity client ID for workflow execution pods
   AZURE_KEY_VAULT_URI: ""       # Key Vault URI (optional; see secret-manager example under config)
-
-  # --- DP -> CP routing ---
-  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
-  CONTROLPLANE_GRPC_ENDPOINT: "" # Override; defaults to dns:///{CONTROLPLANE_HOST}:443
-  QUEUE_GRPC_ENDPOINT: ""       # Override for the task-pod queue path (auth-less escape hatch)
 
   # --- Dataplane to Controlplane Auth ---
   AUTH_CLIENT_ID: ""            # client_credentials client ID

--- a/charts/dataplane/values.gcp.yaml
+++ b/charts/dataplane/values.gcp.yaml
@@ -13,8 +13,10 @@
 # union_extension module. Keep this overlay cloud-only.
 
 global:
+  # --- Control plane (configure first) ---
+  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
+
   # --- Identity ---
-  UNION_CONTROL_PLANE_HOST: ""  # Public CP hostname for Knative app auth callbacks
   CLUSTER_NAME: ""              # Unique cluster identifier
   ORG_NAME: ""                  # Organization name (must match controlplane)
 
@@ -30,18 +32,6 @@ global:
   # Format: <sa-name>@<project-id>.iam.gserviceaccount.com
   BACKEND_IAM_ROLE_ARN: ""      # SA for Union backend services
   WORKER_IAM_ROLE_ARN: ""       # SA for workflow execution pods
-
-  # --- DP -> CP routing ---
-  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
-  CONTROLPLANE_GRPC_ENDPOINT: "" # Override; defaults to dns:///{CONTROLPLANE_HOST}:443
-
-  # DEPRECATED — long-term plan is to remove this once propeller injects
-  # OAuth credentials into task pods. Until then it
-  # remains as the auth-less escape hatch task pods need (their queue events
-  # bypass nginx auth via this endpoint). Empty falls through to
-  # CONTROLPLANE_GRPC_ENDPOINT; for intracluster set the queue Service URL
-  # via examples/values.gcp.intracluster.yaml.
-  QUEUE_GRPC_ENDPOINT: ""
 
   # --- Dataplane to Controlplane Auth ---
   AUTH_CLIENT_ID: ""            # client_credentials client ID

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -2,8 +2,16 @@
 # live in values.{aws,gcp,azure}.yaml — start there for new deployments.
 
 global:
+  # --- Control plane (configure first) ---
+  # The single control-plane host. Everything derives from it: the DP->CP gRPC
+  # endpoint (dns:///<host>) and the app-callback URL (https://<host>). To
+  # enable/disable auth or route authless (direct in-cluster service, no nginx),
+  # use the config.union.auth / config.union.connection toggles — not a host
+  # override (see examples/values.authless.yaml).
+  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
+  UNION_CONTROL_PLANE_HOST: ""  # DEPRECATED legacy alias for CONTROLPLANE_HOST (still honored)
+
   # --- Identity ---
-  UNION_CONTROL_PLANE_HOST: ""  # Public CP hostname for Knative app auth callbacks (e.g. "mycompany.union.ai")
   CLUSTER_NAME: ""              # Unique cluster identifier within your org
   ORG_NAME: ""                  # Organization name (must match controlplane)
 
@@ -17,11 +25,6 @@ global:
   # Identity SA); values.azure.yaml uses AZURE_BACKEND_CLIENT_ID /
   # AZURE_WORKER_CLIENT_ID (managed-identity client IDs).
 
-  # --- DP -> CP routing ---
-  CONTROLPLANE_HOST: ""         # Bare CP hostname (no scheme, no port)
-  CONTROLPLANE_GRPC_ENDPOINT: "" # Override; defaults to dns:///{CONTROLPLANE_HOST}:443
-  QUEUE_GRPC_ENDPOINT: ""       # Override for task-pod queue path (see values.{cloud}.yaml)
-
   # --- Dataplane to Controlplane Auth ---
   AUTH_CLIENT_ID: ""            # client_credentials client ID
   OIDC_S2S_SCOPE: ""            # Okta: leave empty. Entra ID: "api://my-app/.default"
@@ -30,9 +33,9 @@ global:
 nameOverride: ""
 # -- Override the chart fullname.
 fullnameOverride: ""
-# -- (Optional) Operator override for the control-plane host. Empty by default;
-# -- when unset the host resolves via global.CONTROLPLANE_HOST then
-# -- global.UNION_CONTROL_PLANE_HOST (see dataplane.cp.host). Precedence:
+# -- DEPRECATED: top-level control-plane host. This is the pre-globals way to
+# -- set the CP host and is still honored as a fallback, but migrate to
+# -- global.CONTROLPLANE_HOST. Precedence in dataplane.cp.host:
 # -- global.CONTROLPLANE_HOST > host > global.UNION_CONTROL_PLANE_HOST.
 host: ""
 # -- Cluster identifier (shared with Union).
@@ -53,7 +56,7 @@ updateStatus:
     enabled: false
     # -- DP-reachable hostname the CP should dial back. e.g.
     # "dp-1.internal.<full_domain>". Bare hostname only — no scheme, no port.
-    # Chart helper derives the gRPC endpoint as `dns:///<host>:443`.
+    # Chart helper derives the gRPC endpoint as `dns:///<host>`.
     # Empty falls back to `Values.ingress.host` (the dataplane's own ingress
     # hostname), so most installs don't need to set this explicitly —
     # the chart already knows where the DP is reachable.
@@ -393,7 +396,7 @@ config:
         enabled: false
     connection:
       # -- Root-tenant (control plane) gRPC dial URL. Defaults to the derived CP
-      # -- endpoint (dns:///<host>:443, honoring global.CONTROLPLANE_GRPC_ENDPOINT).
+      # -- endpoint (dns:///<host>; grpc/https default the port to 443).
       # -- To override, set this same key — it is authoritative (Helm deep-merge
       # -- replaces this leaf before template rendering).
       rootTenantURLPattern: '{{ include "dataplane.cp.endpoint" . }}'

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -464,7 +464,7 @@ data:
       workerName: 'union-union-test-worker1'
     union:
       connection:
-        host: 'dns:///union.test.union.ai:443'
+        host: 'dns:///union.test.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -476,20 +476,20 @@ data:
     admin:
       clientId: 'test-client'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.test.union.ai:443'
+      endpoint: 'dns:///union.test.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.test.union.ai:443'
+          host: 'dns:///union.test.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.test.union.ai:443'
-      endpoint: 'dns:///union.test.union.ai:443'
+      cache-endpoint: 'dns:///union.test.union.ai'
+      endpoint: 'dns:///union.test.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2639,7 +2639,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///union.test.union.ai:443'
+        host: 'dns:///union.test.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2651,20 +2651,20 @@ data:
     admin:
       clientId: 'test-client'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.test.union.ai:443'
+      endpoint: 'dns:///union.test.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.test.union.ai:443'
+          host: 'dns:///union.test.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.test.union.ai:443'
-      endpoint: 'dns:///union.test.union.ai:443'
+      cache-endpoint: 'dns:///union.test.union.ai'
+      endpoint: 'dns:///union.test.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2747,7 +2747,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.test.union.ai:443'
+        host: 'dns:///union.test.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2764,7 +2764,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.test.union.ai:443'
+          host: 'dns:///union.test.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2840,7 +2840,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.test.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.test.union.ai'
   storage.yaml: | 
     storage:
       container: "test-bucket"
@@ -6848,7 +6848,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1d2e1f5d22c84a5027e48990df7b5ab463cbafbeef8b3dd4b83dcc1766220d8"
+        configChecksum: "849413d01ec27a2fafc2d414187cf48ca88d18e96f414d8be3d8ee3d04fc3ea"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6952,7 +6952,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "830ad74023e0029f2e7c4efa1699b3fa490cdd62610c28e5b9b9c0abfba74d4"
+        configChecksum: "165c8f588ffb07bb854a39190b49d5a47ec7ebf1ccee5970f0978c4c920af07"
         prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7061,7 +7061,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e0c3935d958ef95d40884139ecf293247bc02cefa88c62fc4b845a7787d0702"
+        configChecksum: "a47c660a48af5c0f48f2a688b9bf838ebe3e693af816435efe1bb87d5162c8a"
         prometheus.io/scrape: "true"
       labels:
         
@@ -7201,7 +7201,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e0c3935d958ef95d40884139ecf293247bc02cefa88c62fc4b845a7787d0702"
+        configChecksum: "a47c660a48af5c0f48f2a688b9bf838ebe3e693af816435efe1bb87d5162c8a"
         prometheus.io/scrape: "true"
       labels:
         
@@ -7331,7 +7331,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "1d2e1f5d22c84a5027e48990df7b5ab463cbafbeef8b3dd4b83dcc1766220d8"
+        configChecksum: "849413d01ec27a2fafc2d414187cf48ca88d18e96f414d8be3d8ee3d04fc3ea"
         prometheus.io/scrape: "true"
     spec:
       securityContext:

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -468,7 +468,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -480,20 +480,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.example.com:443'
+          host: 'dns:///test.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.example.com:443'
-      endpoint: 'dns:///test.example.com:443'
+      cache-endpoint: 'dns:///test.example.com'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2647,7 +2647,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2659,20 +2659,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.example.com:443'
+          host: 'dns:///test.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.example.com:443'
-      endpoint: 'dns:///test.example.com:443'
+      cache-endpoint: 'dns:///test.example.com'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2759,7 +2759,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2776,7 +2776,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.example.com:443'
+          host: 'dns:///test.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2852,7 +2852,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test.example.com:443'
+      rootTenantURLPattern: 'dns:///test.example.com'
   storage.yaml: | 
     storage:
       container: ""
@@ -6868,7 +6868,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c1587dc41b2284926ce876a047ab1c35b4c8f2a1f5321b928c0f145b3fb867b"
+        configChecksum: "e5a74aeaf85312edaaec7a925cf0465a8afdc56a4808e85e9cbbd88bcaea12e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6970,7 +6970,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8db8e3acc2ae953d18604fc843d3df71fecc96f0175b099805d4b904b0d9dd0"
+        configChecksum: "1d100cbc69ae7bc6a79d57e720c8e55f821178a0e5d201b117053f63f986ef3"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7077,7 +7077,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d8a6ee0613f2fd39b8bfcd82fb934f412fe6467a7c6da30c2d3c5f3062e6da5"
+        configChecksum: "48460eebda42a2fbe0d48d0d36a29fd361ca6f1c1c6ca5811845beb4d6e95ee"
         
       labels:
         
@@ -7215,7 +7215,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d8a6ee0613f2fd39b8bfcd82fb934f412fe6467a7c6da30c2d3c5f3062e6da5"
+        configChecksum: "48460eebda42a2fbe0d48d0d36a29fd361ca6f1c1c6ca5811845beb4d6e95ee"
         
       labels:
         
@@ -7341,7 +7341,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "c1587dc41b2284926ce876a047ab1c35b4c8f2a1f5321b928c0f145b3fb867b"
+        configChecksum: "e5a74aeaf85312edaaec7a925cf0465a8afdc56a4808e85e9cbbd88bcaea12e"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -589,7 +589,7 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -601,20 +601,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2789,7 +2789,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2801,20 +2801,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2947,7 +2947,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2964,7 +2964,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -3040,7 +3040,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: "test-metadata-bucket"
@@ -7388,7 +7388,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "93fff2a4ee95ea772cb66c11ab43631e14802bb13cc1a0abe6f6c777c73ee29"
+        configChecksum: "c0bd90bbefcb5eb568601100c3f67239ff2399f30763b34fe8d31ced33a65ff"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7490,7 +7490,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "b7702851f5b75a000ee8cf60f2b84b6613925f19cbc943a6643aa0047e31fd6"
+        configChecksum: "9b635e9c90f85818e5d8b17a88d190beae33c89fc5ff6aa22dd672c2862dd48"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7597,7 +7597,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "24558e786fcb7749fc2539de0bbdbca92a88d5cc964d314837c0549273e096c"
+        configChecksum: "d360227b4aa809bc6e74e4758155bfded2213bc38e1a0afc894ca70d657fd0b"
         
       labels:
         
@@ -7735,7 +7735,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "24558e786fcb7749fc2539de0bbdbca92a88d5cc964d314837c0549273e096c"
+        configChecksum: "d360227b4aa809bc6e74e4758155bfded2213bc38e1a0afc894ca70d657fd0b"
         
       labels:
         
@@ -7861,7 +7861,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "93fff2a4ee95ea772cb66c11ab43631e14802bb13cc1a0abe6f6c777c73ee29"
+        configChecksum: "c0bd90bbefcb5eb568601100c3f67239ff2399f30763b34fe8d31ced33a65ff"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -464,7 +464,7 @@ data:
       workerName: 'union-union-aws-worker1'
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -476,20 +476,20 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2639,7 +2639,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2651,20 +2651,20 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2767,7 +2767,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2784,7 +2784,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2863,7 +2863,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "bucket"
@@ -6871,7 +6871,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d02e33cc0899040340690df3846fd6e6aa1774af0f6b951ce0328701b24af0e"
+        configChecksum: "72a3e12c44ab14a4bf2fe0a39bbe5515723f5ecec9882515e2eb9e75cabe0f8"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6973,7 +6973,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "be0075230b950d42bc854f27dfc623dbe6249f8d38481476f4a8ad8b527466d"
+        configChecksum: "9f8371a02c88e5520512b541bfd7783e6d4e879d7bca9c2365a832bd847f9d4"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7080,7 +7080,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "30151eb2cd8ca9368ecc02347afe24f61f6a45a5c03d91d4eb0cab684fdafa6"
+        configChecksum: "6a6869b0d63fe3dd8cfb71c1869a1908f23137e1c01a4cf7b8123904b96becd"
         
       labels:
         
@@ -7218,7 +7218,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "30151eb2cd8ca9368ecc02347afe24f61f6a45a5c03d91d4eb0cab684fdafa6"
+        configChecksum: "6a6869b0d63fe3dd8cfb71c1869a1908f23137e1c01a4cf7b8123904b96becd"
         
       labels:
         
@@ -7350,7 +7350,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "d02e33cc0899040340690df3846fd6e6aa1774af0f6b951ce0328701b24af0e"
+        configChecksum: "72a3e12c44ab14a4bf2fe0a39bbe5515723f5ecec9882515e2eb9e75cabe0f8"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -589,7 +589,7 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -601,20 +601,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2764,7 +2764,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2776,20 +2776,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2872,7 +2872,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2889,7 +2889,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2965,7 +2965,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: "test-metadata-bucket"
@@ -7313,7 +7313,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "f8f99ea93af68a708df720dd5ae66788730f9319dadbc6691473b9b9d6eb656"
+        configChecksum: "f6e57779fb5b784d64414724bffbc132729fd9c6334bb95c4030d580c754c09"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7415,7 +7415,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2f9c3180098e72e65e623f367a94a3a7367ff484f224df3e7604791f333cfbf"
+        configChecksum: "d416680b3d0fa1ecdaa9f0168b278212fc59f644c762ced1f38c5b7976920b0"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7522,7 +7522,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "296e607131d2f1ea0391343852a1e804872b082441d6390e1366db81a91e1f6"
+        configChecksum: "48d8f7612eeb958a5d272f6a612ba1659dd6a0135513a93a854e88b069cd720"
         
       labels:
         
@@ -7660,7 +7660,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "296e607131d2f1ea0391343852a1e804872b082441d6390e1366db81a91e1f6"
+        configChecksum: "48d8f7612eeb958a5d272f6a612ba1659dd6a0135513a93a854e88b069cd720"
         
       labels:
         
@@ -7786,7 +7786,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "f8f99ea93af68a708df720dd5ae66788730f9319dadbc6691473b9b9d6eb656"
+        configChecksum: "f6e57779fb5b784d64414724bffbc132729fd9c6334bb95c4030d580c754c09"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -2363,7 +2363,7 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: 'dns:///override.example.com:443'
+        host: 'dns:///override.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2375,20 +2375,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///override.example.com:443'
+      endpoint: 'dns:///override.example.com'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///override.example.com:443'
+          host: 'dns:///override.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///override.example.com:443'
-      endpoint: 'dns:///override.example.com:443'
+      cache-endpoint: 'dns:///override.example.com'
+      endpoint: 'dns:///override.example.com'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -4538,7 +4538,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///override.example.com:443'
+        host: 'dns:///override.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -4550,20 +4550,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///override.example.com:443'
+      endpoint: 'dns:///override.example.com'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///override.example.com:443'
+          host: 'dns:///override.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///override.example.com:443'
-      endpoint: 'dns:///override.example.com:443'
+      cache-endpoint: 'dns:///override.example.com'
+      endpoint: 'dns:///override.example.com'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -4646,7 +4646,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///override.example.com:443'
+        host: 'dns:///override.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -4663,7 +4663,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///override.example.com:443'
+          host: 'dns:///override.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -4750,7 +4750,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///override.example.com:443'
+      rootTenantURLPattern: 'dns:///override.example.com'
   storage.yaml: | 
     storage:
       container: "test-metadata-bucket"
@@ -7911,7 +7911,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d14acbc15750b0f73d8174266ae6c1bbc391ffeeec742e9623400319d10210a"
+        configChecksum: "81267261cbc21fd8923d7b59aac8d48236c8d1172af000faba515e59c7c6594"
         
       labels:
         
@@ -9033,7 +9033,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5a0019ee015742456c8c365ee8c9c014212b20272a52786c729073160926116"
+        configChecksum: "b03ce671710343b9956baa82437fac3251dafde1f33154b7ee7a330a0ad927a"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9135,7 +9135,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ebe3f7405c678f4c6424ad4b81086db3503d32340e0d0e4ece6f9938a7a7820"
+        configChecksum: "aacb8b239faf66bce35e5c3aef29eae1cab81393a41aef7bf8bcc2c945cfd4f"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9242,7 +9242,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d14acbc15750b0f73d8174266ae6c1bbc391ffeeec742e9623400319d10210a"
+        configChecksum: "81267261cbc21fd8923d7b59aac8d48236c8d1172af000faba515e59c7c6594"
         
       labels:
         
@@ -9380,7 +9380,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d14acbc15750b0f73d8174266ae6c1bbc391ffeeec742e9623400319d10210a"
+        configChecksum: "81267261cbc21fd8923d7b59aac8d48236c8d1172af000faba515e59c7c6594"
         
       labels:
         
@@ -9506,7 +9506,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "5a0019ee015742456c8c365ee8c9c014212b20272a52786c729073160926116"
+        configChecksum: "b03ce671710343b9956baa82437fac3251dafde1f33154b7ee7a330a0ad927a"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -2363,7 +2363,7 @@ data:
       workerName: 'test-org-name-test-cluster-name-worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2375,20 +2375,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -4538,7 +4538,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -4550,20 +4550,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -4646,7 +4646,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -4663,7 +4663,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -4750,7 +4750,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: "test-metadata-bucket"
@@ -7911,7 +7911,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e84847da5823f07d93ecf5ba4fcd751eac972e2dbaa246f13c4da18497b0097"
+        configChecksum: "31324cb3e2480abed2f1852fcdc8d23620be4a4cefefd07a0b208663828a295"
         
       labels:
         
@@ -9033,7 +9033,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a3caa660bf6f6591c69e51f74af6893217d5419e289c098e61d744256d7c84b"
+        configChecksum: "207d417719d17cff11a8803bfef2880aed41ef5afade7a8d398167dd085ed18"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9135,7 +9135,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "89766dfe87d7563981d5e4300f22a2bb2d783b05caa64c3ebab9921e2e1b211"
+        configChecksum: "503996471db328abb46a3286a065aef8afa5e40b087527ecdad51cdd2408a7f"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -9242,7 +9242,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e84847da5823f07d93ecf5ba4fcd751eac972e2dbaa246f13c4da18497b0097"
+        configChecksum: "31324cb3e2480abed2f1852fcdc8d23620be4a4cefefd07a0b208663828a295"
         
       labels:
         
@@ -9380,7 +9380,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e84847da5823f07d93ecf5ba4fcd751eac972e2dbaa246f13c4da18497b0097"
+        configChecksum: "31324cb3e2480abed2f1852fcdc8d23620be4a4cefefd07a0b208663828a295"
         
       labels:
         
@@ -9506,7 +9506,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "a3caa660bf6f6591c69e51f74af6893217d5419e289c098e61d744256d7c84b"
+        configChecksum: "207d417719d17cff11a8803bfef2880aed41ef5afade7a8d398167dd085ed18"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -456,7 +456,7 @@ data:
       workerName: 'test-org-test-azure-cluster-worker1'
     union:
       connection:
-        host: 'dns:///test.dataplane.union.ai:443'
+        host: 'dns:///test.dataplane.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -468,20 +468,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.dataplane.union.ai:443'
+          host: 'dns:///test.dataplane.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      cache-endpoint: 'dns:///test.dataplane.union.ai'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2647,7 +2647,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test.dataplane.union.ai:443'
+        host: 'dns:///test.dataplane.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2659,20 +2659,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.dataplane.union.ai:443'
+          host: 'dns:///test.dataplane.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      cache-endpoint: 'dns:///test.dataplane.union.ai'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2787,7 +2787,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test.dataplane.union.ai:443'
+        host: 'dns:///test.dataplane.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2804,7 +2804,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.dataplane.union.ai:443'
+          host: 'dns:///test.dataplane.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2893,7 +2893,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test.dataplane.union.ai:443'
+      rootTenantURLPattern: 'dns:///test.dataplane.union.ai'
   storage.yaml: | 
     storage:
       container: "test-metadata-container"
@@ -6901,7 +6901,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "244aa889130e24e6debbc63dd622123f571e4560733e8f038293ad877eced53"
+        configChecksum: "d0bb0b54b8b1935a3a1697039fa50ecb701a5437cd4307fec7a8acedb0a30a6"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7004,7 +7004,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "af0806b6628fe8f4de837180ecbbfeaf05c3d1267d69fcedf348a04024b458c"
+        configChecksum: "056f324409b549b8c7e0fb89a899cdddef5d6ac837903edf3cf6f94fccf9e30"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7112,7 +7112,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "31800a0ff719d2715773018859707e3f4308d1b63fd22f4ae563601a33cf40c"
+        configChecksum: "1899f761e65b831a1cc548ff1c7be86bb29ff72cc2afef3f59b0116c63809b2"
         
       labels:
         
@@ -7251,7 +7251,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "31800a0ff719d2715773018859707e3f4308d1b63fd22f4ae563601a33cf40c"
+        configChecksum: "1899f761e65b831a1cc548ff1c7be86bb29ff72cc2afef3f59b0116c63809b2"
         
       labels:
         
@@ -7379,7 +7379,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "244aa889130e24e6debbc63dd622123f571e4560733e8f038293ad877eced53"
+        configChecksum: "d0bb0b54b8b1935a3a1697039fa50ecb701a5437cd4307fec7a8acedb0a30a6"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -456,7 +456,7 @@ data:
       workerName: 'test-org-test-azure-cluster-worker1'
     union:
       connection:
-        host: 'dns:///test.dataplane.union.ai:443'
+        host: 'dns:///test.dataplane.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -468,20 +468,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.dataplane.union.ai:443'
+          host: 'dns:///test.dataplane.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      cache-endpoint: 'dns:///test.dataplane.union.ai'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2647,7 +2647,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test.dataplane.union.ai:443'
+        host: 'dns:///test.dataplane.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2659,20 +2659,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.dataplane.union.ai:443'
+          host: 'dns:///test.dataplane.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.dataplane.union.ai:443'
-      endpoint: 'dns:///test.dataplane.union.ai:443'
+      cache-endpoint: 'dns:///test.dataplane.union.ai'
+      endpoint: 'dns:///test.dataplane.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2787,7 +2787,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test.dataplane.union.ai:443'
+        host: 'dns:///test.dataplane.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2804,7 +2804,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.dataplane.union.ai:443'
+          host: 'dns:///test.dataplane.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2893,7 +2893,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test.dataplane.union.ai:443'
+      rootTenantURLPattern: 'dns:///test.dataplane.union.ai'
   storage.yaml: | 
     storage:
       container: ""
@@ -6901,7 +6901,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c7e01b9dab9664cf8fe6e73adcafb71845769dc5dcd11afea8edd43a7769121"
+        configChecksum: "61b499b3eacd98749e1bbc89502de624c0ce2814deef653689a83e8013bc710"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7004,7 +7004,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8f3a6bb8b5f39d1a4852238fc9a29c5d579bdb5bda7e56166854a8acc57791d"
+        configChecksum: "225a72f12791b15d667020be8422bc0e694289d2e15b4866bfd450d7148ae67"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7112,7 +7112,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "11bee77af5417b977ed3392fea6760f0bbb09b9634fe1daa8d930ead8b5ef6e"
+        configChecksum: "423746d10a0f1b6442c017f85edb5ed225e18f3a2d8a5b4dd1bb5b9e131d8ea"
         
       labels:
         
@@ -7251,7 +7251,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "11bee77af5417b977ed3392fea6760f0bbb09b9634fe1daa8d930ead8b5ef6e"
+        configChecksum: "423746d10a0f1b6442c017f85edb5ed225e18f3a2d8a5b4dd1bb5b9e131d8ea"
         
       labels:
         
@@ -7379,7 +7379,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "c7e01b9dab9664cf8fe6e73adcafb71845769dc5dcd11afea8edd43a7769121"
+        configChecksum: "61b499b3eacd98749e1bbc89502de624c0ce2814deef653689a83e8013bc710"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -336,13 +336,13 @@ data:
         tokenRefreshWindow: 5m
         type: ClientSecret
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
   admin.yaml: | 
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecureSkipVerify: false
     event:
@@ -618,7 +618,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -630,20 +630,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.example.com:443'
+          host: 'dns:///test.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.example.com:443'
-      endpoint: 'dns:///test.example.com:443'
+      cache-endpoint: 'dns:///test.example.com'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2795,7 +2795,7 @@ data:
           memory: 2Ti
     union:
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2807,20 +2807,20 @@ data:
     admin:
       clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test.example.com:443'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.example.com:443'
+          host: 'dns:///test.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test.example.com:443'
-      endpoint: 'dns:///test.example.com:443'
+      cache-endpoint: 'dns:///test.example.com'
+      endpoint: 'dns:///test.example.com'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2906,7 +2906,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test.example.com:443'
+        host: 'dns:///test.example.com'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2923,7 +2923,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test.example.com:443'
+          host: 'dns:///test.example.com'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2995,7 +2995,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test.example.com:443'
+      rootTenantURLPattern: 'dns:///test.example.com'
   storage.yaml: | 
     storage:
       container: ""
@@ -6774,7 +6774,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "de4ca746e53a9210e7c5be8957250e2dd2187b39b9e6fdd92790126284b68e9"
+        configChecksum: "b1fd1ca181e22884bdc049ba9fa10dc342a265d9b76a179c68b1bda619fa918"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7053,7 +7053,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d4b35eeeff8ba433507bf2e754010f3f217634aae5fa56f3867e647cd08558a"
+        configChecksum: "b44bca6c69e108176c1f0a8eda5bd0664bf93188eb45e483c8c054c99f1303d"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7156,7 +7156,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a5b9dece90ab9fbf862de24067a10011bc320cf8686fc8518a93ee884a1c78d"
+        configChecksum: "f7847a18c270511db5b2f954a95d51f6f00f01199ba7d8f6a35d18ffa8f7efe"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7263,7 +7263,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7d02141202a05c2f4a3b3ddd01b371e55702447510359183855961db5b119fd"
+        configChecksum: "c2780ba58c70f49812d00b948a7b6f14bfdd02562cda67d0f73cab979317ea3"
         
       labels:
         
@@ -7403,7 +7403,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7d02141202a05c2f4a3b3ddd01b371e55702447510359183855961db5b119fd"
+        configChecksum: "c2780ba58c70f49812d00b948a7b6f14bfdd02562cda67d0f73cab979317ea3"
         
       labels:
         
@@ -7529,7 +7529,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "d4b35eeeff8ba433507bf2e754010f3f217634aae5fa56f3867e647cd08558a"
+        configChecksum: "b44bca6c69e108176c1f0a8eda5bd0664bf93188eb45e483c8c054c99f1303d"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -455,7 +455,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -467,20 +467,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2634,7 +2634,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2646,20 +2646,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2746,7 +2746,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2763,7 +2763,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2839,7 +2839,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: ""
@@ -6855,7 +6855,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "06c6ae51d4832ae669c3fe2b6724a47b4914ff77b8a4b0c498f8739db9d3a9a"
+        configChecksum: "cdcf564e5350be41f52a9d4bcd78ae91a2782d77fab6d7eafc6427c41d51753"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6957,7 +6957,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aed1b75780fd7f59c233c04dd56b6d52ca35a2cfa711df4fbd955ff879fd5de"
+        configChecksum: "7a05201fdfa82939ffc4e61e8c215413bc983754e33865bce3550b7f0dcd08c"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7064,7 +7064,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "df20bc77ae42f69dae495bfcbd41fbac0af840086bb111c8d1968258403ac80"
+        configChecksum: "a280c434eae8e7f79c2c29a9ad68e30861934f1538c3dd035822d62a81127a7"
         
       labels:
         
@@ -7202,7 +7202,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "df20bc77ae42f69dae495bfcbd41fbac0af840086bb111c8d1968258403ac80"
+        configChecksum: "a280c434eae8e7f79c2c29a9ad68e30861934f1538c3dd035822d62a81127a7"
         
       labels:
         
@@ -7328,7 +7328,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "06c6ae51d4832ae669c3fe2b6724a47b4914ff77b8a4b0c498f8739db9d3a9a"
+        configChecksum: "cdcf564e5350be41f52a9d4bcd78ae91a2782d77fab6d7eafc6427c41d51753"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -580,7 +580,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -592,20 +592,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2759,7 +2759,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2771,20 +2771,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2871,7 +2871,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2888,7 +2888,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2964,7 +2964,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: ""
@@ -7188,7 +7188,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "06c6ae51d4832ae669c3fe2b6724a47b4914ff77b8a4b0c498f8739db9d3a9a"
+        configChecksum: "cdcf564e5350be41f52a9d4bcd78ae91a2782d77fab6d7eafc6427c41d51753"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7290,7 +7290,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aed1b75780fd7f59c233c04dd56b6d52ca35a2cfa711df4fbd955ff879fd5de"
+        configChecksum: "7a05201fdfa82939ffc4e61e8c215413bc983754e33865bce3550b7f0dcd08c"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7397,7 +7397,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "df20bc77ae42f69dae495bfcbd41fbac0af840086bb111c8d1968258403ac80"
+        configChecksum: "a280c434eae8e7f79c2c29a9ad68e30861934f1538c3dd035822d62a81127a7"
         
       labels:
         
@@ -7535,7 +7535,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "df20bc77ae42f69dae495bfcbd41fbac0af840086bb111c8d1968258403ac80"
+        configChecksum: "a280c434eae8e7f79c2c29a9ad68e30861934f1538c3dd035822d62a81127a7"
         
       labels:
         
@@ -7661,7 +7661,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "06c6ae51d4832ae669c3fe2b6724a47b4914ff77b8a4b0c498f8739db9d3a9a"
+        configChecksum: "cdcf564e5350be41f52a9d4bcd78ae91a2782d77fab6d7eafc6427c41d51753"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.flytepropeller.yaml
+++ b/tests/generated/dataplane.flytepropeller.yaml
@@ -501,7 +501,7 @@ data:
       workerName: 'byok-test-e2e-propeller-worker1'
     union:
       connection:
-        host: 'dns:///byok.us-west-2.union.ai:443'
+        host: 'dns:///byok.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -513,20 +513,20 @@ data:
     admin:
       clientId: 'byok-test-e2e-propeller-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///byok.us-west-2.union.ai:443'
+          host: 'dns:///byok.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2677,7 +2677,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///byok.us-west-2.union.ai:443'
+        host: 'dns:///byok.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2689,20 +2689,20 @@ data:
     admin:
       clientId: 'byok-test-e2e-propeller-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///byok.us-west-2.union.ai:443'
+          host: 'dns:///byok.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2786,7 +2786,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///byok.us-west-2.union.ai:443'
+        host: 'dns:///byok.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2803,7 +2803,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///byok.us-west-2.union.ai:443'
+          host: 'dns:///byok.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2880,7 +2880,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///byok.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///byok.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "test-gcp-bucket"
@@ -4143,7 +4143,7 @@ data:
     admin:
       clientId: 'byok-test-e2e-propeller-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     event:
@@ -4152,8 +4152,8 @@ data:
       type: admin
   catalog.yaml: | 
     catalog-cache:
-      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -7031,7 +7031,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "c95d488a772460bb3c799d4a70d13efc93435dff7484df4befd99c9caab319a"
+        configChecksum: "a312fa506bf3f72452f5209de13285e5310320149d570c86241535913841f56"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7134,7 +7134,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6a892d02aaa5eee8130ce02eb29d8bb291c010d0dc7a708611c953f6793491d"
+        configChecksum: "67a8d0b1561a4251ec522c50be3619d29fc2deb27271a97013d7605c0a5369f"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7241,7 +7241,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "96c519552f565e3fc72fc66fd6c9f67319966b3f140cc559fe7876dc9431534"
+        configChecksum: "fa800ae30c59f0101108443865dc445f5203c2d14e0f9d51864056606f97763"
         
       labels:
         
@@ -7379,7 +7379,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "96c519552f565e3fc72fc66fd6c9f67319966b3f140cc559fe7876dc9431534"
+        configChecksum: "fa800ae30c59f0101108443865dc445f5203c2d14e0f9d51864056606f97763"
         
       labels:
         
@@ -7496,7 +7496,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7a45a78ed9cfe0a4d7a4ce42bd4fb31235bd2045c82def27af078a0260c3c4d"
+        configChecksum: "2b411be316a1264cbaea4a60fa61816e58e6829c9e77b6500a54c2696ad7ed2"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7604,7 +7604,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "7a45a78ed9cfe0a4d7a4ce42bd4fb31235bd2045c82def27af078a0260c3c4d"
+        configChecksum: "2b411be316a1264cbaea4a60fa61816e58e6829c9e77b6500a54c2696ad7ed2"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -455,7 +455,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -467,20 +467,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2634,7 +2634,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2646,20 +2646,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2746,7 +2746,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2763,7 +2763,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2839,7 +2839,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: ""
@@ -6855,7 +6855,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "893c76d10aba56ae44a54c1597df53a8e35da6fe916e6200105b6a02c4b6014"
+        configChecksum: "e2f80984f98803bf86fe74139e5497dc8a18d7b9a3a8cd52e4076f6a9dfeab7"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6947,7 +6947,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "55e9d2e2c270a8545866f8a03bc6fefb2708b9a75a9f689b393eb91e32c2a4f"
+        configChecksum: "40fc5a75ed9f90bbf72154da7e073b0767827a83098f83d3a66111eebdf1b34"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7044,7 +7044,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bba92cedc1dac8436aba6797134887cca44264eb5dd80de44cf66f42b81afb6"
+        configChecksum: "443dc490434e707b0b9a9b0a49ee0188e85b4c16beced2bade78ec0dc9ee27d"
         
       labels:
         
@@ -7151,7 +7151,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "bba92cedc1dac8436aba6797134887cca44264eb5dd80de44cf66f42b81afb6"
+        configChecksum: "443dc490434e707b0b9a9b0a49ee0188e85b4c16beced2bade78ec0dc9ee27d"
         
       labels:
         
@@ -7272,7 +7272,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "893c76d10aba56ae44a54c1597df53a8e35da6fe916e6200105b6a02c4b6014"
+        configChecksum: "e2f80984f98803bf86fe74139e5497dc8a18d7b9a3a8cd52e4076f6a9dfeab7"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -465,7 +465,7 @@ data:
       workerName: 'byok-test-e2e-gcp-worker1'
     union:
       connection:
-        host: 'dns:///byok.us-west-2.union.ai:443'
+        host: 'dns:///byok.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -477,20 +477,20 @@ data:
     admin:
       clientId: 'byok-test-e2e-gcp-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///byok.us-west-2.union.ai:443'
+          host: 'dns:///byok.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2641,7 +2641,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///byok.us-west-2.union.ai:443'
+        host: 'dns:///byok.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2653,20 +2653,20 @@ data:
     admin:
       clientId: 'byok-test-e2e-gcp-operator'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///byok.us-west-2.union.ai:443'
+          host: 'dns:///byok.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///byok.us-west-2.union.ai:443'
-      endpoint: 'dns:///byok.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///byok.us-west-2.union.ai'
+      endpoint: 'dns:///byok.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2750,7 +2750,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///byok.us-west-2.union.ai:443'
+        host: 'dns:///byok.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2767,7 +2767,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///byok.us-west-2.union.ai:443'
+          host: 'dns:///byok.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2843,7 +2843,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///byok.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///byok.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "test-gcp-bucket"
@@ -6853,7 +6853,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "080fdac5cb559ddb06f86e512bd175ea81a8de6c22bf3309c274687bdb9858d"
+        configChecksum: "07e03fb4b8692b5e4386cf3333fc8770c3ebdae26e3fbaeb06e904cbe6368c8"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6955,7 +6955,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ddd004821d1af27a3121041ba52cbd67f551102190cceab6864f92471823a92"
+        configChecksum: "642136e6a86c8aae4f6cffaa1c5ca15a0ca965520b1499c6fe070a34cb9e0c4"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7062,7 +7062,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7efc3fcca66741bce755edb40c582e7d25bd7dca5d1d9b6b0c5bcea6b03baa5"
+        configChecksum: "a911bf9b9f29d3c47be0049d9d19724497684e1b53d8b562dfe9fd4bfeed26f"
         
       labels:
         
@@ -7200,7 +7200,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7efc3fcca66741bce755edb40c582e7d25bd7dca5d1d9b6b0c5bcea6b03baa5"
+        configChecksum: "a911bf9b9f29d3c47be0049d9d19724497684e1b53d8b562dfe9fd4bfeed26f"
         
       labels:
         
@@ -7326,7 +7326,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "080fdac5cb559ddb06f86e512bd175ea81a8de6c22bf3309c274687bdb9858d"
+        configChecksum: "07e03fb4b8692b5e4386cf3333fc8770c3ebdae26e3fbaeb06e904cbe6368c8"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -469,7 +469,7 @@ data:
       workerName: 'union-my-cluster-worker1'
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -481,20 +481,20 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2651,7 +2651,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2663,20 +2663,20 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2769,7 +2769,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2786,7 +2786,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2862,7 +2862,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "bucket"
@@ -6878,7 +6878,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "21858dde77de08021d34af9a255ee36b533e3372e22d768547b6edec3c3f3f4"
+        configChecksum: "303cc32d58df4b5d3ad9e3d3feebd870fcf871dc35d2302fb213b5cfb5b39a5"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6980,7 +6980,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "35a8be902663357c6edf82b6e9cf74b90fbd65b24d57ff8263db302460a3e86"
+        configChecksum: "bc7617f6e0589a36299be3644d84846d33443be3733998eb1fe09e858e7c2f1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7087,7 +7087,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6892fa6b3d459028af69e7b399d4f7509f4e201f42f196551e8ff6966e931a1"
+        configChecksum: "b02e09710fb52d8ee0a8f9684dd879287a334577b1f1f071e8db699639e2cf3"
         
       labels:
         
@@ -7225,7 +7225,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6892fa6b3d459028af69e7b399d4f7509f4e201f42f196551e8ff6966e931a1"
+        configChecksum: "b02e09710fb52d8ee0a8f9684dd879287a334577b1f1f071e8db699639e2cf3"
         
       labels:
         
@@ -7351,7 +7351,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "21858dde77de08021d34af9a255ee36b533e3372e22d768547b6edec3c3f3f4"
+        configChecksum: "303cc32d58df4b5d3ad9e3d3feebd870fcf871dc35d2302fb213b5cfb5b39a5"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -1191,7 +1191,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1203,20 +1203,20 @@ data:
     admin:
       clientId: 'test'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -3370,7 +3370,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -3382,20 +3382,20 @@ data:
     admin:
       clientId: 'test'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -3482,7 +3482,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -3499,7 +3499,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -3575,7 +3575,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: ""
@@ -8787,7 +8787,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ffc6da9825afd5c2e51a896536fafb0d097b9c75f5f77e385bea3eeafa5449a"
+        configChecksum: "5b48460178cba38e2403f05a91dd74142c4fc7cf8a8d1386f928be7cdafbd4a"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -8889,7 +8889,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "1a0ad5fe08605c08ce2c1d1801cd0c5be0464714ba22f3d3d16ea93303486ab"
+        configChecksum: "3244d880fbd40912497af29bad1ee45262aba2515c953097ee8b2287b2ab17c"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -8996,7 +8996,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "422f6a91162c643d864e321f877766200b57e19dabb3dc6bdaacac26a119cde"
+        configChecksum: "472ac8f27fa213773ea768d0b6c0d6f9f386d4b1f43588038e54d26f103b52b"
         
       labels:
         
@@ -9134,7 +9134,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "422f6a91162c643d864e321f877766200b57e19dabb3dc6bdaacac26a119cde"
+        configChecksum: "472ac8f27fa213773ea768d0b6c0d6f9f386d4b1f43588038e54d26f103b52b"
         
       labels:
         
@@ -9260,7 +9260,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "ffc6da9825afd5c2e51a896536fafb0d097b9c75f5f77e385bea3eeafa5449a"
+        configChecksum: "5b48460178cba38e2403f05a91dd74142c4fc7cf8a8d1386f928be7cdafbd4a"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.namespace-multi.yaml
+++ b/tests/generated/dataplane.namespace-multi.yaml
@@ -336,13 +336,13 @@ data:
         tokenRefreshWindow: 5m
         type: ClientSecret
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
   admin.yaml: | 
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     event:
@@ -623,7 +623,7 @@ data:
       workerName: 'union-my-cluster-worker1'
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -635,20 +635,20 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2805,7 +2805,7 @@ data:
       template: "test-{{ project }}-{{ domain }}"
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2817,20 +2817,20 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2922,7 +2922,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2939,7 +2939,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -3013,7 +3013,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "bucket"
@@ -6784,7 +6784,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5a7bd8f8ae1d1b8c4a6275c75deab2905a07a623a4feb78d75922ef4c76f7ba"
+        configChecksum: "3c05b3b39a6121ae46880dca41b82be5b677a3aec37eb98a97a6ea6cc24016e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7063,7 +7063,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "2a49153ef0eff470a16e924f2fd5193acf68bba7658b5e8d9800b76c4fd4e80"
+        configChecksum: "9d5b1847a145e107d6c32a8d1602f58302bb96fb0de972f642804e8bc11f2ea"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7166,7 +7166,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "8478cdb2963d197cde39e8024a0451006360055a45b6c95f4a1e2d4e9a913f7"
+        configChecksum: "c7f291d2ea12c2b9c9444b11359ad367984a822866d1bb5308db7aefd77f2fa"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7273,7 +7273,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5d2e361eaa6964d04c1ad63770cd0f6f1876035a8bfdb2d678078a932dd34c4"
+        configChecksum: "9a12bac277855f58be687b48dbe4de525755cc16c126f77a3e34ebb7b9ef9db"
         
       labels:
         
@@ -7413,7 +7413,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "5d2e361eaa6964d04c1ad63770cd0f6f1876035a8bfdb2d678078a932dd34c4"
+        configChecksum: "9a12bac277855f58be687b48dbe4de525755cc16c126f77a3e34ebb7b9ef9db"
         
       labels:
         
@@ -7539,7 +7539,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "2a49153ef0eff470a16e924f2fd5193acf68bba7658b5e8d9800b76c4fd4e80"
+        configChecksum: "9d5b1847a145e107d6c32a8d1602f58302bb96fb0de972f642804e8bc11f2ea"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.namespace-single.yaml
+++ b/tests/generated/dataplane.namespace-single.yaml
@@ -469,7 +469,7 @@ data:
       workerName: 'union-my-cluster-worker1'
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -481,20 +481,20 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2651,7 +2651,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2663,20 +2663,20 @@ data:
     admin:
       clientId: 'my-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2769,7 +2769,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2786,7 +2786,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2862,7 +2862,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "bucket"
@@ -6878,7 +6878,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "21858dde77de08021d34af9a255ee36b533e3372e22d768547b6edec3c3f3f4"
+        configChecksum: "303cc32d58df4b5d3ad9e3d3feebd870fcf871dc35d2302fb213b5cfb5b39a5"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6980,7 +6980,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "35a8be902663357c6edf82b6e9cf74b90fbd65b24d57ff8263db302460a3e86"
+        configChecksum: "bc7617f6e0589a36299be3644d84846d33443be3733998eb1fe09e858e7c2f1"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7087,7 +7087,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6892fa6b3d459028af69e7b399d4f7509f4e201f42f196551e8ff6966e931a1"
+        configChecksum: "b02e09710fb52d8ee0a8f9684dd879287a334577b1f1f071e8db699639e2cf3"
         
       labels:
         
@@ -7225,7 +7225,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6892fa6b3d459028af69e7b399d4f7509f4e201f42f196551e8ff6966e931a1"
+        configChecksum: "b02e09710fb52d8ee0a8f9684dd879287a334577b1f1f071e8db699639e2cf3"
         
       labels:
         
@@ -7351,7 +7351,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "21858dde77de08021d34af9a255ee36b533e3372e22d768547b6edec3c3f3f4"
+        configChecksum: "303cc32d58df4b5d3ad9e3d3feebd870fcf871dc35d2302fb213b5cfb5b39a5"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -462,7 +462,7 @@ data:
       workerName: '--worker1'
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -474,20 +474,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2641,7 +2641,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2653,20 +2653,20 @@ data:
     admin:
       clientId: ''
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///test-controlplane-host:443'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///test-controlplane-host:443'
-      endpoint: 'dns:///test-controlplane-host:443'
+      cache-endpoint: 'dns:///test-controlplane-host'
+      endpoint: 'dns:///test-controlplane-host'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2764,7 +2764,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///test-controlplane-host:443'
+        host: 'dns:///test-controlplane-host'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2781,7 +2781,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///test-controlplane-host:443'
+          host: 'dns:///test-controlplane-host'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2857,7 +2857,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///test-controlplane-host:443'
+      rootTenantURLPattern: 'dns:///test-controlplane-host'
   storage.yaml: | 
     storage:
       container: ""
@@ -7005,7 +7005,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "06c6ae51d4832ae669c3fe2b6724a47b4914ff77b8a4b0c498f8739db9d3a9a"
+        configChecksum: "cdcf564e5350be41f52a9d4bcd78ae91a2782d77fab6d7eafc6427c41d51753"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7107,7 +7107,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "aed1b75780fd7f59c233c04dd56b6d52ca35a2cfa711df4fbd955ff879fd5de"
+        configChecksum: "7a05201fdfa82939ffc4e61e8c215413bc983754e33865bce3550b7f0dcd08c"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7214,7 +7214,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "df20bc77ae42f69dae495bfcbd41fbac0af840086bb111c8d1968258403ac80"
+        configChecksum: "a280c434eae8e7f79c2c29a9ad68e30861934f1538c3dd035822d62a81127a7"
         
       labels:
         
@@ -7352,7 +7352,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "df20bc77ae42f69dae495bfcbd41fbac0af840086bb111c8d1968258403ac80"
+        configChecksum: "a280c434eae8e7f79c2c29a9ad68e30861934f1538c3dd035822d62a81127a7"
         
       labels:
         
@@ -7478,7 +7478,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "06c6ae51d4832ae669c3fe2b6724a47b4914ff77b8a4b0c498f8739db9d3a9a"
+        configChecksum: "cdcf564e5350be41f52a9d4bcd78ae91a2782d77fab6d7eafc6427c41d51753"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -469,7 +469,7 @@ data:
       workerName: 'union-union-oci-worker1'
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -481,20 +481,20 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2656,7 +2656,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2668,20 +2668,20 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2784,7 +2784,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2801,7 +2801,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2877,7 +2877,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "bucket"
@@ -6899,7 +6899,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9a08548821ca6449b371824195a8deadb2bb37bd3d35b3ea7f0ef0c7684a551"
+        configChecksum: "35f648d1f59447e39ff14a8d911e15c51760ed4264906b3347556d1018f7151"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7014,7 +7014,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "662bc7f6083398d6a38d4ba4c6cf7779e29aaf0a080bfd998ecbea14ad65a89"
+        configChecksum: "7d79d7efc31b7addaf82e32ed5d21fcc18aafab41eba174783d7874819033ad"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7134,7 +7134,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "83d0136020e284a70cfc91ff30e3cb6c990a4989451f0a93d4d6f63e9a1a070"
+        configChecksum: "617eb75b72b2bb99e4dd8e2757ff4d3185ae2d1f69f00132219d58f426a3544"
         
       labels:
         
@@ -7285,7 +7285,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "83d0136020e284a70cfc91ff30e3cb6c990a4989451f0a93d4d6f63e9a1a070"
+        configChecksum: "617eb75b72b2bb99e4dd8e2757ff4d3185ae2d1f69f00132219d58f426a3544"
         
       labels:
         
@@ -7424,7 +7424,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "9a08548821ca6449b371824195a8deadb2bb37bd3d35b3ea7f0ef0c7684a551"
+        configChecksum: "35f648d1f59447e39ff14a8d911e15c51760ed4264906b3347556d1018f7151"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -467,7 +467,7 @@ data:
       workerName: 'union-union-oci-worker1'
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -479,20 +479,20 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2645,7 +2645,7 @@ data:
       template: union
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2657,20 +2657,20 @@ data:
     admin:
       clientId: 'clientId'
       clientSecretLocation: /etc/union/secret/client_secret
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecureSkipVerify: false
     authorizer:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
     catalog-cache:
-      cache-endpoint: 'dns:///union.us-west-2.union.ai:443'
-      endpoint: 'dns:///union.us-west-2.union.ai:443'
+      cache-endpoint: 'dns:///union.us-west-2.union.ai'
+      endpoint: 'dns:///union.us-west-2.union.ai'
       insecure: false
       insecure-skip-verify: false
       type: cacheservicev2
@@ -2757,7 +2757,7 @@ data:
   config.yaml: |
     union:
       connection:
-        host: 'dns:///union.us-west-2.union.ai:443'
+        host: 'dns:///union.us-west-2.union.ai'
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2774,7 +2774,7 @@ data:
       authorizerClient:
         credentials: ServiceCredentials
         grpcConfig:
-          host: 'dns:///union.us-west-2.union.ai:443'
+          host: 'dns:///union.us-west-2.union.ai'
           insecure: false
           insecureSkipVerify: false
       type: Authorizer
@@ -2850,7 +2850,7 @@ data:
       identity:
         enabled: false
     connection:
-      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai:443'
+      rootTenantURLPattern: 'dns:///union.us-west-2.union.ai'
   storage.yaml: | 
     storage:
       container: "bucket"
@@ -6862,7 +6862,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "e807e0221053fad77055f602f847327dd3a20fa56ecba2570ad9e22d81e84b0"
+        configChecksum: "f02910fc9f688992db68c1678a1805d9c4b00011239073ed53d74a20590d890"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6964,7 +6964,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "efa627418e35f07f0dd1bbf41cdb1c3acabfa6acce15f6278daf3ee498e7fbc"
+        configChecksum: "b7daf36143a9e4c70fbaecc7ce5e1a7d2413d1dc9c3d31ebc8aa88e48e74b3b"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -7071,7 +7071,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3c535d5e096130c3e2af30215f9741b4b34314b6e7357c29914fe181357fa24"
+        configChecksum: "eeb5a1cdd8fcab8fefb54d896945eb6c005b3b75278b63385dd7086553390c2"
         
       labels:
         
@@ -7209,7 +7209,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "3c535d5e096130c3e2af30215f9741b4b34314b6e7357c29914fe181357fa24"
+        configChecksum: "eeb5a1cdd8fcab8fefb54d896945eb6c005b3b75278b63385dd7086553390c2"
         
       labels:
         
@@ -7335,7 +7335,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "e807e0221053fad77055f602f847327dd3a20fa56ecba2570ad9e22d81e84b0"
+        configChecksum: "f02910fc9f688992db68c1678a1805d9c4b00011239073ed53d74a20590d890"
         
     spec:
       securityContext:


### PR DESCRIPTION
## Overview

The DP→CP destination was four overlapping globals (`CONTROLPLANE_HOST`, `UNION_CONTROL_PLANE_HOST`, `CONTROLPLANE_GRPC_ENDPOINT`, `QUEUE_GRPC_ENDPOINT`). This collapses them to **one host**.

- **`CONTROLPLANE_HOST`** is the single host global, moved to the **top** of the globals ("configure first"). `dataplane.cp.endpoint` derives `dns:///<host>` from it.
- **Removed `CONTROLPLANE_GRPC_ENDPOINT`** — always derived (`dns:///<host>`). The `:443` port is omitted; grpc-go's DNS resolver and Connect/https both default to 443.
- **Removed `QUEUE_GRPC_ENDPOINT` + the `dataplane.cp.queueEndpoint` helper** — the task-pod endpoint is injected by the leaseworker/executor from `config.union.connection`; there is no separate queue global. Authless / direct-service routing (skip nginx + OAuth, dial the in-cluster Service on `:80`) is configured explicitly via `config.union.auth` + `config.union.connection`, documented in the new **`examples/values.authless.yaml`**.
- **`UNION_CONTROL_PLANE_HOST` and top-level `.Values.host`** are marked **DEPRECATED** — still honored as fallbacks (precedence `CONTROLPLANE_HOST` > `.Values.host` > `UNION_CONTROL_PLANE_HOST`), migrate to `CONTROLPLANE_HOST`. No terraform env sets `.Values.host`.

Paired terraform (unionai/cloud): `union_extension` stops emitting the three retired globals; all four mike staging envs regenerated.

## Testing

`make helm-test` green. Snapshot diff is exactly the `:443` drop at every endpoint site (293) + derived configChecksums — nothing else. Deployed to all four mike staging envs (managed-CP aws/gcp/azure + selfhosted-intracluster/split gcp + aws-CP) via `internal-selfmanaged-staging-sync-all` to confirm the task-pod SDK resolves 443 without the explicit port.

## Migration

Any env whose generated values still set the retired globals or reference `dataplane.cp.queueEndpoint` in task-pod `default-env-vars` must be regenerated before adopting (the helper is removed). See RELEASE.md.

## Stack

Stacked on #498 → #497. Part of the selfmanaged overlay/host cleanup.

- `main` <!-- branch-stack -->
  - \#498
    - **dataplane: consolidate control-plane host to a single CONTROLPLANE\_HOST** :point\_left:
