### PR TITLE
ci: trigger cloud canary deploys on chart merges to main

### DIFF
--- a/.github/scripts/trigger-buildkite-build.sh
+++ b/.github/scripts/trigger-buildkite-build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create a Buildkite build on a cloud pipeline via the REST API.
+#
+# Usage: trigger-buildkite-build.sh <pipeline-slug> [KEY=VALUE ...]
+#
+# Each KEY=VALUE becomes a build env var. TRIGGER_PROVENANCE is always added,
+# stamped as "helm-charts@<sha> by <actor>" so the triggered cloud pipeline
+# (and its PR-back / annotation) can attribute the run to this merge.
+#
+# The build runs cloud's main (commit HEAD, branch main): the target pipelines'
+# repository is unionai/cloud, so they must build cloud, not helm-charts.
+#
+# Requires: BUILDKITE_API_TOKEN in the environment (Buildkite API token with the
+# write_builds scope), plus GITHUB_SHA and GITHUB_ACTOR (set by Actions).
+set -euo pipefail
+
+pipeline="${1:?pipeline slug required}"
+shift || true
+
+org="unionai"
+provenance="helm-charts@${GITHUB_SHA} by ${GITHUB_ACTOR}"
+
+# Build the env object from the KEY=VALUE args plus provenance.
+env_json='{}'
+for kv in "$@"; do
+  key="${kv%%=*}"
+  val="${kv#*=}"
+  env_json="$(jq -c --arg k "$key" --arg v "$val" '. + {($k): $v}' <<<"$env_json")"
+done
+env_json="$(jq -c --arg v "$provenance" '. + {TRIGGER_PROVENANCE: $v}' <<<"$env_json")"
+
+body="$(jq -n \
+  --arg commit "HEAD" \
+  --arg branch "main" \
+  --arg message "$provenance: trigger ${pipeline}" \
+  --argjson env "$env_json" \
+  '{commit: $commit, branch: $branch, message: $message, env: $env}')"
+
+echo "Triggering ${org}/${pipeline} with env: ${env_json}"
+curl --fail --silent --show-error \
+  -X POST \
+  -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" \
+  "https://api.buildkite.com/v2/organizations/${org}/pipelines/${pipeline}/builds" \
+  -d "$body" \
+  | jq -r '"Created build: \(.web_url)"'

--- a/.github/workflows/trigger-union-internal-checks.yaml
+++ b/.github/workflows/trigger-union-internal-checks.yaml
@@ -61,11 +61,11 @@ jobs:
           echo "charts=$charts" >> "$GITHUB_OUTPUT"
           echo "Routing: overlays=$overlays charts=$charts"
 
-      - name: Trigger tf-fanout-canary-deploy (overlay change)
+      - name: Trigger selfmanaged-tf-canary-fanout (overlay change)
         if: steps.route.outputs.overlays == 'true'
         env:
           BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
-        run: .github/scripts/trigger-buildkite-build.sh tf-fanout-canary-deploy SKIP_INPUT=TRUE
+        run: .github/scripts/trigger-buildkite-build.sh selfmanaged-tf-canary-fanout SKIP_INPUT=TRUE
 
       - name: Trigger internal-selfmanaged-canary-sync-all (chart change)
         if: steps.route.outputs.charts == 'true'

