### PR TITLE
Remove duplicate container

### DIFF
--- a/charts/dataplane/templates/_storage.tpl
+++ b/charts/dataplane/templates/_storage.tpl
@@ -85,8 +85,13 @@ the stow based options to provide additional configuration flexibility.
 {{- end }}
 
 {{- define "storage" -}}
+{{- /* A custom provider block may carry its own container key; rendering the default alongside it would emit a
+       duplicate mapping key, which strict YAML parsers reject. The custom value wins. */}}
+{{- $customHasContainer := and (eq .Values.storage.provider "custom") (hasKey (default dict .Values.storage.custom) "container") -}}
 storage:
+{{- if not $customHasContainer }}
   container: {{ tpl .Values.storage.bucketName . | quote }}
+{{- end }}
 {{- include "storage.base" . }}
   enable-multicontainer: {{ .Values.storage.enableMultiContainer }}
   limits:
@@ -97,8 +102,11 @@ storage:
 {{- end }}
 
 {{- define "fast-registration-storage" -}}
+{{- $customHasContainer := and (eq .Values.storage.provider "custom") (hasKey (default dict .Values.storage.custom) "container") -}}
 fastRegistrationStorage:
+{{- if not $customHasContainer }}
   container: {{ .Values.storage.fastRegistrationBucketName | quote}}
+{{- end }}
 {{- include "storage.base" .}}
 {{- end }}
 

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -274,7 +274,6 @@ metadata:
 data:
   storage.yaml: | 
     storage:
-      container: "test-metadata-container"
       container: 'test-metadata-container'
       stow:
         config:
@@ -541,7 +540,6 @@ data:
           key: kubernetes.azure.com/scalesetpriority
           operator: DoesNotExist
     storage:
-      container: "test-metadata-container"
       container: 'test-metadata-container'
       stow:
         config:
@@ -2288,7 +2286,6 @@ data:
       rootTenantURLPattern: 'dns:///test.dataplane.union.ai'
   storage.yaml: | 
     storage:
-      container: "test-metadata-container"
       container: 'test-metadata-container'
       stow:
         config:
@@ -2303,7 +2300,6 @@ data:
         target_gc_percent: 70
   fast_registration_storage.yaml: | 
     fastRegistrationStorage:
-      container: ""
       container: 'test-metadata-container'
       stow:
         config:
@@ -6199,7 +6195,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "d0bb0b54b8b1935a3a1697039fa50ecb701a5437cd4307fec7a8acedb0a30a6"
+        configChecksum: "7257a03afbf2e65862fe323073908cfadd1a155bb7254d38a95c6991625ceab"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6306,7 +6302,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "483d6b5a07262b9916400b70284e43266e5ae8dfa1534c2d7405e5fdbd78829"
+        configChecksum: "ff482cbda9e86db6abf4ab84a171abb3f032f671b55a6088d1f3218f2e0a59c"
         
       labels:
         
@@ -6445,7 +6441,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "483d6b5a07262b9916400b70284e43266e5ae8dfa1534c2d7405e5fdbd78829"
+        configChecksum: "ff482cbda9e86db6abf4ab84a171abb3f032f671b55a6088d1f3218f2e0a59c"
         
       labels:
         
@@ -6573,7 +6569,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "d0bb0b54b8b1935a3a1697039fa50ecb701a5437cd4307fec7a8acedb0a30a6"
+        configChecksum: "7257a03afbf2e65862fe323073908cfadd1a155bb7254d38a95c6991625ceab"
         
     spec:
       securityContext:

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -238,7 +238,6 @@ metadata:
 data:
   storage.yaml: | 
     storage:
-      container: ""
       container: 'test-metadata-container'
       stow:
         config:
@@ -505,7 +504,6 @@ data:
           key: kubernetes.azure.com/scalesetpriority
           operator: DoesNotExist
     storage:
-      container: ""
       container: 'test-metadata-container'
       stow:
         config:
@@ -2252,7 +2250,6 @@ data:
       rootTenantURLPattern: 'dns:///test.dataplane.union.ai'
   storage.yaml: | 
     storage:
-      container: ""
       container: 'test-metadata-container'
       stow:
         config:
@@ -2267,7 +2264,6 @@ data:
         target_gc_percent: 70
   fast_registration_storage.yaml: | 
     fastRegistrationStorage:
-      container: ""
       container: 'test-metadata-container'
       stow:
         config:
@@ -6019,7 +6015,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "61b499b3eacd98749e1bbc89502de624c0ce2814deef653689a83e8013bc710"
+        configChecksum: "8672ad834305df393a5971e86f62ed9e24288f2e3199c1ac3057e47581f218e"
         
       labels:
         platform.union.ai/zone: "dataplane"
@@ -6126,7 +6122,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a2e1109e5a877a92bf7f9b028fbaa7a2d1ae991a434032c8ddabd4d917d1daa"
+        configChecksum: "af8f5257fb21b05f0bc307f864f03fcd847bfb823a42e2ac04cc0d3244e86b4"
         
       labels:
         
@@ -6265,7 +6261,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a2e1109e5a877a92bf7f9b028fbaa7a2d1ae991a434032c8ddabd4d917d1daa"
+        configChecksum: "af8f5257fb21b05f0bc307f864f03fcd847bfb823a42e2ac04cc0d3244e86b4"
         
       labels:
         
@@ -6393,7 +6389,7 @@ spec:
         platform.union.ai/service-group: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
-        configChecksum: "61b499b3eacd98749e1bbc89502de624c0ce2814deef653689a83e8013bc710"
+        configChecksum: "8672ad834305df393a5971e86f62ed9e24288f2e3199c1ac3057e47581f218e"
         
     spec:
       securityContext:


### PR DESCRIPTION
The dataplane chart renders `storage.container` twice when `storage.provider: custom` supplies its own `container` (as `values.azure.yaml` does): once hardcoded from `bucketName`, and once inside the `toYaml` of the custom block. Older service images parsed YAML last-key-wins, so the custom value silently won. Current images (viper 1.21 / yaml.v3) treat duplicate mapping keys as fatal — on azure dataplanes, leaseworker, operator, operator-proxy, and pod-webhook all crashloop with `mapping key "container" already defined`.

Fix: when the custom block carries `container`, skip rendering the default line — the custom value stays the single source of the key, matching what the old parser resolved. Applied to both `storage` and `fastRegistrationStorage` (where the default previously rendered an empty `""` shadow of the real value).

Verified by rendering the chart with azure values and running a duplicate-key scan over every generated ConfigMap: clean. Golden tests regenerated.

Follow-up from https://github.com/unionai/cloud/pull/17428
