### PR TITLE
integration-checks: k3d on every PR, cloud legs on release PRs

### DIFF
--- a/.github/workflows/integration-checks.yaml
+++ b/.github/workflows/integration-checks.yaml
@@ -1,11 +1,13 @@
-# Install a release PR's candidate charts onto standing canary clusters and gate on
-# health. Auth, clusters, and config are provisioned by the ci_deployer terraform in
+# Install a PR's candidate charts onto standing canary clusters and gate on health.
+# Auth, clusters, and config are provisioned by the ci_deployer terraform in
 # cloud (infra/terraform/envs/canary/helm-charts-ci).
 name: Integration Checks
 
 on:
-  # Run on every PR to main, and when a label is added (so a maintainer can add
-  # `run-integration-tests` to any PR); the cheap classify job gates the matrix.
+  # Run on every PR to main. The classify job now runs the integration matrix on
+  # every PR (we have idle canary compute); it still flags release PRs for the
+  # discipline guardrails. `labeled` + force dispatch stay for the revert-to-
+  # release-only path documented in classify.
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
@@ -20,7 +22,7 @@ permissions:
   contents: read
 
 jobs:
-  # ── Classify: a release PR / run-integration-tests label / force dispatch → real-cluster integration ──
+  # ── Classify: runs the integration matrix on every PR (see should_run); flags release PRs for guardrails ──
   classify:
     name: Classify PR (release vs non-release)
     runs-on: ubuntu-latest
@@ -48,11 +50,18 @@ jobs:
           # A maintainer can add the run-integration-tests label to any PR to run the suite.
           label_run=false
           case ",${LABELS:-}," in *,run-integration-tests,*) label_run=true ;; esac
-          # is_release = a genuine release PR; should_run = release PR, label, or forced dispatch.
+          # is_release = a genuine release PR (kept for the guardrail warnings below).
           is_release=false
           [[ "$chart_bump" == true || "$title_release" == true ]] && is_release=true
-          should_run=false
-          [[ "$is_release" == true || "$label_run" == true || "$FORCE" == "true" ]] && should_run=true
+
+          # Run the integration matrix on EVERY PR — we have idle canary compute and
+          # catching deploy/config regressions early is worth it. External PRs are still
+          # gated by GitHub's native "require approval for all external contributors"
+          # before any workflow runs; Union-member PRs run automatically.
+          should_run=true
+          # To restrict back to release PRs only, replace the line above with:
+          #   should_run=false
+          #   [[ "$is_release" == true || "$label_run" == true || "$FORCE" == "true" ]] && should_run=true
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
           echo "chart_bump=$chart_bump title_release=$title_release label=$label_run force=${FORCE:-} is_release=$is_release -> should_run=$should_run"
 
@@ -324,6 +333,20 @@ jobs:
       #    per leg on the shared tenant). ──
       - name: Setup Routing
         run: python .github/ci-scripts/integration_ops.py setup-routing
