### PR TITLE
dataplane: add artifact-trigger to enabled-plugins

### DIFF
--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -443,6 +443,7 @@ config:
           - echo
           - fast-task
           - connector-service
+          - artifact-trigger
         default-for-task-types:
           actor: fast-task
           container: container


### PR DESCRIPTION
Adds the `artifact-trigger` leaseworker core plugin (unionai/cloud#17441) to the dataplane chart's `enabled-plugins` list, which renders into both the leaseworker and propeller configmaps.

Core plugins currently load unconditionally in the leaseworker (`enabled-plugins` only filters K8s plugins), so this is not required for the plugin to run — but it keeps the config an accurate inventory of what executes on the dataplane and guards against any future filtering of core plugins. Propeller ignores plugin names it has no registration for, so the extra entry is inert on the v1 side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)