### PR TITLE
feat(charts): support custom AWS identity annotation prefixes

### DIFF
--- a/charts/controlplane/README.md
+++ b/charts/controlplane/README.md
@@ -151,6 +151,40 @@ All pods should be `Running` and `flyteadmin` should be serving requests.
 
 ---
 
+## AWS Pod Identity Webhook Annotation Prefix
+
+The AWS pod identity webhook mutates pods by reading a service account annotation named `<annotation-prefix>/role-arn`. EKS uses `eks.amazonaws.com` by default, so the AWS values file defaults to `eks.amazonaws.com/role-arn`.
+
+If your cluster operator installed the webhook with a custom `--annotation-prefix`, override each control plane service account annotation key that uses AWS IAM:
+
+```yaml
+flyte:
+  flyteadmin:
+    serviceAccount:
+      annotations:
+        customer.example.com/role-arn: "arn:aws:iam::123456789012:role/union-flyteadmin"
+  datacatalog:
+    serviceAccount:
+      annotations:
+        customer.example.com/role-arn: "arn:aws:iam::123456789012:role/union-flyteadmin"
+  cacheservice:
+    serviceAccount:
+      annotations:
+        customer.example.com/role-arn: "arn:aws:iam::123456789012:role/union-flyteadmin"
+
+services:
+  artifacts:
+    serviceAccount:
+      annotations:
+        customer.example.com/role-arn: "arn:aws:iam::123456789012:role/union-artifacts"
+```
+
+When this is layered on top of an AWS preset values file, Helm may still render the default `eks.amazonaws.com/role-arn` annotation. That extra annotation is ignored by a webhook configured with a different prefix; the custom `<prefix>/role-arn` annotation is the one that controls mutation.
+
+The IAM role trust policies must still trust the Kubernetes service account subjects used by the rendered service accounts.
+
+---
+
 ## Installation
 
 ### Database Architecture