--- a/.github/workflows/trigger-union-internal-checks.yaml
+++ b/.github/workflows/trigger-union-internal-checks.yaml
@@ -1,0 +1,74 @@
+name: Trigger Union Internal Checks
+
+# On merge to main, trigger the unionai/cloud Buildkite pipelines that keep the
+# canary selfmanaged fleet in sync with this repo (auth: BUILDKITE_API_TOKEN secret).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/*/values.yaml'
+      - 'charts/*/values.*.yaml'      # any per-cloud overlay (values.<cloud>.yaml)
+      - '!charts/*/values.k3d.yaml'   # …except the local-only k3d dev overlay
+      - 'charts/*/templates/**'
+      - 'charts/*/Chart.yaml'
+
+permissions:
+  contents: read  # only to checkout + diff; the Buildkite call uses its own token, not GITHUB_TOKEN
+
+jobs:
+  trigger:
+    # Never run on forks (they get no secret anyway; this is belt-and-suspenders).
+    if: github.repository == 'unionai/helm-charts'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Route changed files to pipelines
+        id: route
+        run: |
+          set -euo pipefail
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            before="$(git rev-parse "${{ github.sha }}^")"
+          fi
+          changed="$(git diff --name-only "$before" "${{ github.sha }}")"
+          echo "Changed files:"; echo "$changed"
+
+          overlays=false
+          charts=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            # Order matters: base values.yaml / Chart.yaml / templates and the
+            # k3d ignore are matched before the generic values.*.yaml overlay
+            # catch-all (case takes the first match).
+            case "$f" in
+              charts/*/values.yaml|charts/*/Chart.yaml)
+                charts=true ;;
+              charts/*/templates/*)
+                charts=true ;;
+              charts/*/values.k3d.yaml)
+                : ;;  # local-only dev overlay, no k3d env in the fleet — ignore
+              charts/*/values.*.yaml)
+                overlays=true ;;  # any per-cloud overlay: values.<cloud>.yaml
+            esac
+          done <<< "$changed"
+
+          echo "overlays=$overlays" >> "$GITHUB_OUTPUT"
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "Routing: overlays=$overlays charts=$charts"
+
+      - name: Trigger tf-fanout-canary-deploy (overlay change)
+        if: steps.route.outputs.overlays == 'true'
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
+        run: .github/scripts/trigger-buildkite-build.sh tf-fanout-canary-deploy SKIP_INPUT=TRUE
+
+      - name: Trigger internal-selfmanaged-canary-sync-all (chart change)
+        if: steps.route.outputs.charts == 'true'
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
+        run: .github/scripts/trigger-buildkite-build.sh internal-selfmanaged-canary-sync-all


### PR DESCRIPTION
## Overview

On merge to `main`, poke the Union cloud Buildkite pipelines that keep the canary self-managed fleet in sync with this repo, routed by which chart files changed. Implemented as a `push`-to-`main` GitHub Action (`.github/workflows/trigger-union-internal-checks.yaml`) that calls the Buildkite REST API via a small helper (`.github/scripts/trigger-buildkite-build.sh`).

## Routing

| Changed | Pipeline triggered |
| --- | --- |
| `charts/*/values.aws.yaml`, `values.gcp.yaml`, `values.azure.yaml` | `tf-fanout-canary-deploy` |
| `charts/*/values.yaml`, `charts/*/templates/**`, `charts/*/Chart.yaml` | `internal-selfmanaged-canary-sync-all` |

A merge touching both classes fires both. Scope is broad by design (all canary self-managed): `DIR_LIST` / `ORGS_LIST` are left unset, which both pipelines treat as "the whole canary tier". `SKIP_INPUT=TRUE` is sent to the fan-out so it auto-applies. Each build carries a `helm-charts@<sha> by <actor>` provenance stamp.

## Auth

The Action authenticates with a `BUILDKITE_API_TOKEN` repo secret — a Buildkite API token scoped to the `unionai` organization with the `write_builds` REST scope (nothing else). It must be provisioned once in repo settings:

```
gh secret set BUILDKITE_API_TOKEN --repo unionai/helm-charts --body '<token>'
```

## Test Plan

- `yaml.safe_load` on the workflow — parses.
- `bash -n` on the helper script — clean.
- Router logic exercised against a sample changed-file list: overlays route to the fan-out, base `values.yaml` / nested `templates/**` / `Chart.yaml` route to sync-all, and non-chart files (e.g. `values.k3d.yaml`, `README.md`) are correctly ignored.
- End-to-end trigger fires only once the `BUILDKITE_API_TOKEN` secret is provisioned and the target pipelines are live.