+
+      # ── Console links to inspect this leg's runs + apps (handy when a run fails).
+      #    Emitted as an annotation + in the job summary. project == cluster name;
+      #    the smoke suite runs in the development domain. ──
+      - name: Inspect links (runs + apps)
+        if: always() && env.CONTROL_PLANE_URL != '' && env.CLUSTER_NAME != ''
+        run: |
+          base="${CONTROL_PLANE_URL}/v2/domain/development/project/${CLUSTER_NAME}"
+          echo "::notice title=Inspect ${{ matrix.topology }}/${{ matrix.cloud }}::runs: $base/runs | apps: $base/apps"
+          {
+            echo "### 🔎 Inspect \`${{ matrix.topology }}/${{ matrix.cloud }}\` (project \`${CLUSTER_NAME}\`)"
+            echo "- [Runs]($base/runs)"
+            echo "- [Apps]($base/apps)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # ── Selfhosted only: register the build-image task and route the system project
       #    to this DP so the remote image builder works. The managed tenant (selfmanaged

--- a/.github/workflows/integration-checks.yaml
+++ b/.github/workflows/integration-checks.yaml
@@ -4,10 +4,9 @@
 name: Integration Checks
 
 on:
-  # Run on every PR to main. The classify job now runs the integration matrix on
-  # every PR (we have idle canary compute); it still flags release PRs for the
-  # discipline guardrails. `labeled` + force dispatch stay for the revert-to-
-  # release-only path documented in classify.
+  # Run on every PR to main. classify builds the matrix: the self-contained k3d leg
+  # runs on every PR; the contract-dependent cloud legs run only on release PRs (or a
+  # `run-integration-tests` label / force dispatch). See classify for the rationale.
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
@@ -22,12 +21,12 @@ permissions:
   contents: read
 
 jobs:
-  # ── Classify: runs the integration matrix on every PR (see should_run); flags release PRs for guardrails ──
+  # ── Classify: builds the matrix (k3d every PR; cloud legs on release PRs) + flags release PRs for guardrails ──
   classify:
     name: Classify PR (release vs non-release)
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.detect.outputs.should_run }}
+      matrix: ${{ steps.detect.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,16 +53,32 @@ jobs:
           is_release=false
           [[ "$chart_bump" == true || "$title_release" == true ]] && is_release=true
 
-          # Run the integration matrix on EVERY PR — we have idle canary compute and
-          # catching deploy/config regressions early is worth it. External PRs are still
-          # gated by GitHub's native "require approval for all external contributors"
-          # before any workflow runs; Union-member PRs run automatically.
-          should_run=true
-          # To restrict back to release PRs only, replace the line above with:
-          #   should_run=false
-          #   [[ "$is_release" == true || "$label_run" == true || "$FORCE" == "true" ]] && should_run=true
-          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
-          echo "chart_bump=$chart_bump title_release=$title_release label=$label_run force=${FORCE:-} is_release=$is_release -> should_run=$should_run"
+          # Build the matrix. k3d is self-contained (installs the PR's own
+          # values.k3d.yaml), so it runs on EVERY PR. The cloud legs install the S3
+          # config contract, which is only refreshed post-merge by the
+          # selfmanaged-tf-canary-fanout — so they run only on release PRs (clean
+          # version/appVersion bumps that don't touch overlays). This keeps overlay
+          # changes flowing through normal PRs (k3d-validated) into main, where the
+          # contract refreshes, and keeps release PRs minimal.
+          run_cloud=false
+          [[ "$is_release" == true || "$label_run" == true || "$FORCE" == "true" ]] && run_cloud=true
+
+          k3d_leg='{"topology":"selfmanaged-dp","cloud":"k3d","charts":"dataplane","crd_dirs":"dataplane","namespaces":"dataplane","kctx":"k3d-ci-dataplane"}'
+          cloud_legs='[
+            {"topology":"selfmanaged-dp","cloud":"aws","charts":"dataplane","crd_dirs":"dataplane kube-prometheus-stack","kctx":"self-dp-helm-charts-ci-sm-aws-dp-1"},
+            {"topology":"selfmanaged-dp","cloud":"gcp","charts":"dataplane","crd_dirs":"dataplane kube-prometheus-stack","kctx":"self-dp-helm-charts-ci-sm-gcp-dp-1"},
+            {"topology":"selfmanaged-dp","cloud":"azure","charts":"dataplane","crd_dirs":"dataplane kube-prometheus-stack","kctx":"self-dp-helm-charts-ci-sm-azure-dp-1"},
+            {"topology":"selfhosted","cloud":"aws","charts":"controlplane dataplane","crd_dirs":"dataplane kube-prometheus-stack scylla-operator envoy-gateway","kctx":"self-cp-helm-charts-ci-cp-aws"},
+            {"topology":"selfhosted","cloud":"gcp","charts":"controlplane dataplane","crd_dirs":"dataplane kube-prometheus-stack scylla-operator envoy-gateway","kctx":"self-cp-helm-charts-ci-cp-gcp"}
+          ]'
+          if [[ "$run_cloud" == true ]]; then
+            include=$(jq -c -n --argjson k "$k3d_leg" --argjson c "$cloud_legs" '[$k] + $c')
+          else
+            include=$(jq -c -n --argjson k "$k3d_leg" '[$k]')
+          fi
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+          echo "chart_bump=$chart_bump title_release=$title_release label=$label_run force=${FORCE:-} is_release=$is_release run_cloud=$run_cloud"
+          echo "matrix include: $include"
 
           # Soft guardrails: nudge release PRs toward clean version bumps.
           if [[ "$is_release" == true ]]; then
@@ -81,7 +96,6 @@ jobs:
   integration:
     name: ${{ matrix.topology }}/${{ matrix.cloud }}
     needs: classify
-    if: needs.classify.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: helm-charts-ci   # pins the OIDC subject; no required reviewers (see ci_github.tf)
@@ -93,17 +107,9 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # One leg per standing cluster; each chart installs into its own namespace
-          # (= chart name). crd_dirs = CRDs to apply; kctx = kubectl context to inspect it.
-          - { topology: selfmanaged-dp, cloud: aws,   charts: "dataplane",              crd_dirs: "dataplane kube-prometheus-stack",                            kctx: self-dp-helm-charts-ci-sm-aws-dp-1 }
-          - { topology: selfmanaged-dp, cloud: gcp,   charts: "dataplane",              crd_dirs: "dataplane kube-prometheus-stack",                            kctx: self-dp-helm-charts-ci-sm-gcp-dp-1 }
-          - { topology: selfmanaged-dp, cloud: azure, charts: "dataplane",              crd_dirs: "dataplane kube-prometheus-stack",                            kctx: self-dp-helm-charts-ci-sm-azure-dp-1 }
-          - { topology: selfhosted,     cloud: aws,   charts: "controlplane dataplane", crd_dirs: "dataplane kube-prometheus-stack scylla-operator envoy-gateway", kctx: self-cp-helm-charts-ci-cp-aws }
-          - { topology: selfhosted,     cloud: gcp,   charts: "controlplane dataplane", crd_dirs: "dataplane kube-prometheus-stack scylla-operator envoy-gateway", kctx: self-cp-helm-charts-ci-cp-gcp }
-          # k3d: an ephemeral DP created on the runner.
-          - { topology: selfmanaged-dp, cloud: k3d,   charts: "dataplane",              crd_dirs: "dataplane",                                                  namespaces: "dataplane", kctx: k3d-ci-dataplane }
+      # Legs are computed by the classify job: k3d always (self-contained), the
+      # contract-dependent cloud legs only on release PRs. One job per include entry.
+      matrix: ${{ fromJSON(needs.classify.outputs.matrix) }}
     env:
       HELM_VERSION: "v4.2.3"
       CONTRACT_BUCKET: ${{ vars.HELM_CHARTS_CI_CONTRACT_BUCKET }}


### PR DESCRIPTION
## Overview

`classify` now builds the integration matrix **dynamically**, so each leg runs where it's actually meaningful:

- **k3d — every PR.** Self-contained: it installs the PR's own `charts/dataplane/values.k3d.yaml` (no external contract), so it validates the PR's templates **and overlay** directly and can never stall on the config contract.
- **Cloud legs (selfmanaged aws/gcp/azure + selfhosted aws/gcp) — release PRs only** (or a `run-integration-tests` label / `workflow_dispatch force`). They install the **S3 config contract**, which is refreshed only **post-merge** by `selfmanaged-tf-canary-fanout`.

**Why the split (avoids a real deadlock).** A PR that edits `values.<cloud>.yaml` can't be validated by the cloud legs pre-merge — the contract still reflects `main`. Worse, a *coupled* overlay+template change would fail the cloud legs against the stale contract, and if that check were ever required, you couldn't merge to refresh the contract → deadlock. Restricting the cloud legs to release PRs (clean version/appVersion bumps that don't touch overlays) sidesteps this: overlay changes flow through normal PRs (k3d-validated) → `main` → the fan-out refreshes the contract, and **release PRs stay minimal**.

> Keep the integration matrix **advisory** (not a required status check). If a hard pre-merge gate is ever wanted, gate on the **k3d** leg only — it's self-contained and can't deadlock on the contract.

## Security posture — recently changed, still holds

Access control moved **off the custom gate and onto GitHub-native settings**:

- **Before:** the `helm-charts-ci-gate` App (a custom deployment-protection rule) auto-approved `unionai/all-eng` members and auto-rejected everyone else — after the job started, before the OIDC token minted.
- **Now:** GitHub's native **"Require approval for all external contributors"** (`all_external_contributors`, already enabled) gates external PRs at the **workflow** level — nothing runs, and no OIDC token mints, until a maintainer approves. The custom App + rule is removed in cloud #17523.

Untrusted PR code still can't reach the cluster-admin OIDC token / long-lived `FLYTE_API_KEY` — and external PRs now need an explicit human approve-and-run (stronger than the old membership auto-approve). Union-member PRs run automatically. The workflow keeps `environment: helm-charts-ci` (pins the OIDC subject).

## Console inspect links

After Setup Routing, each leg emits its Union console **runs** + **apps** links (a `::notice::` annotation + job summary), built from the leg's own `CONTROL_PLANE_URL` + `CLUSTER_NAME` so the host is correct per topology:
- selfhosted/aws → `helm-charts-ci-cp-aws.sh-c-us-east-2.unionai.cloud`
- selfhosted/gcp → `helm-charts-ci-cp-gcp.sh-c-us-east-2.unionai.cloud`
- selfmanaged / k3d → `helm-charts-ci.canary.unionai.cloud`

## Test Plan

- `yaml.safe_load` passes; matrix JSON dry-run confirms k3d-only on non-release, k3d + 5 cloud legs on release.
- On this PR (non-release): only the k3d leg runs; its summary shows the Runs/Apps links.

Ref FAB-430 (gate removal, cloud #17523).