### PR TITLE
fix(controlplane): harden actions chart rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ generate-expected: $(GEN_DIR) vendor-crds
 .PHONY: test
 test: check-vendored-crds helm-test kubeconform-test check-image-paths
 
+.PHONY: snapshot-generator-test
+snapshot-generator-test:
+	bash ./tests/test-atomic-render.sh
+
 # Gate on fully qualified image references. Reads the checked-in
 # tests/generated/ corpus, so it needs neither network nor helm — but that
 # means it is only as fresh as `make generate-expected`. helm-test is what
@@ -56,7 +60,7 @@ check-vendored-crds:
 	exit $${fail}
 
 .PHONY: helm-test
-helm-test: $(TMP_DIR)
+helm-test: $(TMP_DIR) snapshot-generator-test
 	./tests/run.sh helm
 
 .PHONY: kubeconform-test

--- a/charts/controlplane/templates/actions/deployment-shard.yaml
+++ b/charts/controlplane/templates/actions/deployment-shard.yaml
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/component: shard
     {{- if $isSharded }}
     shard-index: "{{ $idx }}"
-    shard-hash: {{ $hash }}
+    shard-hash: {{ $hash | quote }}
     {{- end }}
 spec:
   replicas: 1
@@ -30,7 +30,7 @@ spec:
       {{- include "actions.selectorLabels" $ | nindent 6 }}
       {{- if $isSharded }}
       shard-index: "{{ $idx }}"
-      shard-hash: {{ $hash }}
+      shard-hash: {{ $hash | quote }}
       {{- end }}
   strategy:
     type: Recreate
@@ -48,7 +48,7 @@ spec:
         app.kubernetes.io/component: shard
         {{- if $isSharded }}
         shard-index: "{{ $idx }}"
-        shard-hash: {{ $hash }}
+        shard-hash: {{ $hash | quote }}
         {{- end }}
     spec:
       {{- if $.Values.actions.spreadConstraints.enabled }}
@@ -135,13 +135,10 @@ spec:
             limits:
               memory: "64Mi"
               cpu: "100m"
+          {{- with $.Values.actions.coordination.securityContext }}
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
       containers:
         - name: {{ include "actions.name" $ }}

--- a/charts/controlplane/templates/actions/service-shard.yaml
+++ b/charts/controlplane/templates/actions/service-shard.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: shard
     {{- if $isSharded }}
     shard-index: "{{ $idx }}"
-    shard-hash: {{ $hash }}
+    shard-hash: {{ $hash | quote }}
     {{- end }}
 spec:
   type: {{ $.Values.actions.service.type }}
@@ -43,7 +43,7 @@ spec:
     {{- include "actions.selectorLabels" $ | nindent 4 }}
     {{- if $isSharded }}
     shard-index: "{{ $idx }}"
