### PR TITLE
dataplane: document overriding embedded-secret init container image

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -465,6 +465,13 @@ config:
           namespace: '{{ include "proxy.secretsNamespace" . }}'
         imagePullSecrets:
           enabled: true
+        # -- Init container used to mount embedded secrets as files into task pods.
+        # -- Uncomment and override `image` to repoint the default upstream busybox
+        # -- image (public.ecr.aws/docker/library/busybox:latest) at a private or
+        # -- mirrored registry — required for air-gapped clusters that cannot reach
+        # -- public.ecr.aws. Maps to webhook.embeddedSecretManagerConfig.fileMountInitContainer.
+        # fileMountInitContainer:
+        #   image: <your-registry>/busybox:latest
   # -- Domains configuration for Union projects. This enables the specified number of domains across all projects in Union.
   domain:
     domains:


### PR DESCRIPTION
Adds a commented example under `config.core.webhook.embeddedSecretManagerConfig` in the dataplane `values.yaml` showing how to override the embedded secret manager's `fileMountInitContainer.image`.

The upstream default is `public.ecr.aws/docker/library/busybox:latest`, which air-gapped clusters cannot reach. The override knob (`webhook.embeddedSecretManagerConfig.fileMountInitContainer.image`) was previously undiscoverable from `values.yaml` — this documents it in place next to the existing embedded-secret settings.

Comment-only change; rendered output and snapshot tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)