### PR TITLE
controlplane: rootTenantURLPattern default to UNION_HOST + endpoint guard

### DIFF
--- a/charts/controlplane/RELEASE.md
+++ b/charts/controlplane/RELEASE.md
@@ -33,6 +33,10 @@ the only execution path.
   stay on chart `2026.7.2` until clients are on SDK >= 2.0.4.
 - Overlays setting `actionsLeasor.enabled` or `services.queue.*` should drop
   those keys; both are ignored (harmless, but misleading).
+### Configuration changes (helm-charts)
+
+- **`connection.rootTenantURLPattern` default now the publicly-resolvable control-plane host.** It defaulted to the cluster-local ingress svc FQDN (`controlPlaneLibrary.ingressFqdn`), which only resolves intracluster — but this endpoint is minted into eager api-keys and dialed by **dataplane task pods** (and CP↔CP services), so a separate-cluster data plane couldn't reach it. It now defaults to `dns:///{{ .Values.global.UNION_HOST }}`. The union shared-services config and flyteadmin's config are converged on the same `global.UNION_HOST`. **Action:** none for cloud-managed envs (the generated overlay sets the topology-aware host); a standalone chart install that relied on the svc-FQDN default and runs an intracluster data plane may set `configMap.connection.rootTenantURLPattern` (and `flyte…connection.rootTenantURLPattern`) back to `dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}` via overlay.
+- **Render-time guard on `connection.rootTenantURLPattern`.** The chart now fails render if the value is not a `dns:///` gRPC target or carries a trailing `:port` (control-plane services strip the `dns:///` prefix and dial the bare host, and a port corrupts the eager-api-key codec's decoded fields). No effect on valid configs.
 
 ## 2026.7.2
 

--- a/charts/controlplane/RELEASE.md
+++ b/charts/controlplane/RELEASE.md
@@ -33,10 +33,12 @@ the only execution path.
   stay on chart `2026.7.2` until clients are on SDK >= 2.0.4.
 - Overlays setting `actionsLeasor.enabled` or `services.queue.*` should drop
   those keys; both are ignored (harmless, but misleading).
+
 ### Configuration changes (helm-charts)
 
 - **`connection.rootTenantURLPattern` default now the publicly-resolvable control-plane host.** It defaulted to the cluster-local ingress svc FQDN (`controlPlaneLibrary.ingressFqdn`), which only resolves intracluster — but this endpoint is minted into eager api-keys and dialed by **dataplane task pods** (and CP↔CP services), so a separate-cluster data plane couldn't reach it. It now defaults to `dns:///{{ .Values.global.UNION_HOST }}`. The union shared-services config and flyteadmin's config are converged on the same `global.UNION_HOST`. **Action:** none for cloud-managed envs (the generated overlay sets the topology-aware host); a standalone chart install that relied on the svc-FQDN default and runs an intracluster data plane may set `configMap.connection.rootTenantURLPattern` (and `flyte…connection.rootTenantURLPattern`) back to `dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}` via overlay.
 - **Render-time guard on `connection.rootTenantURLPattern`.** The chart now fails render if the value is not a `dns:///` gRPC target or carries a trailing `:port` (control-plane services strip the `dns:///` prefix and dial the bare host, and a port corrupts the eager-api-key codec's decoded fields). No effect on valid configs.
+- **Render-time consistency guard on `rootTenantURLPattern`.** The endpoint lives in two independent values paths — the top-level `configMap.connection` (control-plane services + the EAGER_API_KEY the operator mints and data-plane task pods dial) and `flyte.configmap.adminServer.connection` (flyteadmin-private's admin clientset cache, which the flyte subchart owns and can't share via a helm `include`). The chart now fails render if they resolve to different values, so an overlay that overrides one but not the other can't silently leave flyteadmin dialing a different control-plane host than every other service. Both still default to `dns:///{{ .Values.global.UNION_HOST }}`; override them together.
 
 ## 2026.7.2
 

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -43,14 +43,41 @@ Notes:
 {{- end }}
 
 {{/*
-Cluster-local FQDN for CP↔CP gRPC routing (rootTenantURLPattern).
-Switches between envoy and nginx based on the ingress provider.
+Cluster-local FQDN default for connection.rootTenantURLPattern. Originally just
+CP↔CP gRPC routing; scope has since expanded — EAGER_API_KEY bootstrapping mints
+this endpoint into the api-key, and dataplane task pods dial it. Switches between
+envoy and nginx based on the ingress provider.
 */}}
 {{- define "controlPlaneLibrary.ingressFqdn" -}}
 {{- if eq (default "nginx" .Values.global.INGRESS_PROVIDER) "envoy" -}}
 {{ .Values.global.ENVOY_INGRESS_FQDN | default "envoy-controlplane.envoy-gateway.svc.cluster.local" }}
 {{- else -}}
 controlplane-nginx-controller.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate a connection endpoint (rootTenantURLPattern). It is minted into eager
+api-keys and dialed by both control-plane services and dataplane task pods.
+Control-plane services strip the dns:/// prefix and dial the bare host, and the
+key codec shifts its decoded fields when the endpoint carries a trailing :port —
+so require a dns:/// gRPC target with no port. The {{`{{ organization }}`}}
+placeholder is substituted by the services at runtime (not a helm template), so
+neutralize it before rendering the rest of the value.
+Args: dict "ep" <raw endpoint, may be a tpl string> "ctx" <root context>
+"name" <field name for the error message>.
+*/}}
+{{- define "controlPlaneLibrary.validateGrpcEndpoint" -}}
+{{- $raw := .ep | toString | replace "{{ organization }}" "organization" -}}
+{{- $resolved := trim (tpl $raw .ctx) -}}
+{{- if $resolved -}}
+{{- if not (hasPrefix "dns:///" $resolved) -}}
+{{- fail (printf "controlplane: %s = %q must be a dns:/// gRPC target — control-plane services strip the dns:/// prefix and dial the bare host" .name $resolved) -}}
+{{- end -}}
+{{- $host := trimPrefix "dns:///" $resolved -}}
+{{- if regexMatch ":[0-9]+$" $host -}}
+{{- fail (printf "controlplane: %s = %q must not carry a trailing :port (a port shifts the eager-api-key codec's decoded fields)" .name $resolved) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -456,6 +483,14 @@ IfNotPresent
   {{- $_ := set $app "apiKeyOverrides" $overrides }}
   {{- $_ := set $identity "app" $app }}
   {{- $_ := set $merged "identity" $identity }}
+{{- end }}
+
+{{- /* Guard the eager-api-key / CP↔CP endpoint against misconfiguration: a
+       supported scheme and no trailing :port. Runs for every service's merged
+       connection. */}}
+{{- $mergedRootPattern := index (index $merged "connection" | default dict) "rootTenantURLPattern" }}
+{{- if $mergedRootPattern }}
+  {{- include "controlPlaneLibrary.validateGrpcEndpoint" (dict "ep" $mergedRootPattern "ctx" . "name" (printf "services.%s connection.rootTenantURLPattern" (.key | default "*"))) }}
 {{- end }}
 
 {{- /* dataproxy: default union.connection.host to the in-cluster control-plane

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -81,6 +81,35 @@ Args: dict "ep" <raw endpoint, may be a tpl string> "ctx" <root context>
 {{- end -}}
 {{- end -}}
 
+{{/*
+Enforce that rootTenantURLPattern is identical across every connection in the
+chart. The endpoint is minted into the operator EAGER_API_KEY and dialed by
+dataplane task pods: the control-plane services read the top-level
+configMap.connection, while flyteadmin-private reads
+flyte.configmap.adminServer.connection — a separate values path the flyte
+subchart owns, which cannot share the value through a helm `include`. If the two
+diverge, flyteadmin dials a different control-plane host than every other service
+and the minted key points somewhere the task pods can't reach. Resolve each (tpl)
+and fail on any mismatch. Both default to dns:///<global.UNION_HOST>; override
+them together (e.g. for intracluster svc-FQDN or internal-VPC routing).
+Args: root context (.)
+*/}}
+{{- define "controlPlaneLibrary.validateRootTenantConsistency" -}}
+{{- $tl := index (index (.Values.configMap | default dict) "connection" | default dict) "rootTenantURLPattern" -}}
+{{- $fa := index (index (index (index (.Values.flyte | default dict) "configmap" | default dict) "adminServer" | default dict) "connection" | default dict) "rootTenantURLPattern" -}}
+{{- $sources := dict "configMap.connection.rootTenantURLPattern" $tl "flyte.configmap.adminServer.connection.rootTenantURLPattern" $fa -}}
+{{- $byValue := dict -}}
+{{- range $field, $raw := $sources -}}
+{{- if $raw -}}
+{{- $resolved := trim (tpl ($raw | toString | replace "{{ organization }}" "organization") $) -}}
+{{- $_ := set $byValue $resolved (append (index $byValue $resolved | default list) $field) -}}
+{{- end -}}
+{{- end -}}
+{{- if gt (len (keys $byValue)) 1 -}}
+{{- fail (printf "controlplane: rootTenantURLPattern must be identical across all connections (it is minted into the operator EAGER_API_KEY and dialed by dataplane task pods), but got divergent values %v — set configMap.connection and flyte.configmap.adminServer.connection consistently (both default to dns:///<global.UNION_HOST>)" $byValue) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "unionai.imagePullSecrets" -}}
 {{- if and (hasKey .config "imagePullSecrets") }}
 {{ toYaml .config.imagePullSecrets }}

--- a/charts/controlplane/templates/validate-connection-consistency.yaml
+++ b/charts/controlplane/templates/validate-connection-consistency.yaml
@@ -1,0 +1,4 @@
+{{- /* Render-time guard only — emits no manifest. Fails the render if the
+       control-plane connection.rootTenantURLPattern (services + EAGER_API_KEY)
+       and the flyteadmin adminServer.connection.rootTenantURLPattern diverge. */ -}}
+{{- include "controlPlaneLibrary.validateRootTenantConsistency" . -}}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -500,8 +500,10 @@ configMap:
   connection:
     environment: "staging"
     region: ""  # Cloud-specific: set in overlay (e.g. AWS_REGION)
-    # Use controlplane ingress controller for gRPC routing.
-    rootTenantURLPattern: 'dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}'
+    # Operator eager-key (CreateAPI) bootstrap + CP↔CP dial. Converged with
+    # flyteadmin's connection on global.UNION_HOST; override per-env for
+    # intracluster svc-FQDN or internal-VPC routing.
+    rootTenantURLPattern: 'dns:///{{ .Values.global.UNION_HOST }}'
   otel:  # Ref: https://github.com/flyteorg/flyte/blob/master/flytestdlib/otelutils/config.go
     type: noop
   sharedService:
@@ -2149,7 +2151,7 @@ flyte:
       connection:
         environment: "staging"
         region: ""  # Cloud-specific: set in overlay
-        rootTenantURLPattern: 'dns:///{{ include "controlPlaneLibrary.ingressFqdn" . }}'
+        rootTenantURLPattern: 'dns:///{{ .Values.global.UNION_HOST }}'
       flyteadmin:
         metricsKeys:
           - phase

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -388,7 +388,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8827,7 +8827,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a47f70dd39aa636afb5d25ffe53ec0785c33272fcc33b02d5f2066d8e65eeeb"
+        configChecksum: "7abc3d6dc5a339ef65b6cce19618eca57bdc2240211b11b6fa776a80d040443"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -388,7 +388,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8827,7 +8827,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7abc3d6dc5a339ef65b6cce19618eca57bdc2240211b11b6fa776a80d040443"
+        configChecksum: "16e854f21f34e1c31662c7eef8a56b315e7c5b09ff6ee580810cc185d9631ee"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -390,7 +390,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8829,7 +8829,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
+        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -390,7 +390,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8829,7 +8829,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
+        configChecksum: "712b2efbb5c7c45fd42f5e1b561347d64a9d1c732767ef5eba78c2830fbadf6"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -390,7 +390,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8829,7 +8829,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
+        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -390,7 +390,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8829,7 +8829,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
+        configChecksum: "712b2efbb5c7c45fd42f5e1b561347d64a9d1c732767ef5eba78c2830fbadf6"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -396,7 +396,7 @@ data:
     connection:
       environment: staging
       region: ''
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8861,7 +8861,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a0f42d8ab0c2cb777666895d1e6a15851b72d27c3e18ca11ae7262e673b9cb7"
+        configChecksum: "eec616161743ae4370e86ee9ad655b2da365a4c41823a211493b0150c0794e5"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -396,7 +396,7 @@ data:
     connection:
       environment: staging
       region: ''
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8861,7 +8861,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "9ba12634f13b7d4907c344ff751168385ecd5909a6a12f6c36760971d14faf8"
+        configChecksum: "a0f42d8ab0c2cb777666895d1e6a15851b72d27c3e18ca11ae7262e673b9cb7"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -391,7 +391,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8834,7 +8834,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "75607c68c256979d7b2a8d9cd1a5c6bc240cc520cbec45bf36135ac37befef2"
+        configChecksum: "660ecd073e8ca278cff1ba7396f331698b5bec9b906b488774d4750164a7b48"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -391,7 +391,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8834,7 +8834,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "660ecd073e8ca278cff1ba7396f331698b5bec9b906b488774d4750164a7b48"
+        configChecksum: "ea171f9c54032e868e92c800e9ea07f8bf69aca4c9c7d01e67811818089f2b5"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.image-builder-bootstrap.yaml
+++ b/tests/generated/controlplane.image-builder-bootstrap.yaml
@@ -388,7 +388,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8827,7 +8827,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
+        configChecksum: "712b2efbb5c7c45fd42f5e1b561347d64a9d1c732767ef5eba78c2830fbadf6"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.image-builder-bootstrap.yaml
+++ b/tests/generated/controlplane.image-builder-bootstrap.yaml
@@ -388,7 +388,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8827,7 +8827,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "4a4b481de48c07e25e4649b5c455ad7ac24423ed8c5535da123f6120b3ac928"
+        configChecksum: "32b469acf7c6b536e21341cd7e54e0e5acabe929d772bb135aa5ab1b8aea2b2"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -388,7 +388,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8827,7 +8827,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a47f70dd39aa636afb5d25ffe53ec0785c33272fcc33b02d5f2066d8e65eeeb"
+        configChecksum: "7abc3d6dc5a339ef65b6cce19618eca57bdc2240211b11b6fa776a80d040443"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -388,7 +388,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8827,7 +8827,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "7abc3d6dc5a339ef65b6cce19618eca57bdc2240211b11b6fa776a80d040443"
+        configChecksum: "16e854f21f34e1c31662c7eef8a56b315e7c5b09ff6ee580810cc185d9631ee"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -422,7 +422,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///controlplane-nginx-controller.union.svc.cluster.local
+      rootTenantURLPattern: dns:///test.example.com
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8980,7 +8980,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "723ac272eda01c678d813fd3c3ea46bddf77aa3b48f1301e0ca9ea6c19b62dc"
+        configChecksum: "d99878cab3415457792d93f7896bf46c432e86caffb6751f80e1e6f3d3dc2a6"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -422,7 +422,7 @@ data:
     connection:
       environment: staging
       region: ""
-      rootTenantURLPattern: dns:///test.example.com
+      rootTenantURLPattern: dns:///fake-host.domain
     flyteadmin:
       eventVersion: 2
       metadataStoragePrefix:
@@ -8980,7 +8980,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d99878cab3415457792d93f7896bf46c432e86caffb6751f80e1e6f3d3dc2a6"
+        configChecksum: "6d0f46846b07339e45a5d7fc0ed11d25534feb709ec9160579300a40a2a1ab7"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin

--- a/tests/values/controlplane.actions-leasor.yaml
+++ b/tests/values/controlplane.actions-leasor.yaml
@@ -49,5 +49,7 @@ flyte:
 
 # actionsLeasor toggle on — opt this deployment's UNION_ORG into v2-actions
 # CreateRun routing and hard-reject sub-2.0.4 SDKs.
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
 actionsLeasor:
   enabled: true

--- a/tests/values/controlplane.aws.billing-enable.yaml
+++ b/tests/values/controlplane.aws.billing-enable.yaml
@@ -39,7 +39,12 @@ flyte:
   flyteadmin:
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/adminflyterole
+        eks.amazonaws.com/role-arn: 
+          arn:aws:iam::<account-id>:role/adminflyterole
+  configmap:
+    adminServer:
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
 services:
   usage:
     configMap:

--- a/tests/values/controlplane.aws.yaml
+++ b/tests/values/controlplane.aws.yaml
@@ -72,6 +72,10 @@ flyte:
         eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/adminflyterole
 
   configmap:
+    # rootTenantURLPattern must match configMap.connection above (consistency guard).
+    adminServer:
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
     admin:
       admin:
         endpoint: dns:///fake-host.domain

--- a/tests/values/controlplane.custom-oidc.yaml
+++ b/tests/values/controlplane.custom-oidc.yaml
@@ -13,8 +13,8 @@ global:
   CLI_CLIENT_ID: "55555555-6666-7777-8888-999999999999"
   OIDC_METADATA_URL: ".well-known/openid-configuration"
   OIDC_ALLOWED_AUDIENCE:
-  - "api://my-app"
-  - "00000000-1111-2222-3333-444444444444"
+    - "api://my-app"
+    - "00000000-1111-2222-3333-444444444444"
   OIDC_APP_SCOPE: "api://my-app/all"
   OIDC_APP_AUDIENCE: "api://my-app"
 
@@ -82,7 +82,7 @@ flyte:
           # This is set in values overlay, not via a global.
           identityTypeClaimsForApps:
             idtyp:
-            - app
+              - app
         userAuth:
           openId:
             clientSecretFile: /etc/secrets/oauth/client_secret
@@ -90,6 +90,8 @@ flyte:
 # Eager-key secret-by-reference override on the identity service: CreateKey reads
 # seeded OAuth client creds from a mounted Secret instead of registering an IdP app.
 # Exercises a custom client-secret data key to cover the key-name default-override path.
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
 services:
   identity:
     apiKeyOverrides:

--- a/tests/values/controlplane.external-authz.yaml
+++ b/tests/values/controlplane.external-authz.yaml
@@ -41,10 +41,12 @@ flyte:
       auth:
         appAuth:
           subjectClaimNames:
-          - sub
-          - client_id
+            - sub
+            - client_id
 
 # External authorization — customer-provided gRPC server
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
 services:
   authorizer:
     configMap:

--- a/tests/values/controlplane.image-builder-bootstrap.yaml
+++ b/tests/values/controlplane.image-builder-bootstrap.yaml
@@ -38,6 +38,9 @@ flyte:
 
 # Opt in to the build-image bootstrap Job (disabled by default) so the
 # Job + ConfigMap templates stay covered by snapshot tests.
+    adminServer:
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
 imageBuilder:
   bootstrap:
     enabled: true

--- a/tests/values/controlplane.no-auth.yaml
+++ b/tests/values/controlplane.no-auth.yaml
@@ -46,3 +46,5 @@ flyte:
       server:
         security:
           useAuth: false
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain

--- a/tests/values/controlplane.userclouds.yaml
+++ b/tests/values/controlplane.userclouds.yaml
@@ -59,6 +59,10 @@ flyte:
         eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/adminflyterole
 
   configmap:
+    # rootTenantURLPattern must match configMap.connection above (consistency guard).
+    adminServer:
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
     admin:
       admin:
         endpoint: dns:///fake-host.domain


### PR DESCRIPTION
## Overview

`connection.rootTenantURLPattern` is minted into eager api-keys and dialed by **control-plane services** (`organizations`/`artifacts`/`cluster`/`identity`, which strip the `dns:///` prefix and dial the bare host) **and dataplane task pods**. Two changes:

1. **Default → publicly-resolvable host.** It defaulted to the cluster-local ingress svc FQDN (`controlPlaneLibrary.ingressFqdn`), which only resolves intracluster, so a separate-cluster data plane couldn't reach the minted endpoint. It now defaults to `dns:///{{ .Values.global.UNION_HOST }}`. The union shared-services config and flyteadmin's config are converged on the same `global.UNION_HOST` (no `include` — a global, so it renders in the flyte subchart). Cloud-managed envs override this with the topology-aware host in the generated overlay.

2. **Render-time guard** (`controlPlaneLibrary.validateGrpcEndpoint`). Fails render if the resolved value is not a `dns:///` gRPC target, or carries a trailing `:port` (a port corrupts the key codec's decoded fields). Matches how the services actually parse it — `dns:///` only (the SDK's `sanitize_endpoint` normalizes `http(s)://`, but the CP-service `StripDnsPrefix` does not). The runtime `{{ organization }}` placeholder is neutralized before rendering. Fail-only — no output change beyond the default flip.

## Test Plan

- `make generate-expected` — passes; snapshots reflect the `UNION_HOST` default.
- `helm template … --set configMap.connection.rootTenantURLPattern=dns:///host:443` → fails (trailing :port).
- `… =https://host` → fails (must be dns:///).
- `… =dns:///{{ organization }}.example.com` → renders (org placeholder neutralized).

## Rollback

`git revert`.