### PR TITLE
controlplane: default rootTenantURLPattern to global.UNION_HOST

### DIFF
--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -500,8 +500,10 @@ configMap:
   connection:
     environment: "staging"
     region: ""  # Cloud-specific: set in overlay (e.g. AWS_REGION)
-    # Use controlplane ingress controller for gRPC routing.
-    rootTenantURLPattern: 'dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}'
+    # Operator eager-key (CreateAPI) bootstrap dial. Default to the publicly
+    # resolvable control-plane host; override per-env (global.CONTROLPLANE_HOST /
+    # a values overlay) for intracluster svc-FQDN or internal-VPC routing.
+    rootTenantURLPattern: 'dns:///{{ .Values.global.UNION_HOST }}'
   otel:  # Ref: https://github.com/flyteorg/flyte/blob/master/flytestdlib/otelutils/config.go
     type: noop
   sharedService:
@@ -2194,7 +2196,7 @@ flyte:
       connection:
         environment: "staging"
         region: ""  # Cloud-specific: set in overlay
-        rootTenantURLPattern: 'dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}'
+        rootTenantURLPattern: 'dns:///{{ .Values.global.UNION_HOST }}'
       flyteadmin:
         metricsKeys:
           - phase

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -400,7 +400,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9474,7 +9474,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a47f70dd39aa636afb5d25ffe53ec0785c33272fcc33b02d5f2066d8e65eeeb"
+        configChecksum: "7abc3d6dc5a339ef65b6cce19618eca57bdc2240211b11b6fa776a80d040443"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -402,7 +402,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9476,7 +9476,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
+        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -402,7 +402,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9476,7 +9476,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
+        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -408,7 +408,7 @@ data:
     connection:
       environment: staging
       region: ''
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9508,7 +9508,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9ba12634f13b7d4907c344ff751168385ecd5909a6a12f6c36760971d14faf8"
+        configChecksum: "a0f42d8ab0c2cb777666895d1e6a15851b72d27c3e18ca11ae7262e673b9cb7"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -403,7 +403,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9481,7 +9481,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "75607c68c256979d7b2a8d9cd1a5c6bc240cc520cbec45bf36135ac37befef2"
+        configChecksum: "660ecd073e8ca278cff1ba7396f331698b5bec9b906b488774d4750164a7b48"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.image-builder-bootstrap.yaml
+++ b/tests/generated/controlplane.image-builder-bootstrap.yaml
@@ -400,7 +400,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9474,7 +9474,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
+        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -400,7 +400,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9474,7 +9474,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a47f70dd39aa636afb5d25ffe53ec0785c33272fcc33b02d5f2066d8e65eeeb"
+        configChecksum: "7abc3d6dc5a339ef65b6cce19618eca57bdc2240211b11b6fa776a80d040443"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -434,7 +434,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -9627,7 +9627,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "723ac272eda01c678d813fd3c3ea46bddf77aa3b48f1301e0ca9ea6c19b62dc"
+        configChecksum: "d99878cab3415457792d93f7896bf46c432e86caffb6751f80e1e6f3d3dc2a6"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin


### PR DESCRIPTION
## Overview

`connection.rootTenantURLPattern` is the host identity embeds in minted api-keys (e.g. `EAGER_API_KEY` / operator eager-key bootstrap). The chart defaulted it to the cluster-local ingress svc FQDN (`controlPlaneLibrary.ingressFqdn`), which only resolves **intracluster** — an operator in a separate DP cluster can't reach it.

Default it instead to the publicly-resolvable control-plane host `dns:///{{ .Values.global.UNION_HOST }}`, which works for both topologies. Envs that want optimized in-cluster / internal-VPC routing override it — the selfmanaged `union_extension` module derives the topology-aware host (svc FQDN intracluster, routable host separate-cluster) and sets it in the generated values (unionai/cloud #17367).

Regenerated snapshots (`make generate-expected`).

## Test Plan

- `make generate-expected` + `make test` — snapshots updated to render `dns:///{UNION_HOST}` instead of the svc FQDN.

## Rollback

`git revert`.