-    shard-hash: {{ $hash }}
+    shard-hash: {{ $hash | quote }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -1510,6 +1510,13 @@ actions:
     image:
       repository: docker.io/alpine/k8s
       tag: "1.32.3"
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
 
   serviceAccount:
     create: true

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -8055,7 +8055,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8075,7 +8075,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8092,7 +8092,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8112,7 +8112,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8129,7 +8129,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8149,7 +8149,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8166,7 +8166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8186,7 +8186,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8203,7 +8203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8223,7 +8223,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8240,7 +8240,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8260,7 +8260,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8277,7 +8277,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8297,7 +8297,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8314,7 +8314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8334,7 +8334,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8351,7 +8351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8371,7 +8371,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8388,7 +8388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8408,7 +8408,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9328,7 +9328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9336,7 +9336,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9352,7 +9352,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9424,12 +9424,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9512,7 +9513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9520,7 +9521,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9536,7 +9537,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9608,12 +9609,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9696,7 +9698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9704,7 +9706,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9720,7 +9722,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9792,12 +9794,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9880,7 +9883,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9888,7 +9891,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9904,7 +9907,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9976,12 +9979,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10064,7 +10068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10072,7 +10076,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10088,7 +10092,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10160,12 +10164,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10248,7 +10253,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10256,7 +10261,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10272,7 +10277,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10344,12 +10349,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10432,7 +10438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10440,7 +10446,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10456,7 +10462,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10528,12 +10534,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10616,7 +10623,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10624,7 +10631,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10640,7 +10647,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10712,12 +10719,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10800,7 +10808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10808,7 +10816,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10824,7 +10832,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10896,12 +10904,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10984,7 +10993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -10992,7 +11001,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11008,7 +11017,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11080,12 +11089,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.actions-openshift-security-context.yaml
+++ b/tests/generated/controlplane.actions-openshift-security-context.yaml
@@ -1,0 +1,1850 @@
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-0-f288b103
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "0"
+    shard-hash: "f288b103"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "0"
+      shard-hash: "f288b103"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "0"
+        shard-hash: "f288b103"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "0"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-1-f6a76bed
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "1"
+    shard-hash: "f6a76bed"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "1"
+      shard-hash: "f6a76bed"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "1"
+        shard-hash: "f6a76bed"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "1"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-2-44d51338
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "2"
+    shard-hash: "44d51338"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "2"
+      shard-hash: "44d51338"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "2"
+        shard-hash: "44d51338"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "2"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-3-0e2fc543
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "3"
+    shard-hash: "0e2fc543"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "3"
+      shard-hash: "0e2fc543"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "3"
+        shard-hash: "0e2fc543"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "3"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-4-b7f95723
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "4"
+    shard-hash: "b7f95723"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "4"
+      shard-hash: "b7f95723"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "4"
+        shard-hash: "b7f95723"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "4"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-5-3d7905f8
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "5"
+    shard-hash: "3d7905f8"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "5"
+      shard-hash: "3d7905f8"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "5"
+        shard-hash: "3d7905f8"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "5"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-6-a7e57068
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "6"
+    shard-hash: "a7e57068"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "6"
+      shard-hash: "a7e57068"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "6"
+        shard-hash: "a7e57068"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "6"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-7-a5084d4e
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "7"
+    shard-hash: "a5084d4e"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "7"
+      shard-hash: "a5084d4e"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "7"
+        shard-hash: "a5084d4e"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "7"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-8-2e085e60
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "8"
+    shard-hash: "2e085e60"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "8"
+      shard-hash: "2e085e60"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "8"
+        shard-hash: "2e085e60"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "8"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"
+---
+# Source: controlplane/templates/actions/deployment-shard.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actions-9-cf8e9eab
+  namespace: union
+  labels:
+    helm.sh/chart: controlplane-2026.8.1
+    app.kubernetes.io/name: actions
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2026.8.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: shard
+    shard-index: "9"
+    shard-hash: "cf8e9eab"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: actions
+      app.kubernetes.io/instance: release-name
+      shard-index: "9"
+      shard-hash: "cf8e9eab"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ffc0200049ba65f4995a6a0df5e37781dc3678002cf1287bfc1fe8935e8b95f7
+        kubectl.kubernetes.io/default-container: actions
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10254"
+      labels:
+        platform.union.ai/zone: "controlplane"
+        app.kubernetes.io/name: actions
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: shard
+        shard-index: "9"
+        shard-hash: "cf8e9eab"
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: actions
+              app.kubernetes.io/component: shard
+      imagePullSecrets:
+        - name: union-registry-secret
+      serviceAccountName: actions
+      volumes:
+        - name: secrets
+          secret:
+            secretName: 
+        - name: config
+          configMap:
+            name: actions
+        - name: coordination-scripts
+          configMap:
+            name: actions-coordination
+            defaultMode: 0555
+            items:
+            - key: wait-for-non-peers.sh
+              path: wait-for-non-peers.sh
+      initContainers:
+        - name: actions-migrate
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - migrate
+            - --config
+            - /etc/config/*.yaml
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+        - name: wait-for-non-peers
+          # alpine/k8s pins kubectl to the cluster's k8s minor; matches the
+          # dataplane chart's convention (see dataplane/values.yaml). Override
+          # via .Values.actions.coordination.image.{repository,tag} for air-
+          # gapped/customer-mirrored installs.
+          image: docker.io/alpine/k8s:1.32.3
+          command: ["/scripts/wait-for-non-peers.sh"]
+          env:
+          - name: SHARD_LABEL_SELECTOR
+            value: "app.kubernetes.io/component=shard,app.kubernetes.io/name=actions"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PEER_HASHES
+            valueFrom:
+              configMapKeyRef:
+                name: actions-coordination
+                key: peer-hashes
+          volumeMounts:
+          - name: coordination-scripts
+            mountPath: /scripts
+            readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000740000
+      containers:
+        - name: actions
+          image: "registry.unionai.cloud/controlplane/services:2026.8.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - actions
+            - serve
+            - --config
+            - /etc/config/*.yaml
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
+            - name: http
+              containerPort: 8089
+              protocol: TCP
+            - name: debug
+              containerPort: 10254
+              protocol: TCP
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets/union
+            - name: config
+              mountPath: /etc/config/
+          env:
+            - name: SHARD_INDEX
+              value: "9"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: debug
+            initialDelaySeconds: 3
+            periodSeconds: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: actions
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: shard
+              topologyKey: "kubernetes.io/hostname"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -8057,7 +8057,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8077,7 +8077,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8094,7 +8094,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8114,7 +8114,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8131,7 +8131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8151,7 +8151,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8168,7 +8168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8188,7 +8188,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8205,7 +8205,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8225,7 +8225,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8242,7 +8242,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8262,7 +8262,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8279,7 +8279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8299,7 +8299,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8316,7 +8316,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8336,7 +8336,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8353,7 +8353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8373,7 +8373,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8390,7 +8390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8410,7 +8410,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9330,7 +9330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9338,7 +9338,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9354,7 +9354,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9426,12 +9426,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9514,7 +9515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9522,7 +9523,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9538,7 +9539,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9610,12 +9611,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9698,7 +9700,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9706,7 +9708,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9722,7 +9724,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9794,12 +9796,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9882,7 +9885,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9890,7 +9893,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9906,7 +9909,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9978,12 +9981,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10066,7 +10070,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10074,7 +10078,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10090,7 +10094,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10162,12 +10166,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10250,7 +10255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10258,7 +10263,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10274,7 +10279,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10346,12 +10351,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10434,7 +10440,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10442,7 +10448,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10458,7 +10464,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10530,12 +10536,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10618,7 +10625,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10626,7 +10633,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10642,7 +10649,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10714,12 +10721,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10802,7 +10810,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10810,7 +10818,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10826,7 +10834,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10898,12 +10906,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10986,7 +10995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -10994,7 +11003,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11010,7 +11019,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11082,12 +11091,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.aws.custom-identity-annotation.yaml
+++ b/tests/generated/controlplane.aws.custom-identity-annotation.yaml
@@ -8290,7 +8290,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8310,7 +8310,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8327,7 +8327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8347,7 +8347,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8364,7 +8364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8384,7 +8384,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8401,7 +8401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8421,7 +8421,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8438,7 +8438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8458,7 +8458,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8475,7 +8475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8495,7 +8495,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8512,7 +8512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8532,7 +8532,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8549,7 +8549,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8569,7 +8569,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8586,7 +8586,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8606,7 +8606,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8623,7 +8623,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8643,7 +8643,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9699,7 +9699,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9707,7 +9707,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9723,7 +9723,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9795,12 +9795,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9883,7 +9884,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9891,7 +9892,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9907,7 +9908,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9979,12 +9980,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10067,7 +10069,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -10075,7 +10077,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -10091,7 +10093,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10163,12 +10165,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10251,7 +10254,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -10259,7 +10262,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -10275,7 +10278,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10347,12 +10350,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10435,7 +10439,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10443,7 +10447,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10459,7 +10463,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10531,12 +10535,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10619,7 +10624,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10627,7 +10632,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10643,7 +10648,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10715,12 +10720,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10803,7 +10809,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10811,7 +10817,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10827,7 +10833,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10899,12 +10905,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10987,7 +10994,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10995,7 +11002,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -11011,7 +11018,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11083,12 +11090,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -11171,7 +11179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -11179,7 +11187,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -11195,7 +11203,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11267,12 +11275,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -11355,7 +11364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -11363,7 +11372,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11379,7 +11388,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11451,12 +11460,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -8057,7 +8057,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8077,7 +8077,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8094,7 +8094,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8114,7 +8114,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8131,7 +8131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8151,7 +8151,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8168,7 +8168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8188,7 +8188,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8205,7 +8205,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8225,7 +8225,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8242,7 +8242,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8262,7 +8262,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8279,7 +8279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8299,7 +8299,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8316,7 +8316,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8336,7 +8336,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8353,7 +8353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8373,7 +8373,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8390,7 +8390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8410,7 +8410,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9330,7 +9330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9338,7 +9338,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9354,7 +9354,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9426,12 +9426,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9514,7 +9515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9522,7 +9523,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9538,7 +9539,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9610,12 +9611,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9698,7 +9700,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9706,7 +9708,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9722,7 +9724,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9794,12 +9796,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9882,7 +9885,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9890,7 +9893,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9906,7 +9909,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9978,12 +9981,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10066,7 +10070,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10074,7 +10078,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10090,7 +10094,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10162,12 +10166,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10250,7 +10255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10258,7 +10263,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10274,7 +10279,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10346,12 +10351,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10434,7 +10440,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10442,7 +10448,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10458,7 +10464,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10530,12 +10536,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10618,7 +10625,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10626,7 +10633,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10642,7 +10649,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10714,12 +10721,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10802,7 +10810,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10810,7 +10818,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10826,7 +10834,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10898,12 +10906,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10986,7 +10995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -10994,7 +11003,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11010,7 +11019,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11082,12 +11091,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -8089,7 +8089,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8109,7 +8109,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8126,7 +8126,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8146,7 +8146,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8163,7 +8163,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8183,7 +8183,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8200,7 +8200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8220,7 +8220,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8237,7 +8237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8257,7 +8257,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8274,7 +8274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8294,7 +8294,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8311,7 +8311,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8331,7 +8331,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8348,7 +8348,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8368,7 +8368,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8385,7 +8385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8405,7 +8405,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8422,7 +8422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8442,7 +8442,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9368,7 +9368,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9376,7 +9376,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9392,7 +9392,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9464,12 +9464,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9552,7 +9553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9560,7 +9561,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9576,7 +9577,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9648,12 +9649,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9736,7 +9738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9744,7 +9746,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9760,7 +9762,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9832,12 +9834,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9920,7 +9923,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9928,7 +9931,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9944,7 +9947,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10016,12 +10019,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10104,7 +10108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10112,7 +10116,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10128,7 +10132,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10200,12 +10204,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10288,7 +10293,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10296,7 +10301,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10312,7 +10317,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10384,12 +10389,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10472,7 +10478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10480,7 +10486,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10496,7 +10502,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10568,12 +10574,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10656,7 +10663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10664,7 +10671,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10680,7 +10687,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10752,12 +10759,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10840,7 +10848,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10848,7 +10856,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10864,7 +10872,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10936,12 +10944,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -11024,7 +11033,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -11032,7 +11041,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11048,7 +11057,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11120,12 +11129,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -8062,7 +8062,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8082,7 +8082,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8099,7 +8099,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8119,7 +8119,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8136,7 +8136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8156,7 +8156,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8173,7 +8173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8193,7 +8193,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8210,7 +8210,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8230,7 +8230,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8247,7 +8247,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8267,7 +8267,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8284,7 +8284,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8304,7 +8304,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8321,7 +8321,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8341,7 +8341,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8358,7 +8358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8378,7 +8378,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8395,7 +8395,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8415,7 +8415,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9335,7 +9335,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9343,7 +9343,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9359,7 +9359,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9431,12 +9431,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9519,7 +9520,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9527,7 +9528,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9543,7 +9544,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9615,12 +9616,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9703,7 +9705,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9711,7 +9713,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9727,7 +9729,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9799,12 +9801,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9887,7 +9890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9895,7 +9898,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9911,7 +9914,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9983,12 +9986,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10071,7 +10075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10079,7 +10083,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10095,7 +10099,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10167,12 +10171,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10255,7 +10260,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10263,7 +10268,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10279,7 +10284,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10351,12 +10356,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10439,7 +10445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10447,7 +10453,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10463,7 +10469,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10535,12 +10541,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10623,7 +10630,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10631,7 +10638,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10647,7 +10654,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10719,12 +10726,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10807,7 +10815,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10815,7 +10823,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10831,7 +10839,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10903,12 +10911,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10991,7 +11000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -10999,7 +11008,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11015,7 +11024,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11087,12 +11096,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.image-builder-bootstrap.yaml
+++ b/tests/generated/controlplane.image-builder-bootstrap.yaml
@@ -8055,7 +8055,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8075,7 +8075,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8092,7 +8092,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8112,7 +8112,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8129,7 +8129,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8149,7 +8149,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8166,7 +8166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8186,7 +8186,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8203,7 +8203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8223,7 +8223,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8240,7 +8240,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8260,7 +8260,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8277,7 +8277,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8297,7 +8297,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8314,7 +8314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8334,7 +8334,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8351,7 +8351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8371,7 +8371,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8388,7 +8388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8408,7 +8408,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9328,7 +9328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9336,7 +9336,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9352,7 +9352,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9424,12 +9424,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9512,7 +9513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9520,7 +9521,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9536,7 +9537,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9608,12 +9609,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9696,7 +9698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9704,7 +9706,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9720,7 +9722,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9792,12 +9794,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9880,7 +9883,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9888,7 +9891,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9904,7 +9907,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9976,12 +9979,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10064,7 +10068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10072,7 +10076,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10088,7 +10092,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10160,12 +10164,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10248,7 +10253,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10256,7 +10261,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10272,7 +10277,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10344,12 +10349,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10432,7 +10438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10440,7 +10446,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10456,7 +10462,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10528,12 +10534,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10616,7 +10623,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10624,7 +10631,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10640,7 +10647,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10712,12 +10719,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10800,7 +10808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10808,7 +10816,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10824,7 +10832,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10896,12 +10904,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10984,7 +10993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -10992,7 +11001,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11008,7 +11017,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11080,12 +11089,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -8055,7 +8055,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8075,7 +8075,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8092,7 +8092,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8112,7 +8112,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8129,7 +8129,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8149,7 +8149,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8166,7 +8166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8186,7 +8186,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8203,7 +8203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8223,7 +8223,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8240,7 +8240,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8260,7 +8260,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8277,7 +8277,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8297,7 +8297,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8314,7 +8314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8334,7 +8334,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8351,7 +8351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8371,7 +8371,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8388,7 +8388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8408,7 +8408,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/cacheservice/service.yaml
@@ -9328,7 +9328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9336,7 +9336,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9352,7 +9352,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9424,12 +9424,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9512,7 +9513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9520,7 +9521,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9536,7 +9537,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9608,12 +9609,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9696,7 +9698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9704,7 +9706,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9720,7 +9722,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9792,12 +9794,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9880,7 +9883,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -9888,7 +9891,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -9904,7 +9907,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9976,12 +9979,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10064,7 +10068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10072,7 +10076,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10088,7 +10092,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10160,12 +10164,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10248,7 +10253,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10256,7 +10261,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10272,7 +10277,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10344,12 +10349,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10432,7 +10438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10440,7 +10446,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10456,7 +10462,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10528,12 +10534,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10616,7 +10623,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10624,7 +10631,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10640,7 +10647,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10712,12 +10719,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10800,7 +10808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10808,7 +10816,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10824,7 +10832,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10896,12 +10904,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10984,7 +10993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -10992,7 +11001,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11008,7 +11017,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11080,12 +11089,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -8185,7 +8185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   type: ClusterIP
   ports:
@@ -8205,7 +8205,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8222,7 +8222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   type: ClusterIP
   ports:
@@ -8242,7 +8242,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8259,7 +8259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   type: ClusterIP
   ports:
@@ -8279,7 +8279,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8296,7 +8296,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   type: ClusterIP
   ports:
@@ -8316,7 +8316,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8333,7 +8333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   type: ClusterIP
   ports:
@@ -8353,7 +8353,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8370,7 +8370,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   type: ClusterIP
   ports:
@@ -8390,7 +8390,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8407,7 +8407,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   type: ClusterIP
   ports:
@@ -8427,7 +8427,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8444,7 +8444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   type: ClusterIP
   ports:
@@ -8464,7 +8464,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8481,7 +8481,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   type: ClusterIP
   ports:
@@ -8501,7 +8501,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 ---
 # Source: controlplane/templates/actions/service-shard.yaml
 apiVersion: v1
@@ -8518,7 +8518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   type: ClusterIP
   ports:
@@ -8538,7 +8538,7 @@ spec:
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 
 ---
 # Source: controlplane/templates/authz/service.yaml
@@ -9481,7 +9481,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "0"
-    shard-hash: f288b103
+    shard-hash: "f288b103"
 spec:
   replicas: 1
   selector:
@@ -9489,7 +9489,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "0"
-      shard-hash: f288b103
+      shard-hash: "f288b103"
   strategy:
     type: Recreate
   template:
@@ -9505,7 +9505,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "0"
-        shard-hash: f288b103
+        shard-hash: "f288b103"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9577,12 +9577,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9665,7 +9666,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "1"
-    shard-hash: f6a76bed
+    shard-hash: "f6a76bed"
 spec:
   replicas: 1
   selector:
@@ -9673,7 +9674,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "1"
-      shard-hash: f6a76bed
+      shard-hash: "f6a76bed"
   strategy:
     type: Recreate
   template:
@@ -9689,7 +9690,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "1"
-        shard-hash: f6a76bed
+        shard-hash: "f6a76bed"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9761,12 +9762,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -9849,7 +9851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "2"
-    shard-hash: 44d51338
+    shard-hash: "44d51338"
 spec:
   replicas: 1
   selector:
@@ -9857,7 +9859,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "2"
-      shard-hash: 44d51338
+      shard-hash: "44d51338"
   strategy:
     type: Recreate
   template:
@@ -9873,7 +9875,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "2"
-        shard-hash: 44d51338
+        shard-hash: "44d51338"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -9945,12 +9947,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10033,7 +10036,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "3"
-    shard-hash: 0e2fc543
+    shard-hash: "0e2fc543"
 spec:
   replicas: 1
   selector:
@@ -10041,7 +10044,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "3"
-      shard-hash: 0e2fc543
+      shard-hash: "0e2fc543"
   strategy:
     type: Recreate
   template:
@@ -10057,7 +10060,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "3"
-        shard-hash: 0e2fc543
+        shard-hash: "0e2fc543"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10129,12 +10132,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10217,7 +10221,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "4"
-    shard-hash: b7f95723
+    shard-hash: "b7f95723"
 spec:
   replicas: 1
   selector:
@@ -10225,7 +10229,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "4"
-      shard-hash: b7f95723
+      shard-hash: "b7f95723"
   strategy:
     type: Recreate
   template:
@@ -10241,7 +10245,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "4"
-        shard-hash: b7f95723
+        shard-hash: "b7f95723"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10313,12 +10317,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10401,7 +10406,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "5"
-    shard-hash: 3d7905f8
+    shard-hash: "3d7905f8"
 spec:
   replicas: 1
   selector:
@@ -10409,7 +10414,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "5"
-      shard-hash: 3d7905f8
+      shard-hash: "3d7905f8"
   strategy:
     type: Recreate
   template:
@@ -10425,7 +10430,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "5"
-        shard-hash: 3d7905f8
+        shard-hash: "3d7905f8"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10497,12 +10502,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10585,7 +10591,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "6"
-    shard-hash: a7e57068
+    shard-hash: "a7e57068"
 spec:
   replicas: 1
   selector:
@@ -10593,7 +10599,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "6"
-      shard-hash: a7e57068
+      shard-hash: "a7e57068"
   strategy:
     type: Recreate
   template:
@@ -10609,7 +10615,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "6"
-        shard-hash: a7e57068
+        shard-hash: "a7e57068"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10681,12 +10687,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10769,7 +10776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "7"
-    shard-hash: a5084d4e
+    shard-hash: "a5084d4e"
 spec:
   replicas: 1
   selector:
@@ -10777,7 +10784,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "7"
-      shard-hash: a5084d4e
+      shard-hash: "a5084d4e"
   strategy:
     type: Recreate
   template:
@@ -10793,7 +10800,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "7"
-        shard-hash: a5084d4e
+        shard-hash: "a5084d4e"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -10865,12 +10872,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -10953,7 +10961,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "8"
-    shard-hash: 2e085e60
+    shard-hash: "2e085e60"
 spec:
   replicas: 1
   selector:
@@ -10961,7 +10969,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "8"
-      shard-hash: 2e085e60
+      shard-hash: "2e085e60"
   strategy:
     type: Recreate
   template:
@@ -10977,7 +10985,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "8"
-        shard-hash: 2e085e60
+        shard-hash: "2e085e60"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11049,12 +11057,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"
@@ -11137,7 +11146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: shard
     shard-index: "9"
-    shard-hash: cf8e9eab
+    shard-hash: "cf8e9eab"
 spec:
   replicas: 1
   selector:
@@ -11145,7 +11154,7 @@ spec:
       app.kubernetes.io/name: actions
       app.kubernetes.io/instance: release-name
       shard-index: "9"
-      shard-hash: cf8e9eab
+      shard-hash: "cf8e9eab"
   strategy:
     type: Recreate
   template:
@@ -11161,7 +11170,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: shard
         shard-index: "9"
-        shard-hash: cf8e9eab
+        shard-hash: "cf8e9eab"
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -11233,12 +11242,13 @@ spec:
               memory: "64Mi"
               cpu: "100m"
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
       containers:
         - name: actions
           image: "registry.unionai.cloud/controlplane/services:2026.8.0"

--- a/tests/lib/atomic-render.sh
+++ b/tests/lib/atomic-render.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function render-atomically {
+  local target=$1
+  shift
+
+  local candidate
+  candidate=$(mktemp "${target}.tmp.XXXXXX")
+
+  if "$@" > "${candidate}"; then
+    mv "${candidate}" "${target}"
+  else
+    local status=$?
+    rm -f "${candidate}"
+    return "${status}"
+  fi
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,6 +10,8 @@ TMP_DIR=${SCRIPT_DIR}/tmp
 VALUES_DIR=${SCRIPT_DIR}/values
 CHARTS_DIR=${SCRIPT_DIR}/../charts
 
+source "${SCRIPT_DIR}/lib/atomic-render.sh"
+
 function generate {
   TARGET_DIR=$1
   echo "Generating test files..."
@@ -68,12 +70,12 @@ function generate {
       echo "  - Including additional helm args: ${EXTRA_HELM_ARGS}"
     fi
 
-    helm template ${CHARTS_DIR}/${CHART} \
+    render-atomically "${TARGET_DIR}/${OUTPUT}" helm template ${CHARTS_DIR}/${CHART} \
       --namespace union \
       --kube-version 1.32.0 \
       ${ADDITIONAL_VALUES} \
       ${EXTRA_HELM_ARGS} \
-      --values ${file} > ${TARGET_DIR}/${OUTPUT}
+      --values ${file}
   done
 }
 

--- a/tests/test-atomic-render.sh
+++ b/tests/test-atomic-render.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/lib/atomic-render.sh"
+
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/helm-charts-atomic-render.XXXXXX")
+trap 'rm -rf "${TEST_DIR}"' EXIT
+TARGET="${TEST_DIR}/snapshot.yaml"
+
+function fail-after-partial-output {
+  printf 'partial output\n'
+  return 42
+}
+
+function render-complete-output {
+  printf 'complete output\n'
+}
+
+printf 'existing snapshot\n' > "${TARGET}"
+
+if render-atomically "${TARGET}" fail-after-partial-output; then
+  echo "expected the failing render to return non-zero"
+  exit 1
+else
+  status=$?
+fi
+
+if [[ ${status} -ne 42 ]]; then
+  echo "expected render exit status 42, got ${status}"
+  exit 1
+fi
+
+if [[ $(<"${TARGET}") != "existing snapshot" ]]; then
+  echo "failing render changed the existing snapshot"
+  exit 1
+fi
+
+if compgen -G "${TARGET}.tmp.*" > /dev/null; then
+  echo "failing render left a temporary file"
+  exit 1
+fi
+
+render-atomically "${TARGET}" render-complete-output
+
+if [[ $(<"${TARGET}") != "complete output" ]]; then
+  echo "successful render did not replace the snapshot"
+  exit 1
+fi
+
+echo "atomic render tests passed"

--- a/tests/values/controlplane.actions-openshift-security-context.yaml
+++ b/tests/values/controlplane.actions-openshift-security-context.yaml
@@ -1,0 +1,37 @@
+# helm-args: --show-only templates/actions/deployment-shard.yaml
+global:
+  UNION_HOST: "test.example.com"
+  UNION_ORG: "test-org"
+  INTERNAL_CLIENT_ID: "test-internal-client-id"
+  AUTH_TOKEN_URL: "https://test.example.com/oauth2/v1/token"
+
+dbHost: "db-instance-url"
+dbName: "dbName"
+dbUser: "dbUser"
+dbPass: "dbPass"
+bucketName: "bucketName"
+artifactsBucketName: "artifactsBucketName"
+
+configMap:
+  connection:
+    environment: staging
+    region: us-east-2
+    rootTenantURLPattern: dns:///fake-host.domain
+  controlplane:
+    enabled: true
+
+flyte:
+  configmap:
+    adminServer:
+      connection:
+        rootTenantURLPattern: dns:///fake-host.domain
+
+actions:
+  coordination:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000740000
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]


### PR DESCRIPTION
## Overview

Makes sharded Actions deployments more portable and Helm snapshot generation safer.

- Adds `actions.coordination.securityContext` so the coordination init container can run with deployment-specific security settings, including dynamically assigned UIDs.
- Quotes shard-hash labels and selectors so they consistently render as strings.
- Adds focused coverage for overriding the Actions coordination security context.
- Generates snapshots through temporary files and replaces checked-in output only after Helm succeeds.
- Adds a regression test verifying failed renders preserve the existing snapshot and propagate the original exit status.

## Testing

- `make generate-expected`
- `make test`
- `make snapshot-generator-test`
- `bash -n tests/run.sh tests/lib/atomic-render.sh tests/test-atomic-render.sh`
- `git diff --check`

## Stack

- `main` <!-- branch-stack -->
  - **fix(controlplane): harden actions chart rendering** :point\_left:
    - \#516
