### PR TITLE
Release 2026.8.1

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -3,7 +3,7 @@ name: controlplane
 description: Deploys the Union controlplane components to onboard a kubernetes cluster to the Union Cloud
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.8.0
+version: 2026.8.1
 appVersion: 2026.8.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/controlplane/RELEASE.md
+++ b/charts/controlplane/RELEASE.md
@@ -1,5 +1,9 @@
 # controlplane — Release Notes
 
+## 2026.8.1
+
+Adding redis-consumer service to control plane ([#525](https://github.com/unionai/helm-charts/pull/525)).
+
 ## 2026.8.0
 
 Chart-only release: `version` moves `2026.7.2` → `2026.8.0` while `appVersion` stays

--- a/charts/dataplane-crds/Chart.yaml
+++ b/charts/dataplane-crds/Chart.yaml
@@ -10,7 +10,7 @@ description: 'DEPRECATED. Use `crds/flyte-v1/` for FlyteWorkflow and `crds/kube-
 deprecated: true
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.8.0
+version: 2026.8.1
 appVersion: 2026.7.2
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane-crds/RELEASE.md
+++ b/charts/dataplane-crds/RELEASE.md
@@ -1,5 +1,10 @@
 # dataplane-crds — Release Notes
 
+## 2026.8.1
+
+Lockstep `version` bump with the `dataplane` chart (`2026.8.0` -> `2026.8.1`).
+No CRD changes in this release.
+
 ## 2026.8.0
 
 Lockstep `version` bump with the `dataplane` chart (`2026.7.2` → `2026.8.0`);

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -3,7 +3,7 @@ name: dataplane
 description: Deploys the Union dataplane components to onboard a kubernetes cluster to the Union Cloud.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.8.0
+version: 2026.8.1
 appVersion: 2026.8.0
 kubeVersion: '>= 1.28.0-0'
 dependencies:

--- a/charts/dataplane/RELEASE.md
+++ b/charts/dataplane/RELEASE.md
@@ -1,5 +1,10 @@
 # dataplane — Release Notes
 
+## 2026.8.1
+
+Lockstep `version` bump with the `controlplane` chart (`2026.8.0` -> `2026.8.1`).
+No data-plane chart changes in this release.
+
 ## 2026.8.0
 
 Chart-only release: `version` moves `2026.7.2` → `2026.8.0` while `appVersion` stays

--- a/charts/knative-migration/Chart.yaml
+++ b/charts/knative-migration/Chart.yaml
@@ -13,6 +13,6 @@ description: 'One-shot cleanup of knative-operator residue (stuck KnativeServing
   '
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.8.0
+version: 2026.8.1
 appVersion: 0.1.0
 kubeVersion: '>= 1.28.0-0'

--- a/charts/knative-migration/RELEASE.md
+++ b/charts/knative-migration/RELEASE.md
@@ -2,6 +2,11 @@
 
 `appVersion` tracks the migration tool's own `0.1.0`, not the control-plane / data-plane image tag.
 
+## 2026.8.1
+
+Lockstep `version` bump with the `controlplane` / `dataplane` charts (`2026.8.0` -> `2026.8.1`).
+No migration-tool or template changes.
+
 ## 2026.8.0
 
 Lockstep `version` bump with the `controlplane` / `dataplane` charts (`2026.7.2` →

--- a/charts/sandbox/Chart.yaml
+++ b/charts/sandbox/Chart.yaml
@@ -3,6 +3,6 @@ name: sandbox
 description: Deploys extras for sandbox testing.
 type: application
 icon: https://i.ibb.co/JxfDQsL/Union-Symbol-yellow-2.png
-version: 2026.8.0
+version: 2026.8.1
 appVersion: 2026.7.2
 kubeVersion: '>= 1.28.0'

--- a/charts/sandbox/RELEASE.md
+++ b/charts/sandbox/RELEASE.md
@@ -1,5 +1,9 @@
 # sandbox — Release Notes
 
+## 2026.8.1
+
+Lockstep `version` bump (`2026.8.0` -> `2026.8.1`). No sandbox chart changes in this release.
+
 ## 2026.8.0
 
 Lockstep `version` bump (`2026.7.2` → `2026.8.0`); `appVersion` stays `2026.7.2`, so the

--- a/tests/generated/controlplane.actions-leasor.yaml
+++ b/tests/generated/controlplane.actions-leasor.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -245,7 +245,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -507,7 +507,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -610,7 +610,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -684,7 +684,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1373,7 +1373,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1407,7 +1407,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1762,7 +1762,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1830,7 +1830,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1929,7 +1929,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2020,7 +2020,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2212,7 +2212,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2328,7 +2328,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2412,7 +2412,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2503,7 +2503,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2588,7 +2588,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2783,7 +2783,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2799,7 +2799,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7751,7 +7751,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7774,7 +7774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7827,7 +7827,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7851,7 +7851,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8014,7 +8014,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8048,7 +8048,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8085,7 +8085,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8122,7 +8122,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8159,7 +8159,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8196,7 +8196,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8233,7 +8233,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8270,7 +8270,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8307,7 +8307,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8344,7 +8344,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8381,7 +8381,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8421,7 +8421,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8449,7 +8449,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8478,7 +8478,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8517,7 +8517,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8556,7 +8556,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8591,7 +8591,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8626,7 +8626,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8661,7 +8661,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8696,7 +8696,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8735,7 +8735,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8770,7 +8770,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9321,7 +9321,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9505,7 +9505,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9689,7 +9689,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9873,7 +9873,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10057,7 +10057,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10241,7 +10241,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10425,7 +10425,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10609,7 +10609,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10793,7 +10793,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10977,7 +10977,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11162,7 +11162,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11180,9 +11180,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11291,7 +11291,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11302,7 +11302,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a17aa10a4809c842a0561cdb6f4c8289c7733db2ead0fa4cf8ee98966fba637"
+        configChecksum: "c1e24cfe7d4180b497e542b20785ce48a181d8dd85cca5b25d95da0e0f15ce6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11311,7 +11311,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11404,7 +11404,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11475,7 +11475,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11590,7 +11590,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11721,7 +11721,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11833,7 +11833,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11961,7 +11961,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12076,7 +12076,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12202,7 +12202,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12349,7 +12349,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12478,7 +12478,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12628,7 +12628,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.aws.billing-enable.yaml
+++ b/tests/generated/controlplane.aws.billing-enable.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -137,7 +137,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -161,7 +161,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -197,7 +197,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -209,7 +209,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -247,7 +247,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -509,7 +509,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -612,7 +612,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -686,7 +686,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1375,7 +1375,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1409,7 +1409,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1764,7 +1764,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1832,7 +1832,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1931,7 +1931,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2022,7 +2022,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2214,7 +2214,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2330,7 +2330,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2414,7 +2414,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2505,7 +2505,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2590,7 +2590,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2785,7 +2785,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2801,7 +2801,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7753,7 +7753,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7776,7 +7776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7829,7 +7829,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7853,7 +7853,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8016,7 +8016,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8050,7 +8050,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8087,7 +8087,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8124,7 +8124,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8161,7 +8161,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8198,7 +8198,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8235,7 +8235,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8272,7 +8272,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8309,7 +8309,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8346,7 +8346,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8383,7 +8383,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8423,7 +8423,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8451,7 +8451,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8480,7 +8480,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8519,7 +8519,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8558,7 +8558,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8593,7 +8593,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8628,7 +8628,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8663,7 +8663,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8698,7 +8698,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8737,7 +8737,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8772,7 +8772,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9323,7 +9323,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9507,7 +9507,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9691,7 +9691,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9875,7 +9875,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10059,7 +10059,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10243,7 +10243,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10427,7 +10427,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10611,7 +10611,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10795,7 +10795,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10979,7 +10979,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11164,7 +11164,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11182,9 +11182,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11293,7 +11293,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11304,7 +11304,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a17aa10a4809c842a0561cdb6f4c8289c7733db2ead0fa4cf8ee98966fba637"
+        configChecksum: "c1e24cfe7d4180b497e542b20785ce48a181d8dd85cca5b25d95da0e0f15ce6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11313,7 +11313,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11406,7 +11406,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11477,7 +11477,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11592,7 +11592,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11723,7 +11723,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11835,7 +11835,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11963,7 +11963,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12078,7 +12078,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12204,7 +12204,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12351,7 +12351,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12480,7 +12480,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12630,7 +12630,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.aws.yaml
+++ b/tests/generated/controlplane.aws.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -137,7 +137,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -161,7 +161,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -197,7 +197,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -209,7 +209,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -247,7 +247,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -509,7 +509,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -612,7 +612,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -686,7 +686,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1375,7 +1375,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1409,7 +1409,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1764,7 +1764,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1832,7 +1832,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1931,7 +1931,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2022,7 +2022,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2214,7 +2214,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2330,7 +2330,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2414,7 +2414,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2505,7 +2505,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2590,7 +2590,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2785,7 +2785,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2801,7 +2801,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7753,7 +7753,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7776,7 +7776,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7829,7 +7829,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7853,7 +7853,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8016,7 +8016,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8050,7 +8050,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8087,7 +8087,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8124,7 +8124,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8161,7 +8161,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8198,7 +8198,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8235,7 +8235,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8272,7 +8272,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8309,7 +8309,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8346,7 +8346,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8383,7 +8383,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8423,7 +8423,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8451,7 +8451,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8480,7 +8480,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8519,7 +8519,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8558,7 +8558,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8593,7 +8593,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8628,7 +8628,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8663,7 +8663,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8698,7 +8698,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8737,7 +8737,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8772,7 +8772,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9323,7 +9323,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9507,7 +9507,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9691,7 +9691,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9875,7 +9875,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10059,7 +10059,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10243,7 +10243,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10427,7 +10427,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10611,7 +10611,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10795,7 +10795,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10979,7 +10979,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11164,7 +11164,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11182,9 +11182,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11293,7 +11293,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11304,7 +11304,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a17aa10a4809c842a0561cdb6f4c8289c7733db2ead0fa4cf8ee98966fba637"
+        configChecksum: "c1e24cfe7d4180b497e542b20785ce48a181d8dd85cca5b25d95da0e0f15ce6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11314,7 +11314,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11407,7 +11407,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11479,7 +11479,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11595,7 +11595,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11727,7 +11727,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11840,7 +11840,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11969,7 +11969,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12085,7 +12085,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12212,7 +12212,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12360,7 +12360,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12490,7 +12490,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12635,7 +12635,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.custom-oidc.yaml
+++ b/tests/generated/controlplane.custom-oidc.yaml
@@ -95,7 +95,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -111,7 +111,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
   annotations: 
     eks.amazonaws.com/role-arn: ''
@@ -125,7 +125,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -163,7 +163,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -175,7 +175,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -187,7 +187,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -199,7 +199,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -223,7 +223,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -235,7 +235,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -249,7 +249,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -520,7 +520,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -623,7 +623,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -697,7 +697,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1386,7 +1386,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1420,7 +1420,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1775,7 +1775,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1850,7 +1850,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1949,7 +1949,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2040,7 +2040,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2232,7 +2232,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2348,7 +2348,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2443,7 +2443,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2534,7 +2534,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2619,7 +2619,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2814,7 +2814,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2830,7 +2830,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7785,7 +7785,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7808,7 +7808,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7861,7 +7861,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7885,7 +7885,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8048,7 +8048,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8082,7 +8082,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8119,7 +8119,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8156,7 +8156,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8193,7 +8193,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8230,7 +8230,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8267,7 +8267,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8304,7 +8304,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8341,7 +8341,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8378,7 +8378,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8415,7 +8415,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8455,7 +8455,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8483,7 +8483,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8512,7 +8512,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8551,7 +8551,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8590,7 +8590,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8625,7 +8625,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8660,7 +8660,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8695,7 +8695,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8730,7 +8730,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8769,7 +8769,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8804,7 +8804,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9361,7 +9361,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9545,7 +9545,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9729,7 +9729,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9913,7 +9913,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10097,7 +10097,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10281,7 +10281,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10465,7 +10465,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10649,7 +10649,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10833,7 +10833,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11017,7 +11017,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11202,7 +11202,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11220,9 +11220,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11331,7 +11331,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11342,7 +11342,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "6b163d24f7c0f173d85c15f4e6a55a89e370012c4df26bfa60a6ceed15a4134"
+        configChecksum: "b34f43030b6efc4359b5ad3041f8bafdde5b7678a286ea4ff8c0ef24059b8fe"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11351,7 +11351,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11444,7 +11444,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11515,7 +11515,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11630,7 +11630,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11761,7 +11761,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11873,7 +11873,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12001,7 +12001,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12138,7 +12138,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12264,7 +12264,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12411,7 +12411,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12540,7 +12540,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12690,7 +12690,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.external-authz.yaml
+++ b/tests/generated/controlplane.external-authz.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -245,7 +245,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -510,7 +510,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -613,7 +613,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -687,7 +687,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1376,7 +1376,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1410,7 +1410,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1765,7 +1765,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1833,7 +1833,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1936,7 +1936,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2027,7 +2027,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2219,7 +2219,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2335,7 +2335,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2419,7 +2419,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2510,7 +2510,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2595,7 +2595,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2790,7 +2790,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2806,7 +2806,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7758,7 +7758,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7781,7 +7781,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7834,7 +7834,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7858,7 +7858,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8021,7 +8021,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8055,7 +8055,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8092,7 +8092,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8129,7 +8129,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8166,7 +8166,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8203,7 +8203,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8240,7 +8240,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8277,7 +8277,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8314,7 +8314,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8351,7 +8351,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8388,7 +8388,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8428,7 +8428,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8456,7 +8456,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8485,7 +8485,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8524,7 +8524,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8563,7 +8563,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8598,7 +8598,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8633,7 +8633,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8668,7 +8668,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8703,7 +8703,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8742,7 +8742,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8777,7 +8777,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9328,7 +9328,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9512,7 +9512,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9696,7 +9696,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9880,7 +9880,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10064,7 +10064,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10248,7 +10248,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10432,7 +10432,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10616,7 +10616,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10800,7 +10800,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10984,7 +10984,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11169,7 +11169,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11187,9 +11187,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11298,7 +11298,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11309,7 +11309,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "ed2b685b7f57a69cfe0dbef332d754b404667fa08d16224db1a85a15e5c2830"
+        configChecksum: "97044e8ae69a2f87a639c02dbef9e39c7f3e910ee04d2ecc17a2805ec299488"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11318,7 +11318,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11411,7 +11411,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11482,7 +11482,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11597,7 +11597,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11728,7 +11728,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11840,7 +11840,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11968,7 +11968,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12083,7 +12083,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12209,7 +12209,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12356,7 +12356,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12485,7 +12485,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12635,7 +12635,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.image-builder-bootstrap.yaml
+++ b/tests/generated/controlplane.image-builder-bootstrap.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -245,7 +245,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -507,7 +507,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -610,7 +610,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -684,7 +684,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1373,7 +1373,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1407,7 +1407,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1762,7 +1762,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1830,7 +1830,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1929,7 +1929,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2020,7 +2020,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2212,7 +2212,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2328,7 +2328,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2412,7 +2412,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2503,7 +2503,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2588,7 +2588,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2783,7 +2783,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2799,7 +2799,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7751,7 +7751,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7774,7 +7774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7827,7 +7827,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7851,7 +7851,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8014,7 +8014,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8048,7 +8048,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8085,7 +8085,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8122,7 +8122,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8159,7 +8159,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8196,7 +8196,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8233,7 +8233,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8270,7 +8270,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8307,7 +8307,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8344,7 +8344,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8381,7 +8381,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8421,7 +8421,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8449,7 +8449,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8478,7 +8478,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8517,7 +8517,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8556,7 +8556,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8591,7 +8591,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8626,7 +8626,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8661,7 +8661,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8696,7 +8696,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8735,7 +8735,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8770,7 +8770,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9321,7 +9321,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9505,7 +9505,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9689,7 +9689,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9873,7 +9873,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10057,7 +10057,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10241,7 +10241,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10425,7 +10425,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10609,7 +10609,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10793,7 +10793,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10977,7 +10977,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11162,7 +11162,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11180,9 +11180,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11291,7 +11291,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11302,7 +11302,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a17aa10a4809c842a0561cdb6f4c8289c7733db2ead0fa4cf8ee98966fba637"
+        configChecksum: "c1e24cfe7d4180b497e542b20785ce48a181d8dd85cca5b25d95da0e0f15ce6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11311,7 +11311,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11404,7 +11404,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11475,7 +11475,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11590,7 +11590,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11721,7 +11721,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11833,7 +11833,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11961,7 +11961,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12076,7 +12076,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12202,7 +12202,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12349,7 +12349,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12478,7 +12478,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12628,7 +12628,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.no-auth.yaml
+++ b/tests/generated/controlplane.no-auth.yaml
@@ -93,7 +93,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -109,7 +109,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -121,7 +121,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -135,7 +135,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -147,7 +147,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -183,7 +183,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -207,7 +207,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -245,7 +245,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -507,7 +507,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -610,7 +610,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -684,7 +684,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1373,7 +1373,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1407,7 +1407,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1762,7 +1762,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1830,7 +1830,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1929,7 +1929,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2020,7 +2020,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2212,7 +2212,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2328,7 +2328,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2412,7 +2412,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2503,7 +2503,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2588,7 +2588,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2783,7 +2783,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2799,7 +2799,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7751,7 +7751,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7774,7 +7774,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7827,7 +7827,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7851,7 +7851,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8014,7 +8014,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8048,7 +8048,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8085,7 +8085,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8122,7 +8122,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8159,7 +8159,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8196,7 +8196,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8233,7 +8233,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8270,7 +8270,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8307,7 +8307,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8344,7 +8344,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8381,7 +8381,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8421,7 +8421,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8449,7 +8449,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8478,7 +8478,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8517,7 +8517,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8556,7 +8556,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8591,7 +8591,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8626,7 +8626,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8661,7 +8661,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8696,7 +8696,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8735,7 +8735,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8770,7 +8770,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9321,7 +9321,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9505,7 +9505,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9689,7 +9689,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9873,7 +9873,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10057,7 +10057,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10241,7 +10241,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10425,7 +10425,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10609,7 +10609,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10793,7 +10793,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10977,7 +10977,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11162,7 +11162,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11180,9 +11180,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11291,7 +11291,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11302,7 +11302,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a17aa10a4809c842a0561cdb6f4c8289c7733db2ead0fa4cf8ee98966fba637"
+        configChecksum: "c1e24cfe7d4180b497e542b20785ce48a181d8dd85cca5b25d95da0e0f15ce6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11311,7 +11311,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11404,7 +11404,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11475,7 +11475,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11590,7 +11590,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11721,7 +11721,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11833,7 +11833,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11961,7 +11961,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12076,7 +12076,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12202,7 +12202,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12349,7 +12349,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12478,7 +12478,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12628,7 +12628,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/controlplane.userclouds.yaml
+++ b/tests/generated/controlplane.userclouds.yaml
@@ -39,7 +39,7 @@ kind: PodDisruptionBudget
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -114,7 +114,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -127,7 +127,7 @@ kind: ServiceAccount
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -143,7 +143,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 imagePullSecrets: 
   - name: union-registry-secret
@@ -155,7 +155,7 @@ kind: ServiceAccount
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -169,7 +169,7 @@ kind: ServiceAccount
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -181,7 +181,7 @@ kind: ServiceAccount
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -205,7 +205,7 @@ kind: ServiceAccount
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -217,7 +217,7 @@ kind: ServiceAccount
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -229,7 +229,7 @@ kind: ServiceAccount
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -241,7 +241,7 @@ kind: ServiceAccount
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -279,7 +279,7 @@ metadata:
   name: union
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -541,7 +541,7 @@ metadata:
   name: actions
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -644,7 +644,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -718,7 +718,7 @@ metadata:
   name: actions-router-cds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1407,7 +1407,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1441,7 +1441,7 @@ metadata:
   name: actions-router-lds
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1793,7 +1793,7 @@ kind: ConfigMap
 metadata:
   name: release-name-union-authz-config
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -1843,7 +1843,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 data:
   db.yaml: | 
@@ -1911,7 +1911,7 @@ kind: ConfigMap
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2022,7 +2022,7 @@ kind: ConfigMap
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2113,7 +2113,7 @@ kind: ConfigMap
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2305,7 +2305,7 @@ kind: ConfigMap
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2421,7 +2421,7 @@ kind: ConfigMap
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2505,7 +2505,7 @@ kind: ConfigMap
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2596,7 +2596,7 @@ kind: ConfigMap
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2681,7 +2681,7 @@ kind: ConfigMap
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -2876,7 +2876,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 data:
   private.yaml: |
@@ -2892,7 +2892,7 @@ kind: ConfigMap
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7844,7 +7844,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7864,7 +7864,7 @@ kind: Role
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7883,7 +7883,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -7936,7 +7936,7 @@ metadata:
   name: actions-coordination
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7957,7 +7957,7 @@ kind: RoleBinding
 metadata:
   name: release-name-union-authz-secrets-manager
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7981,7 +7981,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: flyteadmin
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     #app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8144,7 +8144,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8178,7 +8178,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8215,7 +8215,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8252,7 +8252,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8289,7 +8289,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8326,7 +8326,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8363,7 +8363,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8400,7 +8400,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8437,7 +8437,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8474,7 +8474,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8511,7 +8511,7 @@ metadata:
   namespace: union
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8547,7 +8547,7 @@ kind: Service
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8574,7 +8574,7 @@ metadata:
     platform.union.ai/prometheus-group: "union-services"
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -8602,7 +8602,7 @@ metadata:
   name: unionconsole
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8631,7 +8631,7 @@ metadata:
   name: authorizer
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8670,7 +8670,7 @@ metadata:
   name: cluster
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8709,7 +8709,7 @@ metadata:
   name: dataproxy
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8744,7 +8744,7 @@ metadata:
   name: executions
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8779,7 +8779,7 @@ metadata:
   name: identity
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8814,7 +8814,7 @@ metadata:
   name: leasor
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8849,7 +8849,7 @@ metadata:
   name: organizations
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8888,7 +8888,7 @@ metadata:
   name: run-scheduler
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8923,7 +8923,7 @@ metadata:
   name: usage
   labels:
     platform.union.ai/prometheus-group: "union-services"
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9474,7 +9474,7 @@ metadata:
   name: actions-0-f288b103
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9658,7 +9658,7 @@ metadata:
   name: actions-1-f6a76bed
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -9842,7 +9842,7 @@ metadata:
   name: actions-2-44d51338
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10026,7 +10026,7 @@ metadata:
   name: actions-3-0e2fc543
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10210,7 +10210,7 @@ metadata:
   name: actions-4-b7f95723
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10394,7 +10394,7 @@ metadata:
   name: actions-5-3d7905f8
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10578,7 +10578,7 @@ metadata:
   name: actions-6-a7e57068
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10762,7 +10762,7 @@ metadata:
   name: actions-7-a5084d4e
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -10946,7 +10946,7 @@ metadata:
   name: actions-8-2e085e60
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11130,7 +11130,7 @@ metadata:
   name: actions-9-cf8e9eab
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11315,7 +11315,7 @@ metadata:
   name: actions-router
   namespace: union
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: actions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11333,9 +11333,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/router-bootstrap: 49e667dc7bd53feae399cc5d9533c53e1f9755c749cb55d848062b078cfc3813
-        checksum/router-cds: 88a04d450315992f8a895df49e0f59c62b7227d30f6e4f0b814a97ac86f3780b
-        checksum/router-lds: 392d1716df640a0cd90b4f4900d611020cf4bce62d395522d01fe80c1fed91ca
+        checksum/router-bootstrap: 00095ef7e8cbd2f1dc802374b671ce811106643d36af815318f1d1352cd71c15
+        checksum/router-cds: e5d22c55dd7cbce562e5a3fae1a01680a5e197541f8cf3084b52d40d3e2e1861
+        checksum/router-lds: 3a185c459d12ba8534df97eb7c5a09dbafc2ac2472058008c2bb8f6333a71c1a
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "9901"
       labels:
@@ -11441,7 +11441,7 @@ kind: Deployment
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11459,7 +11459,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 470c932d69328bb5598148ce3f07901b076aba6f1837d6460fd58fa7d435b38f
+        checksum/config: 942702dda6fbf32368f890aa0b39ca542aa37b1b777f6fbf10b8ba77ec1eca84
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11561,7 +11561,7 @@ metadata:
   labels: 
     app.kubernetes.io/name: cacheservice
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -11572,7 +11572,7 @@ spec:
   template:
     metadata:
       annotations:
-        configChecksum: "a17aa10a4809c842a0561cdb6f4c8289c7733db2ead0fa4cf8ee98966fba637"
+        configChecksum: "c1e24cfe7d4180b497e542b20785ce48a181d8dd85cca5b25d95da0e0f15ce6"
         linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "10254"
@@ -11581,7 +11581,7 @@ spec:
         
         app.kubernetes.io/name: cacheservice
         app.kubernetes.io/instance: release-name
-        helm.sh/chart: controlplane-2026.8.0
+        helm.sh/chart: controlplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext: 
@@ -11674,7 +11674,7 @@ kind: Deployment
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11745,7 +11745,7 @@ kind: Deployment
 metadata:
   name: authorizer
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: authorizer
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11860,7 +11860,7 @@ kind: Deployment
 metadata:
   name: cluster
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: cluster
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -11991,7 +11991,7 @@ kind: Deployment
 metadata:
   name: dataproxy
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: dataproxy
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12103,7 +12103,7 @@ kind: Deployment
 metadata:
   name: executions
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: executions
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12231,7 +12231,7 @@ kind: Deployment
 metadata:
   name: identity
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12346,7 +12346,7 @@ kind: Deployment
 metadata:
   name: leasor
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: leasor
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12472,7 +12472,7 @@ kind: Deployment
 metadata:
   name: organizations
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: organizations
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12619,7 +12619,7 @@ kind: Deployment
 metadata:
   name: run-scheduler
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: run-scheduler
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12748,7 +12748,7 @@ kind: Deployment
 metadata:
   name: usage
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: usage
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12892,7 +12892,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: release-name-union-authz
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: union-authz
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12919,7 +12919,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: unionconsole
   labels:
-    helm.sh/chart: controlplane-2026.8.0
+    helm.sh/chart: controlplane-2026.8.1
     app.kubernetes.io/name: unionconsole
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.additional-podlabels.yaml
+++ b/tests/generated/dataplane.additional-podlabels.yaml
@@ -2285,7 +2285,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6452,7 +6452,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6841,7 +6841,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6895,7 +6895,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.additional-templates.yaml
+++ b/tests/generated/dataplane.additional-templates.yaml
@@ -2301,7 +2301,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6462,7 +6462,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6849,7 +6849,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6903,7 +6903,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.aws.apps-disabled.yaml
+++ b/tests/generated/dataplane.aws.apps-disabled.yaml
@@ -2165,7 +2165,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -4915,7 +4915,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME

--- a/tests/generated/dataplane.aws.eks-automode.yaml
+++ b/tests/generated/dataplane.aws.eks-automode.yaml
@@ -2460,7 +2460,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6961,7 +6961,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -7437,7 +7437,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7491,7 +7491,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.aws.with-ingress.yaml
+++ b/tests/generated/dataplane.aws.with-ingress.yaml
@@ -2308,7 +2308,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6475,7 +6475,7 @@ spec:
               readOnly: true
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6986,7 +6986,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7040,7 +7040,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.aws.yaml
+++ b/tests/generated/dataplane.aws.yaml
@@ -2410,7 +2410,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6911,7 +6911,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -7330,7 +7330,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7384,7 +7384,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.aws.zero-trust-apps-disabled.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-apps-disabled.yaml
@@ -157,7 +157,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2404,7 +2404,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -4268,7 +4268,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -4917,7 +4917,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -4933,7 +4933,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.8.0
+        helm.sh/chart: dataplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -4944,7 +4944,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: e9566aa8fc1dc99618939e9df6f1208ca9195186ed0bd736e840316ce0071911
+        checksum/bootstrap-config: fb587773bd4ee83d9281d006d1d9fbb80c2496af9379a54347ee42fec48781e8
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -5456,7 +5456,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -5662,7 +5662,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:

--- a/tests/generated/dataplane.aws.zero-trust-overrides.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-overrides.yaml
@@ -84,7 +84,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -113,7 +113,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -127,7 +127,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -178,7 +178,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -258,7 +258,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -537,7 +537,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -752,7 +752,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -826,7 +826,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -986,7 +986,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1125,7 +1125,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1194,7 +1194,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1454,7 +1454,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1558,7 +1558,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1646,7 +1646,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1712,7 +1712,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1797,7 +1797,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2007,7 +2007,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2131,7 +2131,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -4195,7 +4195,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -5446,7 +5446,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5479,7 +5479,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5516,7 +5516,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5532,7 +5532,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5573,7 +5573,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5593,7 +5593,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5613,7 +5613,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5644,7 +5644,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5712,7 +5712,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5737,7 +5737,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5773,7 +5773,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5795,7 +5795,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5816,7 +5816,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5837,7 +5837,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5874,7 +5874,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6212,7 +6212,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6522,7 +6522,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6557,7 +6557,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6584,7 +6584,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6614,7 +6614,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6644,7 +6644,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -6673,7 +6673,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -6697,7 +6697,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6724,7 +6724,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7400,7 +7400,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7529,7 +7529,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7633,7 +7633,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7746,7 +7746,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7845,7 +7845,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7861,7 +7861,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.8.0
+        helm.sh/chart: dataplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -7872,7 +7872,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: cb57c16b224cd3e794a55494c405adea57e3575cabd1bc66d1d2dd1f06e34a18
+        checksum/bootstrap-config: 94aadd0ddcd1a9f87095d964a816ebc2eb7699a7fd460c8147c0d30bd492d118
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -7988,7 +7988,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8013,7 +8013,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.8.0
+        helm.sh/chart: dataplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -8120,7 +8120,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8632,7 +8632,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -8850,7 +8850,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8885,7 +8885,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -8930,7 +8930,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8977,7 +8977,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9184,7 +9184,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9229,7 +9229,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9384,7 +9384,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9419,7 +9419,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.aws.zero-trust-serving-disabled.yaml
+++ b/tests/generated/dataplane.aws.zero-trust-serving-disabled.yaml
@@ -157,7 +157,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2404,7 +2404,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -4268,7 +4268,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -4917,7 +4917,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -4933,7 +4933,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.8.0
+        helm.sh/chart: dataplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -4944,7 +4944,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: e9566aa8fc1dc99618939e9df6f1208ca9195186ed0bd736e840316ce0071911
+        checksum/bootstrap-config: fb587773bd4ee83d9281d006d1d9fbb80c2496af9379a54347ee42fec48781e8
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -5456,7 +5456,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -5662,7 +5662,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:

--- a/tests/generated/dataplane.aws.zero-trust.yaml
+++ b/tests/generated/dataplane.aws.zero-trust.yaml
@@ -84,7 +84,7 @@ metadata:
   name: net-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -113,7 +113,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -127,7 +127,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -178,7 +178,7 @@ metadata:
   name: webhook-certs
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -258,7 +258,7 @@ metadata:
   name: union-operator-gateway-envoy-bootstrap
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -537,7 +537,7 @@ metadata:
   name: config-autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -752,7 +752,7 @@ metadata:
   name: config-certmanager
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -826,7 +826,7 @@ metadata:
   name: config-defaults
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -986,7 +986,7 @@ metadata:
   name: config-deployment
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1125,7 +1125,7 @@ metadata:
   name: config-domain
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1194,7 +1194,7 @@ metadata:
   name: config-features
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1454,7 +1454,7 @@ metadata:
   name: config-gc
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1558,7 +1558,7 @@ metadata:
   name: config-kourier
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1646,7 +1646,7 @@ metadata:
   name: config-leader-election
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1712,7 +1712,7 @@ metadata:
   name: config-logging
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -1797,7 +1797,7 @@ metadata:
   name: config-network
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2007,7 +2007,7 @@ metadata:
   name: config-observability
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -2131,7 +2131,7 @@ metadata:
   name: config-tracing
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -4195,7 +4195,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -5446,7 +5446,7 @@ kind: ClusterRole
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5479,7 +5479,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5516,7 +5516,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5532,7 +5532,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5573,7 +5573,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-admin
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5593,7 +5593,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-edit
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5613,7 +5613,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-namespaced-view
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5644,7 +5644,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5712,7 +5712,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5737,7 +5737,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5773,7 +5773,7 @@ kind: ClusterRoleBinding
 metadata:
   name: net-kourier
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5795,7 +5795,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5816,7 +5816,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5837,7 +5837,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-activator-cluster
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -5874,7 +5874,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6212,7 +6212,7 @@ metadata:
   name: knative-serving-activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6522,7 +6522,7 @@ metadata:
   name: activator-service
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6557,7 +6557,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6584,7 +6584,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6614,7 +6614,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6644,7 +6644,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -6673,7 +6673,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -6697,7 +6697,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -6724,7 +6724,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7400,7 +7400,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7529,7 +7529,7 @@ metadata:
   name: autoscaler-hpa
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7633,7 +7633,7 @@ metadata:
   name: autoscaler
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7746,7 +7746,7 @@ metadata:
   name: controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -7845,7 +7845,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -7861,7 +7861,7 @@ spec:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: dataplane-2026.8.0
+        helm.sh/chart: dataplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
       annotations:
@@ -7872,7 +7872,7 @@ spec:
         # makes the pod-template hash drift when the configmap content
         # does. Mirrors the legacy serving/knative-serving.yaml workload-
         # block at .annotations.checksum/bootstrap-config.
-        checksum/bootstrap-config: 0d4e0b4c1f5e379b038352e5a442d434bedf391bc46d1b74628a43ee274e3d8a
+        checksum/bootstrap-config: 4af834327601c9418f14140809655f9df6582add944c097ca970a8567c441c87
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
         prometheus.io/path: "/stats/prometheus"
@@ -7988,7 +7988,7 @@ metadata:
   name: net-kourier-controller
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8013,7 +8013,7 @@ spec:
         prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
-        helm.sh/chart: dataplane-2026.8.0
+        helm.sh/chart: dataplane-2026.8.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/name: knative-serving
@@ -8120,7 +8120,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8632,7 +8632,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -8850,7 +8850,7 @@ metadata:
   name: activator
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8885,7 +8885,7 @@ metadata:
   namespace: union
   labels:
     app: gateway
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
 spec:
@@ -8930,7 +8930,7 @@ metadata:
   name: webhook
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -8977,7 +8977,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9184,7 +9184,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9229,7 +9229,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9384,7 +9384,7 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving
@@ -9419,7 +9419,7 @@ metadata:
   name: queue-proxy
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: knative-serving

--- a/tests/generated/dataplane.azure-custom-storage-prefix.yaml
+++ b/tests/generated/dataplane.azure-custom-storage-prefix.yaml
@@ -2318,7 +2318,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6482,7 +6482,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6870,7 +6870,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6924,7 +6924,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.azure.yaml
+++ b/tests/generated/dataplane.azure.yaml
@@ -2282,7 +2282,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6302,7 +6302,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6667,7 +6667,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6721,7 +6721,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.clusterresourcesync.yaml
+++ b/tests/generated/dataplane.clusterresourcesync.yaml
@@ -2447,7 +2447,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6653,7 +6653,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -7026,7 +7026,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7080,7 +7080,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.cost.yaml
+++ b/tests/generated/dataplane.cost.yaml
@@ -2288,7 +2288,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6449,7 +6449,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6836,7 +6836,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6890,7 +6890,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.dcgm-exporter.yaml
+++ b/tests/generated/dataplane.dcgm-exporter.yaml
@@ -2413,7 +2413,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6782,7 +6782,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -7201,7 +7201,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7255,7 +7255,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.flytepropeller.yaml
+++ b/tests/generated/dataplane.flytepropeller.yaml
@@ -2326,7 +2326,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6629,7 +6629,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -7111,7 +7111,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7165,7 +7165,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.fully-selfhosted.yaml
+++ b/tests/generated/dataplane.fully-selfhosted.yaml
@@ -2288,7 +2288,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6403,7 +6403,7 @@ spec:
               name: config-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6914,7 +6914,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6968,7 +6968,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.gcp.yaml
+++ b/tests/generated/dataplane.gcp.yaml
@@ -2289,7 +2289,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6450,7 +6450,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6837,7 +6837,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6891,7 +6891,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.hook-kubectl-default.yaml
+++ b/tests/generated/dataplane.hook-kubectl-default.yaml
@@ -2288,7 +2288,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6449,7 +6449,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6911,7 +6911,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6965,7 +6965,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.hook-kubectl-image.yaml
+++ b/tests/generated/dataplane.hook-kubectl-image.yaml
@@ -2288,7 +2288,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6449,7 +6449,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6914,7 +6914,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6968,7 +6968,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.low-priv.yaml
+++ b/tests/generated/dataplane.low-priv.yaml
@@ -2308,7 +2308,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6469,7 +6469,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6856,7 +6856,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6910,7 +6910,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.monitoring.yaml
+++ b/tests/generated/dataplane.monitoring.yaml
@@ -3024,7 +3024,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -8381,7 +8381,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -12800,7 +12800,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -12854,7 +12854,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.namespace-multi.yaml
+++ b/tests/generated/dataplane.namespace-multi.yaml
@@ -2460,7 +2460,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6658,7 +6658,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -7031,7 +7031,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7085,7 +7085,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.namespace-single.yaml
+++ b/tests/generated/dataplane.namespace-single.yaml
@@ -2308,7 +2308,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6469,7 +6469,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6856,7 +6856,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6910,7 +6910,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.nodeobserver.yaml
+++ b/tests/generated/dataplane.nodeobserver.yaml
@@ -2306,7 +2306,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6599,7 +6599,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6986,7 +6986,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -7040,7 +7040,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.oci.yaml
+++ b/tests/generated/dataplane.oci.yaml
@@ -2318,7 +2318,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6511,7 +6511,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6924,7 +6924,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6978,7 +6978,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.operator-pdb.yaml
+++ b/tests/generated/dataplane.operator-pdb.yaml
@@ -2312,7 +2312,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6473,7 +6473,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6860,7 +6860,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6914,7 +6914,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/dataplane.storage-credentials-secret.yaml
+++ b/tests/generated/dataplane.storage-credentials-secret.yaml
@@ -2296,7 +2296,7 @@ metadata:
   name: release-name-prometheus
   namespace: union
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6457,7 +6457,7 @@ spec:
               name: secret-volume
           env:
             - name: HELM_CHART_VERSION
-              value: "2026.8.0"
+              value: "2026.8.1"
             - name: HELM_APP_VERSION
               value: "2026.8.0"
             - name: POD_NAME
@@ -6844,7 +6844,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: dataplane-2026.8.0
+    helm.sh/chart: dataplane-2026.8.1
     app.kubernetes.io/name: release-name-dataplane
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2026.8.0"
@@ -6898,7 +6898,7 @@ spec:
   workloads:
   - name: 3scale-kourier-gateway
     labels:
-      helm.sh/chart: dataplane-2026.8.0
+      helm.sh/chart: dataplane-2026.8.1
       app.kubernetes.io/name: release-name-dataplane
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/version: "2026.8.0"

--- a/tests/generated/knative-migration.adoption.yaml
+++ b/tests/generated/knative-migration.adoption.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.8.0
+        helm.sh/chart: knative-migration-2026.8.1
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.argocd-presync.yaml
+++ b/tests/generated/knative-migration.argocd-presync.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -76,7 +76,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -96,7 +96,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -120,7 +120,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -135,7 +135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.8.0
+        helm.sh/chart: knative-migration-2026.8.1
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/tests/generated/knative-migration.default.yaml
+++ b/tests/generated/knative-migration.default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ kind: ClusterRole
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-knative-migration
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -67,7 +67,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -105,7 +105,7 @@ metadata:
   name: release-name-knative-migration
   namespace: union
   labels:
-    helm.sh/chart: knative-migration-2026.8.0
+    helm.sh/chart: knative-migration-2026.8.1
     app.kubernetes.io/name: knative-migration
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: knative-migration-2026.8.0
+        helm.sh/chart: knative-migration-2026.8.1
         app.kubernetes.io/name: knative-migration
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
## 2026.8.1
- Adding redis-consumer service to control plane (https://github.com/unionai/helm-charts/pull/525)