### PR TITLE
Operator Configmap Role/Binding

### DIFF
--- a/charts/dataplane/templates/operator/serviceaccount-proxy.yaml
+++ b/charts/dataplane/templates/operator/serviceaccount-proxy.yaml
@@ -38,6 +38,50 @@ rules:
       - list
       - watch
 ---
+# GetClusterConfig reads the rendered component ConfigMaps, which only ever live in the
+# release namespace. Always a namespaced Role naming those ConfigMaps, independent of
+# low_privilege: the ClusterRole branch above would otherwise grant cluster-wide read of
+# every ConfigMap. Redundant when useCommonServiceAccount collapses this onto the shared
+# SA (the operator role already grants ConfigMaps); required when it does not.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $roleName }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "proxy.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - union-operator
+      # Deprecated: no longer rendered, but still present on clusters pinned to an older chart.
+      - executor
+      - leaseworker
+      - flyte-propeller-config
+      - flyte-clusterresourcesync-config
+      - union-clusterresourcesync-config
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $roleName }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "proxy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $roleName }}-config
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "proxy.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.low_privilege }}
 kind: RoleBinding


### PR DESCRIPTION
Adding role and binding to allow operator to read configmaps for `flyte get cluster-config`