@@ -463,9 +497,7 @@ kubectl delete namespace union-cp
 
 For deploying Union control plane in the **same Kubernetes cluster** as your Union dataplane, see the [Self-hosted deployment guide](https://docs.union.ai/selfmanaged/deployment/selfhosted-deployment/) on the Union documentation site.
 
-Reference guides are also available in this repository:
-- [AWS](SELFHOSTED_INTRA_CLUSTER_AWS.md)
-- [GCP](SELFHOSTED_INTRA_CLUSTER_GCP.md)
+For intra-cluster topologies, layer `examples/values.{cloud}.intracluster.yaml` on top of the canonical `values.{cloud}.yaml` overlay. See [`MIGRATION.md`](../MIGRATION.md) for details about the cloud overlay consolidation.
 
 ---
 

--- a/charts/controlplane/templates/_helpers.tpl
+++ b/charts/controlplane/templates/_helpers.tpl
@@ -198,9 +198,9 @@ false
 
 {{- define "unionai.serviceAccount.annotations" -}}
 {{- if and (hasKey .config "serviceAccount") (hasKey .config.serviceAccount "annotations") }}
-{{- toYaml .config.serviceAccount.annotations }}
+{{- tpl (toYaml .config.serviceAccount.annotations) . }}
 {{- else if and (hasKey .Values "serviceAccount") (hasKey .Values.serviceAccount "annotations") }}
-{{- toYaml .Values.serviceAccount.annotations }}
+{{- tpl (toYaml .Values.serviceAccount.annotations) . }}
 {{- else }}
 {}
 {{- end }}

--- a/charts/controlplane/values.aws.yaml
+++ b/charts/controlplane/values.aws.yaml
@@ -45,24 +45,26 @@ flyte:
       # the Okta/Entra fill-in guidance). Set it there or at the env layer.
 
   # --- AWS IRSA Annotations ---
+  # Override global.AWS_POD_IDENTITY_ANNOTATION_PREFIX if your AWS pod identity
+  # webhook uses a custom --annotation-prefix.
   flyteadmin:
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: "{{ .Values.global.FLYTEADMIN_IAM_ROLE_ARN }}"
+        "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ .Values.global.FLYTEADMIN_IAM_ROLE_ARN }}"
   datacatalog:
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: "{{ .Values.global.FLYTEADMIN_IAM_ROLE_ARN }}"
+        "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ .Values.global.FLYTEADMIN_IAM_ROLE_ARN }}"
   cacheservice:
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: "{{ .Values.global.FLYTEADMIN_IAM_ROLE_ARN }}"
+        "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ .Values.global.FLYTEADMIN_IAM_ROLE_ARN }}"
 
 services:
   artifacts:
     serviceAccount:
       annotations:
-        eks.amazonaws.com/role-arn: "{{ .Values.global.ARTIFACT_IAM_ROLE_ARN }}"
+        "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ .Values.global.ARTIFACT_IAM_ROLE_ARN }}"
 
 scylla:
   storageClass:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -54,6 +54,9 @@ global:
   # --- Ingress ---
   INGRESS_PROVIDER: nginx   # nginx | envoy | both
 
+  # --- AWS IAM ---
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: eks.amazonaws.com
+
   # --- Service-to-Service OAuth2 ---
   # Full IdP config lives in flyte.configmap.adminServer.auth below; these
   # three globals feed into that block plus a few service ConfigMaps.

--- a/charts/dataplane/README.md
+++ b/charts/dataplane/README.md
@@ -135,6 +135,23 @@ gateway:
 
 ---
 
+## AWS Pod Identity Webhook Annotation Prefix
+
+The AWS pod identity webhook mutates pods by reading a service account annotation named `<annotation-prefix>/role-arn`. EKS uses `eks.amazonaws.com` by default, so the AWS values files default to `eks.amazonaws.com/role-arn`.
+
+If your cluster operator installed the webhook with a custom `--annotation-prefix`, set the shared prefix value:
+
+```yaml
+global:
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: customer.example.com
+```
+
+The AWS values files derive both Union system service account annotations and workflow service account annotations from this prefix.
+
+The IAM role trust policies must still trust the Kubernetes service account subjects used by the rendered service accounts.
+
+---
+
 ## Logging (FluentBit)
 
 The data plane deploys [FluentBit](https://fluentbit.io/) as a DaemonSet to collect container logs from every node and write them to the `persisted-logs/` path in the configured object store. FluentBit runs under the `fluentbit-system` Kubernetes service account, which must have write access to the storage bucket.

--- a/charts/dataplane/examples/values.aws.eks-automode.yaml
+++ b/charts/dataplane/examples/values.aws.eks-automode.yaml
@@ -70,6 +70,7 @@ global:
   #    Format: Full ARN
   #    Example: "arn:aws:iam::123456789012:role/union-backend-role"
   #    Permissions: S3 access, ECR (if private images)
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: eks.amazonaws.com
   BACKEND_IAM_ROLE_ARN: ""
 
   # 3. WORKER_IAM_ROLE_ARN - IAM role for workflow execution pods
@@ -122,11 +123,13 @@ storage:
 # These IAM roles must be created with appropriate trust policies and permissions.
 
 # IAM role for Union backend services (operator, propeller, etc.)
+# Override global.AWS_POD_IDENTITY_ANNOTATION_PREFIX if your AWS pod identity
+# webhook uses a custom --annotation-prefix.
 additionalServiceAccountAnnotations:
-  eks.amazonaws.com/role-arn: "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
+  "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
 
 # IAM role for workflow execution pods
-userRoleAnnotationKey: eks.amazonaws.com/role-arn
+userRoleAnnotationKey: "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn"
 userRoleAnnotationValue: "{{ tpl .Values.global.WORKER_IAM_ROLE_ARN . }}"
 
 # ----------------------------------------------------------------------------

--- a/charts/dataplane/values.aws.yaml
+++ b/charts/dataplane/values.aws.yaml
@@ -29,6 +29,7 @@ global:
 
   # --- AWS IAM (IRSA) ---
   # Format: arn:aws:iam::<account>:role/<role-name>
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: eks.amazonaws.com
   BACKEND_IAM_ROLE_ARN: ""      # IAM role for Union backend services
   WORKER_IAM_ROLE_ARN: ""       # IAM role for workflow execution pods
 
@@ -60,11 +61,13 @@ storage:
 # IAM Roles for Service Accounts; create with the appropriate trust policies.
 
 # IAM role for Union backend services (operator, propeller, etc.)
+# Override global.AWS_POD_IDENTITY_ANNOTATION_PREFIX if your AWS pod identity
+# webhook uses a custom --annotation-prefix.
 additionalServiceAccountAnnotations:
-  eks.amazonaws.com/role-arn: "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
+  "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
 
 # IAM role for workflow execution pods
-userRoleAnnotationKey: eks.amazonaws.com/role-arn
+userRoleAnnotationKey: "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn"
 userRoleAnnotationValue: "{{ tpl .Values.global.WORKER_IAM_ROLE_ARN . }}"
 
 # ----------------------------------------------------------------------------
@@ -255,4 +258,3 @@ imageBuilder:
   # authenticationType: aws
   buildkit:
     rootless: false
-

--- a/tests/generated/controlplane.aws.custom-identity-annotation.yaml
+++ b/tests/generated/controlplane.aws.custom-identity-annotation.yaml
@@ -45,9 +45,26 @@ metadata:
     helm.sh/chart: flyte-v1.16.1
     #app.kubernetes.io/managed-by: Helm
   annotations: 
-    'eks.amazonaws.com/role-arn': ''
+    'customer.example.com/role-arn': 'arn:aws:iam::<account-id>:role/adminflyterole'
 imagePullSecrets: 
   - name: union-registry-secret
+---
+# Source: controlplane/charts/flyte/templates/datacatalog/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datacatalog
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+  annotations: 
+    'customer.example.com/role-arn': 'arn:aws:iam::<account-id>:role/adminflyterole'
+imagePullSecrets: 
+  - name: union-registry-secret
+
 ---
 # Source: controlplane/charts/ingress-nginx/templates/controller-serviceaccount.yaml
 apiVersion: v1
@@ -114,7 +131,7 @@ metadata:
     helm.sh/chart: controlplane-2026.7.2
     app.kubernetes.io/managed-by: Helm
   annotations: 
-    'eks.amazonaws.com/role-arn': ''
+    'customer.example.com/role-arn': 'arn:aws:iam::<account-id>:role/adminflyterole'
 imagePullSecrets: 
   - name: union-registry-secret
 
@@ -133,7 +150,20 @@ metadata:
 
 ---
 # Source: controlplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2026.7.2
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.7.2"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    customer.example.com/role-arn: arn:aws:iam::<account-id>:role/artifactsrole
 ---
+# Source: controlplane/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -348,12 +378,9 @@ data:
         authServerType: External
         externalAuthServer:
           allowedAudience:
-          - https://test.example.com
+          - https://
           baseUrl: ""
           metadataUrl: .well-known/oauth-authorization-server
-        identityTypeClaimsForApps:
-          idtyp:
-          - app
         thirdPartyConfig:
           flyteClient:
             audience: ""
@@ -364,7 +391,7 @@ data:
       authorizedUris:
       - http://flyteadmin:80
       - http://flyteadmin.union.svc.cluster.local:80
-      - https://test.example.com
+      - https://
       grpcAuthorizationHeader: flyte-authorization
       httpAuthorizationHeader: flyte-authorization
       userAuth:
@@ -375,7 +402,6 @@ data:
         openId:
           baseUrl: ""
           clientId: ""
-          clientSecretFile: /etc/secrets/oauth/client_secret
           scopes:
           - profile
           - openid
@@ -434,10 +460,10 @@ data:
       httpPort: 8088
       port: 8089
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       internalConnectionConfig:
         enabled: true
@@ -486,6 +512,68 @@ metadata:
 data: 
   BASE_URL: /console
   CONFIG_DIR: /etc/flyte/config
+
+---
+# Source: controlplane/charts/flyte/templates/datacatalog/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datacatalog-config
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+data:
+  db.yaml: | 
+    database:
+      connMaxLifeTime: 120s
+      dbname: datacatalog
+      host: ''
+      maxIdleConnections: 10
+      maxOpenConnections: 20
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+  otel.yaml: | 
+    otel:
+      file:
+        filename: /tmp/trace.txt
+      jaeger:
+        endpoint: http://localhost:14268/api/traces
+      otlpgrpc:
+        endpoint: http://localhost:4317
+      otlphttp:
+        endpoint: http://localhost:4318/v1/traces
+      sampler:
+        parentSampler: always
+      type: noop
+  server.yaml: | 
+    application:
+      grpcMaxRecvMsgSizeMBs: 6
+      grpcPort: 8089
+      grpcServerReflection: true
+      httpPort: 8080
+    datacatalog:
+      heartbeat-grace-period-multiplier: 3
+      max-reservation-heartbeat: 30s
+      metrics-scope: flyte
+      profiler-port: 10254
+      storage-prefix: metadata/datacatalog
+  storage.yaml: | 
+    storage:
+      type: s3
+      container: ""
+      connection:
+        auth-type: iam
+        region: 
+      enable-multicontainer: false
+      limits:
+        maxDownloadMBs: 10
+      cache:
+        max_size_mbs: 1024
+        target_gc_percent: 70
 
 ---
 # Source: controlplane/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -590,10 +678,10 @@ data:
       metrics:
         scope: 'actions:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -602,7 +690,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -1589,16 +1677,6 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
-                    # Match the actions ConfigMap's sharedService.security so the
-                    # router and the in-service interceptor agree on org before
-                    # any Host-header fallback. Without this, intra-cluster Host
-                    # (controlplane-nginx-controller.<ns>.svc...) yields the
-                    # wrong org and the router picks the wrong shard. Only set
-                    # when UNION_ORG is configured (single-tenant deployments);
-                    # multi-tenant installs fall through to header-based org
-                    # resolution.
-                    security:
-                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1751,16 +1829,6 @@ data:
                       endPartition: 921
                     - startPartition: 922
                       endPartition: 1023
-                    # Match the actions ConfigMap's sharedService.security so the
-                    # router and the in-service interceptor agree on org before
-                    # any Host-header fallback. Without this, intra-cluster Host
-                    # (controlplane-nginx-controller.<ns>.svc...) yields the
-                    # wrong org and the router picks the wrong shard. Only set
-                    # when UNION_ORG is configured (single-tenant deployments);
-                    # multi-tenant installs fall through to header-based org
-                    # resolution.
-                    security:
-                      singleTenantOrgID: "test-org"
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1843,6 +1911,124 @@ data:
 
 ---
 # Source: controlplane/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2026.7.2
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.7.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    admin:
+      clientId: 'test-internal-client-id'
+      clientSecretLocation: /etc/secrets/union/client_secret
+      endpoint: flyteadmin.union.svc.cluster.local:81
+      insecure: true
+    artifactsConfig:
+      app:
+        adminClient:
+          hackFlagUntilCellIsolation: true
+        artifactBlobStoreConfig:
+          container: ''
+          stow:
+            config: {}
+            kind: ""
+          type: stow
+        artifactDatabaseConfig:
+          connMaxLifeTime: 1m
+          maxIdleConnections: 20
+          maxOpenConnections: 30
+          postgres:
+            dbname: ''
+            host: ''
+            options: sslmode=disable
+            passwordPath: /etc/db/pass.txt
+            port: 5432
+            readReplicaHost: ''
+            username: ''
+        artifactServerConfig:
+          httpPort: 8089
+          port: 8080
+          respectUserOrgsForServerless: true
+        artifactTriggerConfig:
+          executionMaxRetryCount: 3
+          executionSchedulerQuerySize: 20
+          executionSchedulers: 1
+          executionSchedulersWait: 10
+          triggerProcessorQuerySize: 100
+          triggerProcessors: 1
+          triggerProcessorsWait: 10
+    authorizer:
+      authorizerClient:
+        forwardHeaders:
+        - authorization
+        - flyte-authorization
+        - x-user-token
+        grpcConfig:
+          host: dns:///authorizer.union.svc.cluster.local:80
+          insecure: true
+      type: Authorizer
+      useExternalIdentity: 'false'
+    cache:
+      identity:
+        enabled: false
+    connection:
+      environment: staging
+      region: us-east-2
+      rootTenantURLPattern: dns:///fake-host.domain
+    db:
+      connectionPool:
+        maxConnectionLifetime: 1m
+        maxIdleConnections: 20
+        maxOpenConnections: 20
+      dbname: ''
+      debug: 'false'
+      host: ''
+      options: sslmode=disable
+      passwordPath: /etc/db/pass.txt
+      port: 5432
+      username: ''
+    logger:
+      formatter:
+        type: json
+      level: 6
+      show-source: true
+    otel:
+      type: noop
+    sharedService:
+      metrics:
+        scope: 'artifacts:'
+      security:
+        singleTenantOrgID: ''
+      selfServeConfig:
+        legacyHosts:
+        - ''
+    union:
+      auth:
+        authorizationMetadataKey: flyte-authorization
+        clientId: 'test-internal-client-id'
+        clientSecretLocation: /etc/secrets/union/client_secret
+        enable: true
+        scopes:
+        - 'all'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
+        type: ClientSecret
+      connection:
+        insecure: false
+        insecureSkipVerify: true
+        trustedIdentityClaims:
+          enabled: true
+          externalIdentityClaim: ""
+          externalIdentityTypeClaim: app
+      internalConnectionConfig:
+        enabled: true
+        urlPattern: _SERVICE_.union.svc.cluster.local:80
+---
+# Source: controlplane/templates/configmap.yaml
 ---
 
 apiVersion: v1
@@ -1879,7 +2065,7 @@ data:
         - staging
         - production
         maxRetries: 30
-        organization: 'test-org'
+        organization: ''
         projects: []
         retryInterval: 5s
         serviceAccounts: []
@@ -1916,10 +2102,10 @@ data:
       metrics:
         scope: 'authorizer:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -1928,7 +2114,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2007,10 +2193,10 @@ data:
       metrics:
         scope: 'cluster:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2019,7 +2205,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2198,10 +2384,10 @@ data:
       metrics:
         scope: 'dataproxy:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2210,7 +2396,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         host: dns:///fake-host.domain
@@ -2288,10 +2474,10 @@ data:
             insecure: true
             scopes:
             - 'all'
-            tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+            tokenUrl: 'https://test.example.com/oauth2/v1/token'
       apps:
         enrichIdentities: false
-        publicURLPattern: https://%s.apps.test.example.com
+        publicURLPattern: https://%s.apps.
       llm:
         enabled: false
       task:
@@ -2301,7 +2487,7 @@ data:
         enrichIdentities: false
         rejectLegacySDKVersions: true
         useActionsServiceForOrgs:
-        - test-org
+        - ""
     logger:
       formatter:
         type: json
@@ -2313,10 +2499,10 @@ data:
       metrics:
         scope: 'executions:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2325,7 +2511,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2388,18 +2574,7 @@ data:
             insecure: true
             scopes:
             - 'all'
-            tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
-        apiKeyOverrides:
-        - clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY/client_id
-          clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY/client_secret
-          clusterName: ""
-          key: EAGER_API_KEY
-          org: test-org
-        - clientIdLocation: /etc/secrets/apikey/EAGER_API_KEY-dp-1/client_id
-          clientSecretLocation: /etc/secrets/apikey/EAGER_API_KEY-dp-1/client_secret
-          clusterName: dp-1
-          key: EAGER_API_KEY
-          org: test-org
+            tokenUrl: 'https://test.example.com/oauth2/v1/token'
         identityProviderConfig:
           provider: noop
     logger:
@@ -2412,10 +2587,10 @@ data:
     sharedService:
       connectPort: 8081
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2424,7 +2599,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2492,7 +2667,7 @@ data:
     organizations:
       bootStrapConfig:
         organizations:
-        - 'test-org'
+        - ''
         tenantType: SELF_MANAGED
     otel:
       type: noop
@@ -2501,10 +2676,10 @@ data:
       metrics:
         scope: 'organizations:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2513,7 +2688,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2586,10 +2761,10 @@ data:
       metrics:
         scope: 'run-scheduler:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2598,7 +2773,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2665,10 +2840,10 @@ data:
       metrics:
         scope: 'usage:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2677,7 +2852,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -2886,10 +3061,10 @@ data:
       metrics:
         scope: 'leasor:'
       security:
-        singleTenantOrgID: 'test-org'
+        singleTenantOrgID: ''
       selfServeConfig:
         legacyHosts:
-        - 'test-org'
+        - ''
     union:
       auth:
         authorizationMetadataKey: flyte-authorization
@@ -2898,7 +3073,7 @@ data:
         enable: true
         scopes:
         - 'all'
-        tokenUrl: 'https://idp.example.com/oauth2/v2.0/token'
+        tokenUrl: 'https://test.example.com/oauth2/v1/token'
         type: ClientSecret
       connection:
         insecure: false
@@ -7957,6 +8132,32 @@ spec:
     app.kubernetes.io/instance: release-name
 
 ---
+# Source: controlplane/charts/flyte/templates/datacatalog/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datacatalog
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      protocol: TCP
+      port: 10254
+    - name: grpc
+      port: 89
+      protocol: TCP
+      targetPort: 8089
+  selector: 
+    app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+
+---
 # Source: controlplane/charts/ingress-nginx/templates/controller-service-metrics.yaml
 apiVersion: v1
 kind: Service
@@ -8505,7 +8706,41 @@ spec:
 
 ---
 # Source: controlplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: artifacts
+  labels:
+    platform.union.ai/prometheus-group: "union-services"
+    helm.sh/chart: controlplane-2026.7.2
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.7.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 80
+      protocol: TCP
+      targetPort: grpc
+    - name: connect
+      port:  83
+      protocol: TCP
+      targetPort: connect
+    - name: http
+      port: 81
+      protocol: TCP
+      targetPort: http
+    - name: debug
+      port: 82
+      protocol: TCP
+      targetPort: debug
+  selector:
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
 ---
+# Source: controlplane/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -8861,7 +9096,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "eec616161743ae4370e86ee9ad655b2da365a4c41823a211493b0150c0794e5"
+        configChecksum: "3a62e3ed0ecca44e09cb5ca7f1dae97c7435a3b0c72c00789119c1981773b14"
         kubectl.kubernetes.io/default-container: flyteadmin
       labels: 
         app.kubernetes.io/name: flyteadmin
@@ -8996,9 +9231,6 @@ spec:
         - mountPath: /etc/flyte/private
           name: private-config
           readOnly: true
-        - mountPath: /etc/secrets/oauth
-          name: oauth-client-secret
-          readOnly: true
       serviceAccountName: flyteadmin
       volumes:
       - name: union-controlplane-secrets
@@ -9029,9 +9261,6 @@ spec:
       - configMap:
           name: flyte-admin-private-config
         name: private-config
-      - name: oauth-client-secret
-        secret:
-          secretName: flyteadmin-oidc-client-secret
 
 ---
 # Source: controlplane/charts/flyte/templates/console/deployment.yaml
@@ -9104,6 +9333,108 @@ spec:
       volumes:
       - emptyDir: {}
         name: shared-data
+
+---
+# Source: controlplane/charts/flyte/templates/datacatalog/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datacatalog
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: datacatalog
+      app.kubernetes.io/instance: release-name
+  strategy: 
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        configChecksum: "ddb1a42ea2f03dde19ff29af6ae32bf1e9f62b12dbcff3c4ba851127df06707"
+      labels: 
+        app.kubernetes.io/name: datacatalog
+        app.kubernetes.io/instance: release-name
+        helm.sh/chart: flyte-v1.16.1
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext: 
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+        runAsUser: 1001
+        seLinuxOptions:
+          type: spc_t
+      initContainers:
+      - command:
+        - datacatalog
+        - --config
+        - /etc/datacatalog/config/*.yaml
+        - migrate
+        - run
+        image: "registry.unionai.cloud/controlplane/datacatalog:"
+        imagePullPolicy: "IfNotPresent"
+        name: run-migrations
+        volumeMounts:
+        - mountPath: /etc/db
+          name: union-controlplane-secrets
+        - mountPath: /etc/datacatalog/config
+          name: config-volume
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      containers:
+      - command:
+        - datacatalog
+        - --config
+        - /etc/datacatalog/config/*.yaml
+        - serve
+        image: "registry.unionai.cloud/controlplane/datacatalog:"
+        imagePullPolicy: "IfNotPresent"
+        name: datacatalog
+        ports:
+        - containerPort: 8080
+        - containerPort: 8089
+        - containerPort: 10254
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: 1
+            ephemeral-storage: 500Mi
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            ephemeral-storage: 50Mi
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/db
+          name: union-controlplane-secrets
+        - mountPath: /etc/datacatalog/config
+          name: config-volume
+      serviceAccountName: datacatalog
+      volumes:
+      - name: union-controlplane-secrets
+        secret:
+          secretName: union-controlplane-secrets
+      - emptyDir: {}
+        name: shared-data
+      - projected:
+          sources:
+            - configMap:
+                name: datacatalog-config
+        name: config-volume
 
 ---
 # Source: controlplane/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -11222,7 +11553,7 @@ spec:
       annotations:
         checksum/router-bootstrap: 2d9488181faf7002c1f92af48ff0533333efd3b950ca2cd6aec23bd41e036762
         checksum/router-cds: 73bde96026a910e0e289cb24729b011186985a966e7ed3a89ac0c6c9679ba15f
-        checksum/router-lds: 43b64c1f2475756b0c7feed7f40ff66dcdfaaddd36348cc85235da08c1b33689
+        checksum/router-lds: 613e9ce950ef9c921db060c1e358cb289e1dba392492f6704db84cad299d75e4
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11346,6 +11677,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "controlplane"
         
@@ -11466,6 +11798,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         platform.union.ai/zone: "controlplane"
         app.kubernetes.io/name: unionconsole
@@ -11498,7 +11831,7 @@ spec:
           protocol: TCP
         env:
           - name: UNION_ORG_OVERRIDE
-            value: 'test-org'
+            value: ''
         resources:
           limits:
             cpu: 500m
@@ -11509,7 +11842,135 @@ spec:
 
 ---
 # Source: controlplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: artifacts
+  labels:
+    helm.sh/chart: controlplane-2026.7.2
+    app.kubernetes.io/name: artifacts
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.7.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: artifacts
+      app.kubernetes.io/instance: release-name
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: artifacts
+        linkerd.io/inject: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: artifacts
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: artifacts
+      volumes:
+      - name: secrets
+        secret:
+          secretName: 
+      - name: db-pass
+        secret:
+          secretName: 
+      - name: config
+        configMap:
+          name: artifacts
+      initContainers:
+        - name: artifacts-migrate
+          image: registry.unionai.cloud/controlplane/services:2026.7.2
+          imagePullPolicy: IfNotPresent
+          args:
+          - artifacts
+          - migrate
+          - --config
+          - /etc/config/*.yaml
+          volumeMounts:
+          - name: db-pass
+            mountPath: /etc/db
+          - name: secrets
+            mountPath: /etc/secrets/union
+          - name: config
+            mountPath: /etc/config/
+      containers:
+        - name: artifacts
+          image: registry.unionai.cloud/controlplane/services:2026.7.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - artifacts
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: db-pass
+              mountPath: /etc/db
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 250Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: artifacts
+                    app.kubernetes.io/instance: release-name
+                topologyKey: "kubernetes.io/hostname"
 ---
+# Source: controlplane/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11537,6 +11998,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: authorizer
         app.kubernetes.io/instance: release-name
@@ -11652,6 +12114,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: cluster
         app.kubernetes.io/instance: release-name
@@ -11783,6 +12246,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: dataproxy
         app.kubernetes.io/instance: release-name
@@ -11895,6 +12359,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: executions
         app.kubernetes.io/instance: release-name
@@ -12023,6 +12488,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: release-name
@@ -12040,22 +12506,6 @@ spec:
       - name: config
         configMap:
           name: identity
-      - name: apikey-eager-api-key
-        secret:
-          secretName: eager-client-creds
-          items:
-          - key: client_id
-            path: client_id
-          - key: oauth_client_secret
-            path: client_secret
-      - name: apikey-eager-api-key-dp-1
-        secret:
-          secretName: eager-dp1-creds
-          items:
-          - key: client_id
-            path: client_id
-          - key: client_secret
-            path: client_secret
       containers:
         - name: identity
           image: registry.unionai.cloud/controlplane/services:2026.7.2
@@ -12085,12 +12535,6 @@ spec:
               mountPath: /etc/secrets/union
             - name: config
               mountPath: /etc/config/
-            - name: apikey-eager-api-key
-              mountPath: /etc/secrets/apikey/EAGER_API_KEY
-              readOnly: true
-            - name: apikey-eager-api-key-dp-1
-              mountPath: /etc/secrets/apikey/EAGER_API_KEY-dp-1
-              readOnly: true
           env:
             - name: GOMEMLIMIT
               valueFrom:
@@ -12158,6 +12602,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: leasor
         app.kubernetes.io/instance: release-name
@@ -12286,6 +12731,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: organizations
         app.kubernetes.io/instance: release-name
@@ -12433,6 +12879,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: run-scheduler
         app.kubernetes.io/instance: release-name
@@ -12562,6 +13009,7 @@ spec:
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: usage
         app.kubernetes.io/instance: release-name
@@ -12666,6 +13114,34 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: flyteadmin
+  minReplicas: 4
+  maxReplicas: 10
+  metrics:
+    
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 70
+          type: Utilization
+      type: Resource
+
+---
+# Source: controlplane/charts/flyte/templates/datacatalog/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: datacatalog
+  namespace: union
+  labels: 
+    app.kubernetes.io/name: datacatalog
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: flyte-v1.16.1
+    app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: datacatalog
   minReplicas: 1
   maxReplicas: 10
   metrics:
@@ -12718,7 +13194,32 @@ spec:
 
 ---
 # Source: controlplane/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: artifacts
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: artifacts
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
 ---
+# Source: controlplane/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/tests/generated/dataplane.aws.custom-identity-annotation.yaml
+++ b/tests/generated/dataplane.aws.custom-identity-annotation.yaml
@@ -1,4 +1,52 @@
 ---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-operator
+  namespace: "union"
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operator-webhook
+  namespace: "union"
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+---
 # Source: dataplane/charts/prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -39,7 +87,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
+    'customer.example.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml
@@ -49,7 +97,7 @@ metadata:
   name: union
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: test-worker-iam-role-arn
+    customer.example.com/role-arn: test-worker-iam-role-arn
 automountServiceAccountToken: true
 ---
 # Source: dataplane/templates/flyteconnector/serviceaccount.yaml
@@ -62,6 +110,32 @@ metadata:
     app.kubernetes.io/name: flyteconnector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: operator-webhook-certs
+  namespace: "union"
+  labels:
+    app.kubernetes.io/component: operator-webhook
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+# The data is populated at install time.
 ---
 # Source: dataplane/templates/common/auth-secret.yaml
 apiVersion: v1
@@ -102,6 +176,54 @@ data:
   ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROekNDQWgrZ0F3SUJBZ0lVSm9kQ09lem4vd1BHQTZjYkw1U3duSlpYT2hJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05Nell3TVRJeE1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFJcjBSWDRGRjFNVTNYdFBmUHErMDUrMGI1Qm0xK3hsTVR5ZUp4bG5mWFJuRlgyegpPcHV6NmsreUpBQk4xRkxmNDVYRnlJclFlaW5DWWJtckZXalFRc3ZDWEloNkpPNGMwdmRMVVU5RERYcldWRFlsCkRNZytTUDlJVnZBMm5USkVFZ2RFREVsKzNWeThUbUJoNlNmcGthcXdHajY5SmhIdy9OeE9yZzM2bUY3TU5VZ1MKWXJVUkxqUFFzTUN6NElTVzhhQnEzS2IwRUFWUTA4V1lZQ0ZEbjY1aHBzVFdxR05rL3BKRnVTYjlsZll6RVdyYwpJeW5wNDhqTnIvNUdKS3NnWG9LeTUwZVo4UkppeTVyOUhENGtnSW15TVNQR2RDMXFZSVppRHRlZW8yOElxNk5nCmd1dWcyTGhlNndYYW9YZXFCQ2d3SHpwWFVXM1hJVzI5eFoxUkFRRUNBd0VBQWFOVE1GRXdIUVlEVlIwT0JCWUUKRktITDQ1RWhQaVg5bnlRN241QUk0YUZVNFlCL01COEdBMVVkSXdRWU1CYUFGS0hMNDVFaFBpWDlueVE3bjVBSQo0YUZVNFlCL01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFEeTRac21XCkNjZ3B5TmI4cU1ydzNYclBNejZLMTRlTVhqQVk1bERFYXM1NklLZExoZFM1bi9sWk95bENuUUtOZ3RHS0VrY3UKT05tMEE2Z0xNT3UzcE43dG9aNXh0WktOcnUvS0x6dm44QUNNNndCbUR0bG5oRERDa3ZUTHBVRzh6UTZSNmlaegpzTWlhVmpLSUJiWkJsZXNYSHZZQnQ2YlRTN2o1QWM2aTdYc1RPK3ZqQ2RUQjVYdCtEZ0x2QnBJRWh2ZGJzNXhmClFtc3ZzQmwxenJnR3JXemo4d0txcXNUMzZaOVU1TzdSK1RJMlQrUDVOR25SeHNQOGJ0R0RtMGZ5SW55WlJrSkcKVTdpVFJyMlZRWlRyaTNZQ2dlVjN1UjFtMnJjc2hyU1Avb082T0QyTXR5Q1FMRWtFK1pxVUVJVnpSYmVaNXl2RQptM29YMFV2OUtBUy9pWTA9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
   tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQxakNDQXI2Z0F3SUJBZ0lVREtRN3A4MFpIdkQyUE5Ya3p3VGRLem9iUjg4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0t6RXBNQ2NHQTFVRUF3d2dabXg1ZEdWd2NtOXdaV3hzWlhJdGQyVmlhRzl2YXk1MWJtbHZiaTV6ZG1NdwpIaGNOTWpZd01USXpNREl6TmpVMVdoY05NamN3TVRJek1ESXpOalUxV2pBck1Ta3dKd1lEVlFRRERDQm1iSGwwClpYQnliM0JsYkd4bGNpMTNaV0pvYjI5ckxuVnVhVzl1TG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFMNnMxUTRaZ3ZxVVdNdFp5VC9EKytEQWl6WmR0Q1lkVzArSGk4S3phQ1Vjbi9zZwo3a21NTEhDM2ZlZWtZK2ZUNENHUTd6K1l2WjRWWSt6WGljKzdrNndLbUZqdm1acEM1Rm96OWo1Q21NRk5HZmlWCnRobzVvSU9MUkIzNXRYMU1ROHUwNFVzT29QcjdMK016eEdxWXVmTFdtN1NVdjh0eEp3ZFMxZVlzMllNV1pMeU4KekI4akdWY01Qc2ZNVkdxdFhTTVljQ3hNYURKaTM1N0VEZSs3clM2U2ZtbnFtYjJxekdQM1BRRStCUm91Yk5nLwo4NCt4c253VXBLZUFpem95dFM2c2ZlOTdMUEtRTW9oVzd2TjZORFJrLy9xSmpHem9iZmZwUHU3endhWHVXMWtMCmllc2g2cVRrdlZLSTF3WFJ2WHArVU5GbjZzdDIwdEVlRks0ZzMwOENBd0VBQWFPQjhUQ0I3akFKQmdOVkhSTUUKQWpBQU1Bc0dBMVVkRHdRRUF3SUY0RENCa3dZRFZSMFJCSUdMTUlHSWdoWm1iSGwwWlhCeWIzQmxiR3hsY2kxMwpaV0pvYjI5cmdoeG1iSGwwWlhCeWIzQmxiR3hsY2kxM1pXSm9iMjlyTG5WdWFXOXVnaUJtYkhsMFpYQnliM0JsCmJHeGxjaTEzWldKb2IyOXJMblZ1YVc5dUxuTjJZNEl1Wm14NWRHVndjbTl3Wld4c1pYSXRkMlZpYUc5dmF5NTEKYm1sdmJpNXpkbU11WTJ4MWMzUmxjaTVzYjJOaGJEQWRCZ05WSFE0RUZnUVV1d25wcDZ1MTNKL0NsNnI3eDZ1Sgo5YmZ1RDhzd0h3WURWUjBqQkJnd0ZvQVVvY3Zqa1NFK0pmMmZKRHVma0FqaG9WVGhnSDh3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFMmlOa1MzczhGT3Z0cDhrVmJNZUN2amxIQytvYTVlZTFGNmowNlZ3bFJPOWdxOXJla1UKMGptWUhNWGNjWjcrZXJkNFRQRXgwK3ZqMzNhRTV3cDFmdVJJL2xIZHhuOUpJRHg2bTFQTHdVa3p1WG9EekYxLwozVXVIWU1xOGkrT2xsY0tqbmdVMUFUNmRWRCtIbFVWeHpMdjlNazdPb05SQUY5dTJHa1hiUHdCN0I1ZGRxdWxlCmtNcXBxbDhES2s4SVNVelVsTjNBb2Q5NmJUelIyV3RCVkxpTi9zRHZtTDZwZThFYm55RnBUb1BZTDlGeWZOcmIKT1ZPZEJwUkZFTG1KOHZaZWY5d1lxRmVXMTE3SGV5VDArZkxGZVNSemZUNVVWUlVraVFBcUVJdUhHUVRrOVFabgo1WnYvNUF0eEg3WE1rcXR0VE1zMFlSUG0xYjQzY3FBeFdhND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQytyTlVPR1lMNmxGakwKV2NrL3cvdmd3SXMyWGJRbUhWdFBoNHZDczJnbEhKLzdJTzVKakN4d3QzM25wR1BuMCtBaGtPOC9tTDJlRldQcwoxNG5QdTVPc0NwaFk3NW1hUXVSYU0vWStRcGpCVFJuNGxiWWFPYUNEaTBRZCtiVjlURVBMdE9GTERxRDYreS9qCk04UnFtTG55MXB1MGxML0xjU2NIVXRYbUxObURGbVM4amN3Zkl4bFhERDdIekZScXJWMGpHSEFzVEdneVl0K2UKeEEzdnU2MHVrbjVwNnBtOXFzeGo5ejBCUGdVYUxtellQL09Qc2JKOEZLU25nSXM2TXJVdXJIM3ZleXp5a0RLSQpWdTd6ZWpRMFpQLzZpWXhzNkczMzZUN3U4OEdsN2x0WkM0bnJJZXFrNUwxU2lOY0YwYjE2ZmxEUlorckxkdExSCkhoU3VJTjlQQWdNQkFBRUNnZ0VBRjV2SnMzbTRMSE9DdlFic2NwOC9DQmgvQkNlOC92MGlpYW5VUmJLMkFlWlYKN3Arb3NXV1FPUktYSGIvT2VPMVVjb09DQkFOUzh3aGQrM3pDZlB5U0w3cU9HM0RyT1Z6djdqVkIxM3FpZEVpcQpId3ZXWk0vZXpuckhYOWpEdm5SYmJwVUNVaXRKQmxwa2x3S1pYc056UHB5UTRkNkxFdEw3VEo1V2lxM2g3cWQzCjhncmJoeWlWNDhZRFAyYkhpZGt0S2QvMHBNL3piSzZPTS9iMFpLUmRBWVpHQXlOcklMaFJ3eDNsQXE2SDVqL20KUHBuNlZEdVQ3Y1h6UFhmNTgxR0IyNjQxWFJVTXRNWGVEREtaU3JudnIrbG5tV2lsYXZmNkg3ZHp4NlRBMmk0RApybCtIRVdUN1RSQUZGMnZ5SVUrYSt5RzNPVFBKRCtmVTdCWWh4Zld4aFFLQmdRRGVvcXVCbzQxK1dKU255blZnCmNWMHZoUEkwZ0dyRGQzNFdIbCtGNTZuSmxuMVVlbUQ2SUQ0TUhnNVpHWmNmd3NkRlB0aHl1VnB0OVl1SW11SGQKRHE5ZDhpWnpHUzJVbStkSWlsWjhnZXJ5Q3dON3hIbFM3SzJrc0RmRGJwYmZZSXZ1LzRnSExZRHh3YzQ0OG54ZwpWNGpCUFY2QTdYTHRqQzZzdFE2OW9uTlIwd0tCZ1FEYlFBUTRGdWpnUjJUOXh2Y01MdXhMbm1YaHE4U2NoZlM5CkRoWndDUzZIeHB1YlBxblBjQ04vQUZjbDZ1cDRXVEVZdVY4bEpwcGwwRmpYQ2lMdkhuUU15cm5vRjlUOThpanQKZGVHYjF6ZWlwRUpndFpNVHkvOGdERWorZU1wSFBuYTZwQVpMOVpRVUdLR2dDNGQ0SzljdVNHMmRlb1dSU0ViSQpMVGgzeGpXVEZRS0JnQStJRWFidG5nVmVjS0IwQTFSREZGa29VUzFRZUNKQ3g4MExPV2JDRHBvOW9XaXZVT3lpCkt6SDFOdE1JY2Y2SlBCV2NtTVVJSVVMaWltVnhTS2gvU2NTb0MvNmpsd1p6Q2VPSm94YjBpVXR4Y1VERktDR2MKMlZCUDZ0UDdkeE1HVFR6VEhzNUJZbWw3TjhQSlJ0d0J2MHliMTJmdktNRmhzaS9pUWJFQkVFSjVBb0dBUm9NSApHRmJkM0V0NXdsZzcyYkk1a25SRnhkY3RLejIxb1J1bndhNWlSWTV0T3Zkak8zQ1FLZWNkSC9lMklyQmtwdFB2Ck1vNkF0MS9UUW8xakFNNGxlbnUwWUYxUnhiNGN4WW5VM2Y3UVNNRlZDNjg1dHZNemdNWVNyNngvT1h4d1NNUTUKdGpJcnhtN0poQ1JSRkNmZFUyZzl3SmpIM2hxRmtSbGlBTHRCUGFVQ2dZRUF2QkRHejQvYS9kRzRJT0VpREk4SgpBbkxaRWZaTFJrdnI0ejRyT0p0TGZtWlFjTW5DSUZmKzBaelhTME9XOWhvMjk5RUNtS1l4U2VUWk1WSDgzOFZCCnRvSkNGM3lzb01rSC9meEVXTUpicDlMblJwSFUzUElicHlhRG1nWW1YdmsvK3laL3Y1c0dDTWNtVGkzWVFLRGsKcStlK1o0SHZyaGUxVytUaHpwOCtoNGs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: "union"
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+data: {}
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: "union"
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+data: {}
 ---
 # Source: dataplane/templates/fluent-bit/configmap.yaml
 apiVersion: v1
@@ -177,7 +299,7 @@ data:
         max_size_mbs: 0
         target_gc_percent: 70
   buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
-  default-repository: "123456789012.dkr.ecr.test-region.amazonaws.com/union-dataplane"
+  default-repository: ".dkr.ecr.test-region.amazonaws.com/union-dataplane"
   authentication-type: "noop"
 
 ---
@@ -346,13 +468,13 @@ data:
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-client-id'
         clientSecretLocation: /etc/union/secret/client_secret
         enable: true
         tokenRefreshWindow: 5m
         type: ClientSecret
     admin:
-      clientId: ''
+      clientId: 'test-client-id'
       clientSecretLocation: /etc/union/secret/client_secret
       endpoint: 'dns:///test-controlplane-host'
       insecure: false
@@ -2039,7 +2161,7 @@ data:
         insecureSkipVerify: false
       auth:
         authorizationMetadataKey: flyte-authorization
-        clientId: ''
+        clientId: 'test-client-id'
         clientSecretLocation: /etc/union/secret/client_secret
         enable: true
         tokenRefreshWindow: 5m
@@ -2061,19 +2183,20 @@ data:
       enableTunnelService: true
       #  enableDepot: false
       tunnel:
-        enableDirectToAppIngress: false
+        enableDirectToAppIngress: true
         deploymentToRestart: union-operator-proxy
+        appIngressOriginURL: "http://kourier-internal"
       limitNamespace: union
       disableClusterPermissions: true
       apps:
-        enabled: 'false'
+        enabled: 'true'
       syncClusterConfig:
         enabled: false
       clusterId:
         name: 'test-cluster-name'
         organization: 'test-org-name'
       clusterData:
-        appId: ''
+        appId: 'test-client-id'
         bucketName: 'test-metadata-bucket'
         bucketRegion: 'test-region'
         cloudHostName: 'test-controlplane-host'
@@ -2081,7 +2204,7 @@ data:
         gcpProjectId: ''
         metadataBucketPrefix: 's3://test-metadata-bucket'
         userRole: 'test-worker-iam-role-arn'
-        userRoleKey: 'eks.amazonaws.com/role-arn'
+        userRoleKey: 'customer.example.com/role-arn'
       collectUsages:
         enabled: false
       billing:
@@ -2110,7 +2233,7 @@ data:
         sourceType: ObjectStore
       smConfig:
         awsConfig:
-          account: '123456789012'
+          account: ''
           region: 'test-region'
         enabled: 'true'
         k8sConfig:
@@ -2154,7 +2277,7 @@ data:
           auth_type: iam
           region: test-region
   image-builder.buildkit-uri: "tcp://union-operator-buildkit.union.svc.cluster.local:1234"
-  image-builder.default-repository: "123456789012.dkr.ecr.test-region.amazonaws.com/union-dataplane"
+  image-builder.default-repository: ".dkr.ecr.test-region.amazonaws.com/union-dataplane"
   image-builder.authentication-type: "noop"
 
 ---
@@ -3378,6 +3501,134 @@ data:
   rules: |
     {}
 ---
+# Source: dataplane/templates/serving/bootstrap-configmap.yaml
+# We need to copy the default configmap here since knative-operator does not automatically update the
+# address of the `net-kourier-controller` endpoint to use the release namespace. It assumes that the
+# resources are being installed into the `knative-serving` namespace instead.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: union-operator-serving-envoy-bootstrap
+  namespace: union
+data:
+  envoy-bootstrap.yaml: |
+    dynamic_resources:
+      ads_config:
+        transport_api_version: V3
+        api_type: GRPC
+        rate_limit_settings: {}
+        grpc_services:
+        - envoy_grpc: {cluster_name: xds_cluster}
+      cds_config:
+        resource_api_version: V3
+        ads: {}
+      lds_config:
+        resource_api_version: V3
+        ads: {}
+    node:
+      cluster: kourier-knative
+      id: 3scale-kourier-gateway
+    static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: stats_server
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                safe_regex:
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    string_match:
+                                      exact: GET
+                              route:
+                                cluster: service_stats
+                            - match:
+                                safe_regex:
+                                  regex: '/drain_listeners'
+                                headers:
+                                  - name: ':method'
+                                    string_match:
+                                      exact: POST
+                              route:
+                                cluster: service_stats
+      clusters:
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
+          load_assignment:
+            cluster_name: service_stats
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 9901
+        - name: xds_cluster
+          # This keepalive is recommended by envoy docs.
+          # https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options:
+                  connection_keepalive:
+                    interval: 30s
+                    timeout: 5s
+          connect_timeout: 1s
+          load_assignment:
+            cluster_name: xds_cluster
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    socket_address:
+                      address: "net-kourier-controller"
+                      port_value: 18000
+          type: STRICT_DNS
+    admin:
+      access_log:
+      - name: envoy.access_loggers.stdout
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 9901
+    stats_config:
+      stats_tags:
+        - tag_name: name
+          regex: '^.*?\.u/.*?n=(.*?)/.*?u\..*$'
+        - tag_name: domain
+          regex: '^.*?\.u/.*?d=(.*?)/.*?u\..*$'
+        - tag_name: org
+          regex: '^.*?\.u/.*?o=(.*?)/.*?u\..*$'
+        - tag_name: project
+          regex: '^.*?\.u/.*?p=(.*?)/.*?u\..*$'
+        - tag_name: target
+          regex: '^.*?\.u/.*?t=(.*?)/.*?u\..*$'
+        - tag_name: target_namespace
+          regex: '^.*?\.u/.*?tns=(.*?)/.*?u\..*$'
+
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -3400,6 +3651,821 @@ rules:
       - list
       - watch
 ---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-serving-operator-aggregated
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+aggregationRule:
+  clusterRoleSelectors:
+    # This (along with escalate below) allows the Operator to pick up any
+    # roles that are provided to the admin of the cluster by knative serving
+    # automatically.
+    - matchExpressions:
+        - {key: serving.knative.dev/release, operator: Exists}
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-serving-operator-aggregated-stable
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+aggregationRule:
+  clusterRoleSelectors:
+    # This (along with escalate below) allows the Operator to pick up any
+    # roles that are provided to the admin of the cluster by knative serving
+    # automatically.
+    - matchExpressions:
+        - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-operator-aggregated
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+aggregationRule:
+  clusterRoleSelectors:
+    # This (along with escalate below) allows the Operator to pick up any
+    # roles that are provided to the admin of the cluster by knative eventing
+    # automatically.
+    - matchExpressions:
+        - {key: eventing.knative.dev/release, operator: Exists}
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-operator-aggregated-stable
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+aggregationRule:
+  clusterRoleSelectors:
+    # This (along with escalate below) allows the Operator to pick up any
+    # roles that are provided to the admin of the cluster by knative eventing
+    # automatically.
+    - matchExpressions:
+        - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
+# Rules are intentionally omitted: the K8s clusterrole-aggregation-controller
+# populates .rules from matching ClusterRoles. Declaring `rules: []` here would
+# claim SSA ownership of the field and conflict with the aggregation controller
+# on every helm upgrade.
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-operator
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+rules:
+  - apiGroups:
+      - operator.knative.dev
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  # Bootstrapping permissions.
+  # Roles that are explicitly bound buch which are specified by this Operator
+  # MUST be specified here with 'get' and 'bind'.
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    resourceNames:
+      - system:auth-delegator
+    verbs:
+      - bind
+      - get
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    resourceNames:
+      - extension-apiserver-authentication-reader
+    verbs:
+      - bind
+      - get
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - roles
+    verbs:
+      - create
+      - delete
+      # Escalate is necessary in order to create a role using cluster role aggregation,
+      # and to allow the Operator to bootstrap itself into the necessary set of
+      # permissions, even as those continue to evolve upstream.
+      - escalate
+      - get
+      - list
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - list
+      - get
+      - update
+  # Permissions required for Knative controller
+  # infra.
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - caching.internal.knative.dev
+    resources:
+      - images
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - update
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - security.istio.io
+      - apps
+      - policy
+    resources:
+      - poddisruptionbudgets
+      - peerauthentications
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  # Old resources that need cleaning up that are not in the knative-serving
+  # namespace.
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - deployments
+      - horizontalpodautoscalers
+    resourceNames:
+      - knative-ingressgateway
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - config-controller
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - knative-serving-operator
+    verbs:
+      - delete
+  # for contour TLS
+  - apiGroups:
+      - projectcontour.io
+    resources:
+      - httpproxies
+      - tlscertificatedelegations
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+      - deletecollection
+      - patch
+  # for security-guard
+  - apiGroups:
+      - guard.security.knative.dev
+    resources:
+      - guardians
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-operator
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+rules:
+  - apiGroups:
+      - operator.knative.dev
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  # Bootstrapping permissions.
+  # Roles that are explicitly bound buch which are specified by this Operator
+  # MUST be specified here with 'get' and 'bind'.
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - roles
+    verbs:
+      - create
+      - delete
+      # Escalate is necessary in order to create a role using cluster role aggregation,
+      # and to allow the Operator to bootstrap itself into the necessary set of
+      # permissions, even as those continue to evolve upstream.
+      - escalate
+      - get
+      - list
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - list
+      - get
+      - update
+  # Permissions required for Knative controller
+  # infra.
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - caching.internal.knative.dev
+    resources:
+      - images
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - update
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+      # Old resources that need cleaning up that are not in the knative-eventing
+      # namespace.
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - knative-eventing-operator
+    verbs:
+      - delete
+  # for RabbitMQ messaging topology objects
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - rabbitmqclusters
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - bindings
+      - queues
+      - exchanges
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - bindings/status
+      - queues/status
+      - exchanges/status
+    verbs:
+      - get
+  # for Kafka eventing source
+  - apiGroups:
+      - keda.sh
+    resources:
+      - scaledobjects
+      - scaledobjects/finalizers
+      - scaledobjects/status
+      - triggerauthentications
+      - triggerauthentications/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+  # Internal APIs
+  - apiGroups:
+      - "internal.kafka.eventing.knative.dev"
+    resources:
+      - "consumers"
+      - "consumers/status"
+      - "consumergroups"
+      - "consumergroups/status"
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - "internal.kafka.eventing.knative.dev"
+    resources:
+      - "consumers/finalizers"
+      - "consumergroups/finalizers"
+    verbs:
+      - update
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - watch
+  - apiGroups:
+      - "*"
+    resources:
+      - configmaps
+    verbs:
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - configmaps
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - pods
+    verbs:
+      - list
+      - update
+      - get
+      - watch
+  - apiGroups:
+      - "*"
+    resources:
+      - pods/finalizers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - events
+    verbs:
+      - patch
+      - create
+  - apiGroups:
+      - "*"
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "*"
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - configmaps
+    resourceNames:
+      - kafka-channel-config
+    verbs:
+      - patch
+  - apiGroups:
+      - "*"
+    resources:
+      - horizontalpodautoscalers
+    resourceNames:
+      - kafka-webhook
+    verbs:
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - leases
+    verbs:
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - poddisruptionbudgets
+    resourceNames:
+      - kafka-webhook
+    verbs:
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - services
+    verbs:
+      - patch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - deletecollection
+  # Eventing TLS
+  - apiGroups:
+      - "cert-manager.io"
+    resources:
+      - certificates
+      - issuers
+      - clusterissuers
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - bundles
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-operator-webhook
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+rules:
+  # For watching logging configuration and getting certs.
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"
+      - "watch"
+      - "patch"
+  # finalizers are needed for the owner reference of the webhook
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces/finalizers"
+    verbs:
+      - "update"
+  # For getting our Deployment so we can decorate with ownerref.
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments/finalizers"
+    verbs:
+      - update
+  # For actually registering our webhook.
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - "mutatingwebhookconfigurations"
+      - "validatingwebhookconfigurations"
+    verbs: &everything
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  # For leader election
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs: *everything
+  # Necessary for conversion webhook. These are copied from the serving
+  # TODO: Do we really need all these permissions?
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
 # Source: dataplane/charts/fluentbit/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3419,6 +4485,192 @@ subjects:
   - kind: ServiceAccount
     name: union-system
     namespace: union
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Consider restriction of non-aggregated role to knativeservings namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-operator
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-operator
+subjects:
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# TODO: Consider restriction of non-aggregated role to knativeeventing namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-operator
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-eventing-operator
+subjects:
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-webhook
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-operator-webhook
+subjects:
+  - kind: ServiceAccount
+    name: operator-webhook
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-operator-aggregated
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-operator-aggregated
+subjects:
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-operator-aggregated-stable
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-operator-aggregated-stable
+subjects:
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-operator-aggregated
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-eventing-operator-aggregated
+subjects:
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-operator-aggregated-stable
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-eventing-operator-aggregated-stable
+subjects:
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: "union"
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: "union"
+  name: knative-operator-webhook
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+rules:
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"
+      - "watch"
+      - "patch"
 ---
 # Source: dataplane/templates/leaseworker/serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3575,6 +4827,19 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - serving.knative.dev
+    resources:
+      - revisions
+      - configurations
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 ---
 # Source: dataplane/templates/prometheus/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3722,6 +4987,38 @@ rules:
       - patch
       - list
       - watch
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: "union"
+  name: operator-webhook
+  labels:
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+subjects:
+  - kind: ServiceAccount
+    name: operator-webhook
+    namespace: "union"
+roleRef:
+  kind: Role
+  name: knative-operator-webhook
+  apiGroup: rbac.authorization.k8s.io
 ---
 # Source: dataplane/templates/leaseworker/serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3876,6 +5173,46 @@ spec:
     app.kubernetes.io/name: fluentbit
     app.kubernetes.io/instance: release-name
 
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: operator-webhook
+    app.kubernetes.io/component: operator-webhook
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+  name: operator-webhook
+  namespace: "union"
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+    - name: https-webhook
+      port: 443
+      targetPort: 8443
+  selector:
+    role: operator-webhook
 ---
 # Source: dataplane/charts/prometheus/charts/kube-state-metrics/templates/service.yaml
 apiVersion: v1
@@ -4203,6 +5540,204 @@ spec:
           name: etcmachineid
       tolerations:
         - operator: Exists
+
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator-webhook
+  namespace: "union"
+  labels:
+    app.kubernetes.io/component: operator-webhook
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/name: knative-operator
+spec:
+  selector:
+    matchLabels:
+      app: operator-webhook
+      role: operator-webhook
+  template:
+    metadata:
+      labels:
+        app: operator-webhook
+        role: operator-webhook
+        app.kubernetes.io/component: operator-webhook
+        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/name: knative-operator
+        sidecar.istio.io/inject: "false"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: operator-webhook
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: operator-webhook
+      containers:
+        - name: operator-webhook
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/operator/cmd/webhook@sha256:d3a7a3304629ccfcaacec620b50736e0b4c902a6328b83369b6cbaf7e94677c9
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: WEBHOOK_NAME
+              value: operator-webhook
+            - name: WEBHOOK_PORT
+              value: "8443"
+            - name: WEBHOOK_SECRET_NAME
+              value: operator-webhook-certs
+            - name: METRICS_DOMAIN
+              value: knative.dev/operator
+            - name: KUBERNETES_MIN_VERSION
+              value: ""
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+          readinessProbe:
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: "webhook"
+          livenessProbe:
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: "webhook"
+            failureThreshold: 6
+            initialDelaySeconds: 120
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knative-operator
+  namespace: "union"
+  labels:
+    app.kubernetes.io/name: knative-operator
+    app.kubernetes.io/version: "1.16.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: knative-operator
+  template:
+    metadata:
+      labels:
+        name: knative-operator
+        app.kubernetes.io/name: knative-operator
+        app.kubernetes.io/version: "1.16.0"
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-operator
+      containers:
+        - name: knative-operator
+          image: gcr.io/knative-releases/knative.dev/operator/cmd/operator@sha256:0b5a3532417f9c8e7b6044e23f6f67ad932a74a40a4092ad965b6f173b2fd887
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: METRICS_DOMAIN
+              value: knative.dev/operator
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: KUBERNETES_MIN_VERSION
+              value: ""
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: metrics
+              containerPort: 9090
 
 ---
 # Source: dataplane/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
@@ -4630,7 +6165,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "207d417719d17cff11a8803bfef2880aed41ef5afade7a8d398167dd085ed18"
+        configChecksum: "f6e57779fb5b784d64414724bffbc132729fd9c6334bb95c4030d580c754c09"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -4736,7 +6271,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ffa09564ab8a9bec79ab1203f5c37fb68fed2bd60292f627dd2e8ed10976383"
+        configChecksum: "2c27298a84ba73a20f346091ae917419ccbd07109a56fc80592625e6db8408e"
         karpenter.sh/do-not-disrupt: "true"
         
       labels:
@@ -4875,7 +6410,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ffa09564ab8a9bec79ab1203f5c37fb68fed2bd60292f627dd2e8ed10976383"
+        configChecksum: "2c27298a84ba73a20f346091ae917419ccbd07109a56fc80592625e6db8408e"
         
       labels:
         
@@ -5001,7 +6536,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "207d417719d17cff11a8803bfef2880aed41ef5afade7a8d398167dd085ed18"
+        configChecksum: "f6e57779fb5b784d64414724bffbc132729fd9c6334bb95c4030d580c754c09"
         
     spec:
       securityContext:
@@ -5156,6 +6691,22 @@ webhooks:
     timeoutSeconds: 30
 
 ---
+# Source: dataplane/charts/knative-operator/templates/knative-operator.yaml
+# Imported via https://github.com/knative/operator/releases/download/knative-v1.16.0/operator.yaml
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 # Source: dataplane/templates/propeller/serviceaccount.yaml
 ---
 
@@ -5274,4 +6825,196 @@ spec:
               kubectl delete deployment flytepropeller-webhook -n ${NS} --ignore-not-found
               kubectl delete secret flyte-pod-webhook -n ${NS} --ignore-not-found
               kubectl delete deployment union-operator-prometheus -n ${NS} --ignore-not-found
+
+---
+# Source: dataplane/templates/serving/knative-serving.yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: union-operator-serving
+  namespace: union
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    helm.sh/chart: dataplane-2026.7.2
+    app.kubernetes.io/name: release-name-dataplane
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.7.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: serving
+spec:
+  config:
+    deployment:
+      progress-deadline: "30m"
+      queue-sidecar-cpu-request: "25m"
+      queue-sidecar-cpu-limit: "1000m"
+      queue-sidecar-memory-request: "400Mi"
+      queue-sidecar-memory-limit: "800Mi"
+      queue-sidecar-ephemeral-storage-request: "512Mi"
+      queue-sidecar-ephemeral-storage-limit: "1024Mi"
+      registries-skipping-tag-resolving: managed.cr.union.ai,ghcr.io,docker.io,.dkr.ecr.test-region.amazonaws.com
+    features:
+      kubernetes.podspec-affinity: "enabled"
+      kubernetes.podspec-nodeselector: "enabled"
+      kubernetes.podspec-tolerations: "enabled"
+      kubernetes.podspec-fieldref: "enabled"
+      kubernetes.podspec-dnspolicy: "enabled"
+      kubernetes.podspec-schedulername: "enabled"
+      kubernetes.podspec-securitycontext: "enabled"
+      # Allow adding a capability subset to the user container's securityContext
+      # (e.g. CAP_SYS_ADMIN, which PodTemplate.allow_fuse() sets so apps/tasks can
+      # mount a FUSE filesystem such as a flyteplugins-union Volume).
+      kubernetes.containerspec-addcapabilities: "enabled"
+    network:
+      ingress-class: "kourier.ingress.networking.knative.dev"
+  high-availability:
+    replicas: 2
+  ingress:
+    kourier:
+      enabled: true
+      bootstrap-configmap: "union-operator-serving-envoy-bootstrap"
+      service-type: ClusterIP
+  podDisruptionBudgets:
+  - name: 3scale-kourier-gateway-pdb
+    minAvailable: 50%
+  - name: activator-pdb
+    minAvailable: 50%
+  - name: webhook-pdb
+    minAvailable: 50%
+  registry:
+    override:
+      # TODO(jeev): Wire up Union fork of Envoy
+      3scale-kourier-gateway/kourier-gateway: ghcr.io/unionai/envoy:456fed84d4ad9a9dfb186d117d9362e9dc0f7c1f
+      # TODO(jeev): Wire up Union fork of Kourier
+      net-kourier-controller/controller: ghcr.io/unionai/kourier@sha256:5804c348d15b3959604e3e3ceed216c3a1c7b32cbe254c7d3eb02a35e62ba9c4
+  workloads:
+  - name: 3scale-kourier-gateway
+    labels:
+      helm.sh/chart: dataplane-2026.7.2
+      app.kubernetes.io/name: release-name-dataplane
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/version: "2026.7.2"
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/component: 3scale-kourier-gateway
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: 3scale-kourier-gateway
+                app.kubernetes.io/instance: release-name
+            topologyKey: topology.kubernetes.io/zone
+    annotations:
+      checksum/bootstrap-config: 6469f6f592eebc9e0c676d8ccc359a05bc799c0988e474b2da942c4cc328f656
+    env:
+    - container: kourier-gateway
+      envVars:
+      - name: UNION_AUTHZ_TENANTAUTHURL
+        value: "https://test-controlplane-host/me"
+      - name: UNION_AUTHZ_TENANTAUTHSIGNINURL
+        value: "https://test-controlplane-host/login"
+      - name: UNION_AUTHZ_TENANTCONTROLPLANEURL
+        value: "https://test-controlplane-host"
+    resources:
+      - container: kourier-gateway
+        limits:
+          cpu: "2"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi
+  - name: activator
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - activator
+            topologyKey: topology.kubernetes.io/zone
+  - name: autoscaler
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - autoscaler
+            topologyKey: topology.kubernetes.io/zone
+  - name: autoscaler-hpa
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - autoscaler-hpa
+            topologyKey: topology.kubernetes.io/zone
+  - name: controller
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - controller
+            topologyKey: topology.kubernetes.io/zone
+  - name: net-kourier-controller
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - net-kourier-controller
+            topologyKey: topology.kubernetes.io/zone
+    env:
+    - container: controller
+      envVars:
+      - name: KOURIER_UNION_AUTHZ_ENABLED
+        value: "true"
+    resources:
+      - container: controller
+        limits:
+          cpu: "1"
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 500Mi
+  - name: webhook
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - webhook
+            topologyKey: topology.kubernetes.io/zone
 

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -116,7 +116,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: 'test-backend-iam-role-arn'
+    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -116,7 +116,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: 'test-backend-iam-role-arn'
+    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml
@@ -2357,6 +2357,9 @@ data:
           prefix: persisted-logs
         sourceType: ObjectStore
       smConfig:
+        awsConfig:
+          account: ''
+          region: 'test-region'
         enabled: 'true'
         k8sConfig:
           namespace: 'union'
@@ -6733,7 +6736,8 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "90604c95c8ca006915a36d2f59142dcb2727d13ea22f0694dad114b3c3d06c9"
+        configChecksum: "6102842598ce2ae9e070bb0e0bae69c7ebd26dd0842e5e99213bbf2dda7f751"
+        karpenter.sh/do-not-disrupt: "true"
         
       labels:
         
@@ -6871,7 +6875,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "90604c95c8ca006915a36d2f59142dcb2727d13ea22f0694dad114b3c3d06c9"
+        configChecksum: "6102842598ce2ae9e070bb0e0bae69c7ebd26dd0842e5e99213bbf2dda7f751"
         
       labels:
         

--- a/tests/generated/dataplane.aws.zero-trust-apps-disabled.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-apps-disabled.yaml
@@ -39,7 +39,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: 'test-backend-iam-role-arn'
+    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -39,7 +39,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: 'test-backend-iam-role-arn'
+    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml

--- a/tests/generated/dataplane.aws.zero-trust-serving-disabled.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-serving-disabled.yaml
@@ -39,7 +39,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: 'test-backend-iam-role-arn'
+    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -39,7 +39,7 @@ metadata:
   name: union-system
   namespace: union
   annotations:
-    eks.amazonaws.com/role-arn: 'test-backend-iam-role-arn'
+    'eks.amazonaws.com/role-arn': 'test-backend-iam-role-arn'
 
 ---
 # Source: dataplane/templates/common/union-serviceaccount.yaml

--- a/tests/values/controlplane.aws.custom-identity-annotation.yaml
+++ b/tests/values/controlplane.aws.custom-identity-annotation.yaml
@@ -1,0 +1,70 @@
+# helm-values: values.aws.yaml
+# Intended to test charts/controlplane AWS identity annotation prefix overrides.
+
+global:
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: customer.example.com
+  INTERNAL_CLIENT_ID: "test-internal-client-id"
+  AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
+  ARTIFACT_IAM_ROLE_ARN: arn:aws:iam::<account-id>:role/artifactsrole
+  FLYTEADMIN_IAM_ROLE_ARN: arn:aws:iam::<account-id>:role/adminflyterole
+
+dbHost: "db-instance-url"
+dbName: "dbName"
+dbUser: "dbUser"
+dbPass: "dbPass"
+bucketName: "bucketName"
+artifactsBucketName: "artifactsBucketName"
+
+configMap:
+  connection:
+    environment: staging
+    region: us-east-2
+    rootTenantURLPattern: dns:///fake-host.domain
+
+controlplane:
+  enabled: true
+
+ingress:
+  host: fake-host.domain
+  tls:
+    - hosts:
+        - fake-host.domain
+      secretName: fake-host-tls-secret
+
+services:
+  artifacts:
+    disabled: false
+
+flyte:
+  common:
+    ingress:
+      tls:
+        secretName: fake-host-tls-secret
+      host: fake-host.domain
+
+  datacatalog:
+    enabled: true
+
+  flyteadmin:
+    autoscaling:
+      enabled: true
+      minReplicas: 4
+      maxReplicas: 10
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 70
+  configmap:
+    admin:
+      admin:
+        endpoint: dns:///fake-host.domain
+        insecure: false
+    adminServer:
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
+
+podAnnotations:
+  prometheus.io/scrape: "true"

--- a/tests/values/dataplane.aws.custom-identity-annotation.yaml
+++ b/tests/values/dataplane.aws.custom-identity-annotation.yaml
@@ -1,0 +1,30 @@
+# helm-values: values.aws.yaml, examples/values-test-certs.yaml
+# Intended to test charts/dataplane AWS identity annotation prefix overrides.
+
+global:
+  UNION_CONTROL_PLANE_HOST: "test-controlplane-host"
+  CONTROLPLANE_HOST: "test-controlplane-host"
+  CLUSTER_NAME: "test-cluster-name"
+  ORG_NAME: "test-org-name"
+  CLIENT_ID: "test-client-id"
+  AUTH_CLIENT_ID: "test-client-id"
+  METADATA_BUCKET: "test-metadata-bucket"
+  FAST_REGISTRATION_BUCKET: "test-fast-registration-bucket"
+  AWS_REGION: "test-region"
+  BACKEND_IAM_ROLE_ARN: "test-backend-iam-role-arn"
+  WORKER_IAM_ROLE_ARN: "test-worker-iam-role-arn"
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: customer.example.com
+
+provider: aws
+
+storage:
+  provider: aws
+  authType: iam
+  region: "{{ .Values.global.AWS_REGION }}"
+  enableMultiContainer: true
+
+secrets:
+  admin:
+    clientId: "{{ .Values.global.CLIENT_ID }}"
+    clientSecret: "test-not-real-secret"
+    create: true

--- a/tests/values/dataplane.aws.eks-automode.yaml
+++ b/tests/values/dataplane.aws.eks-automode.yaml
@@ -8,6 +8,7 @@ global:
   METADATA_BUCKET: "test-metadata-bucket"
   FAST_REGISTRATION_BUCKET: "test-fast-registration-bucket"
   AWS_REGION: "test-region"
+  AWS_POD_IDENTITY_ANNOTATION_PREFIX: eks.amazonaws.com
   BACKEND_IAM_ROLE_ARN: "test-backend-iam-role-arn"
   WORKER_IAM_ROLE_ARN: "test-worker-iam-role-arn"
 
@@ -35,10 +36,10 @@ storage:
 
 # IAM role for Union backend services (operator, propeller, etc.)
 additionalServiceAccountAnnotations:
-  eks.amazonaws.com/role-arn: "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
+  "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn": "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
 
 # IAM role for workflow execution pods
-userRoleAnnotationKey: eks.amazonaws.com/role-arn
+userRoleAnnotationKey: "{{ .Values.global.AWS_POD_IDENTITY_ANNOTATION_PREFIX }}/role-arn"
 userRoleAnnotationValue: "{{ tpl .Values.global.WORKER_IAM_ROLE_ARN . }}"
 
 # ----------------------------------------------------------------------------

--- a/tests/values/dataplane.aws.yaml
+++ b/tests/values/dataplane.aws.yaml
@@ -1,4 +1,4 @@
-# helm-values: examples/values-test-certs.yaml
+# helm-values: values.aws.yaml, examples/values-test-certs.yaml
 # Intended to match and test charts/dataplane/values.aws.yaml
 
 # Test namespace_mapping cascading to all services
@@ -37,20 +37,6 @@ storage:
   # AWS region for S3 buckets
   region: '{{ .Values.global.AWS_REGION }}'
   enableMultiContainer: true
-
-# ----------------------------------------------------------------------------
-# SECTION 4: IAM Roles (REQUIRED for AWS)
-# ----------------------------------------------------------------------------
-# Configure IRSA (IAM Roles for Service Accounts) for secure AWS access.
-# These IAM roles must be created with appropriate trust policies and permissions.
-
-# IAM role for Union backend services (operator, propeller, etc.)
-additionalServiceAccountAnnotations:
-  eks.amazonaws.com/role-arn: "{{ tpl .Values.global.BACKEND_IAM_ROLE_ARN . }}"
-
-# IAM role for workflow execution pods
-userRoleAnnotationKey: eks.amazonaws.com/role-arn
-userRoleAnnotationValue: "{{ tpl .Values.global.WORKER_IAM_ROLE_ARN . }}"
 
 # ----------------------------------------------------------------------------
 # SECTION 5: Authentication Secrets (REQUIRED)


### PR DESCRIPTION
## Overview

Adds configurable AWS Pod Identity Webhook annotation prefixes to the control-plane and dataplane charts.

The standard webhook annotation is `eks.amazonaws.com/role-arn`, but clusters can install the webhook with a custom `--annotation-prefix`. This PR adds `global.AWS_POD_IDENTITY_ANNOTATION_PREFIX`, defaulting to `eks.amazonaws.com`, and derives the relevant service-account annotation keys from it.

Changes include:

- Configure the prefix for control-plane Flyte and artifacts service accounts.
- Configure the prefix for dataplane system and workflow service accounts.
- Evaluate control-plane service-account annotations with Helm `tpl` so templated keys render correctly.
- Update the standalone EKS Auto Mode example to use and define the shared prefix.
- Add focused control-plane and dataplane fixtures for a custom `customer.example.com` prefix.
- Update AWS fixtures to layer the canonical `values.aws.yaml` overlay.
- Document custom-prefix configuration.
- Replace stale control-plane links to deleted local AWS and GCP deployment guides.

## Compatibility

The default remains `eks.amazonaws.com`, so standard EKS deployments require no values changes.

Clusters using a custom webhook prefix can set:

```yaml
global:
  AWS_POD_IDENTITY_ANNOTATION_PREFIX: customer.example.com
```

The value should be configured in both control-plane and dataplane values when both charts use AWS IAM roles.

## Testing

- `make generate-expected`
- `make test`
  - Helm snapshot tests
  - CRD synchronization checks
  - kubeconform validation
  - image-path validation
- Directly rendered the standalone EKS Auto Mode example and verified it produces `eks.amazonaws.com/role-arn`.
- Added snapshots verifying `customer.example.com/role-arn` across control-plane and dataplane service accounts.

## Stack

This is the base of the Lunar extraction stack. Follow-up PRs will separately extract general runtime fixes, Actions fixes and snapshot hardening, and OpenShift support.

- `main` <!-- branch-stack -->
  - **feat(charts): support custom AWS identity annotation prefixes** :point\_left:
    - \#514
      - \#515
        - \#516
